### PR TITLE
Added a django gitignore

### DIFF
--- a/Django.gitignore
+++ b/Django.gitignore
@@ -6,6 +6,5 @@
 static/uploaded/**/*
 *.mo
 *.pot
-*.po
 *.pyc
 


### PR DESCRIPTION
Django has binary files for translations and stores in the application dir  the uploaded stuff by default (`static/uploaded`), if some developer does a careless `git add .` hijinks will ensue! Also, I added some rules for backup and swap files for people that use vim but haven't added 

  set noswapfile
   set nowritebackup
   set nobackup

to their `~/.vimrc` file.
