### PR TITLE
C++ gitignore

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -1,0 +1,8 @@
+# compiled object files
+*.o
+
+# compiled dynamic libraries
+*.so
+
+# compiled static libraries
+*.a


### PR DESCRIPTION
I added a basic gitignore file for C++. Compiled object files, as well as dynamic and static libraries are ignored.
