### PR TITLE
Eclipse

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -1,0 +1,6 @@
+.project
+.classpath
+.settings/
+
+# CDT-specific
+.cproject


### PR DESCRIPTION
Basic .gitignore file for Eclipse workspaces. JDT and CDT are accounted for so far.
