### PR TITLE
Support Xcode user-level setting defaults

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,8 +1,16 @@
 # xcode
 build/*
 *.pbxuser
+!default.pbxuser
 *.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
 *.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
 # osx
 .DS_Store
 profile


### PR DESCRIPTION
Little-known fact: you can supply a set of default Xcode user-level settings that will be copied into any new user settings. For example: Executable arguments and environmental variables are stored on a per-user basis. However, I can have my project users automatically "inherit" these settings by specifying them in a default.pbxuser file in the *.xcodeproj.
