### PR TITLE
Redundant Visual Studio entries

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -1,7 +1,3 @@
-# Visual Studio per-user files
-*.suo
-*.user
-
 # ReSharper meta directory
 _ReSharper*
 


### PR DESCRIPTION
... keeping up the hunt for redundant entries that should be in Global/

Also -- not sure why those "Removing .DS_Store" commits are in there; I believe they were already merged.  If they cause any trouble I'll redo it.
