### PR TITLE
Common "ignores" for Perl 

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -1,0 +1,14 @@
+blib/
+_build/
+cover_db/
+inc/
+Build
+Build.bat
+.last_cover_stats
+Makefile
+Makefile.old
+MANIFEST.bak
+META.yml
+MYMETA.yml
+nytprof.out
+pm_to_blib


### PR DESCRIPTION
Mostly ExtUtils::MakeMaker, Module::Build, Module::Install and Devel::Cover generated files.
