### PR TITLE
Ignore Xcode 4 user configurations for Objective-C

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -3,6 +3,8 @@ build/*
 *.pbxuser
 *.mode1v3
 *.perspectivev3
+*.xcworkspace
+xcuserdata
 # osx
 .DS_Store
 profile


### PR DESCRIPTION
Xcode 4 adds more user configuration files in the project bundle that should be ignored.
