### PR TITLE
rails - ignore vendor/bundle as well

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -1,4 +1,5 @@
 .bundle
+vendor/bundle
 log/*
 tmp/*
 db/*.sqlite3


### PR DESCRIPTION
No point storing all of the installed gems. Just keep vendor/cache around for deploys.
