### PR TITLE
Symfony:  We should ignore propel.ini too

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -2,4 +2,5 @@ cache/*
 log/*
 web/uploads/*
 config/databases.yml
+config/propel.ini
 data/sql


### PR DESCRIPTION
We should ignore propel.ini too, for all those propel users in legacy-land (like me!)
