### PR TITLE
Added gitignore for emacs

### DIFF
--- a/Global/emacs.gitignore
+++ b/Global/emacs.gitignore
@@ -1,0 +1,4 @@
+\#*#
+/.emacs.desktop
+/.emacs.desktop.lock
+.DS_Store


### PR DESCRIPTION
Ignoring emacs buffers and desktop save file. DS_Store is included too but I see that someone has added that to the OSX gitignore so may be redundant. 

Also, thanks! Cool project.
