### PR TITLE
C++: apxs2 / libtoolize build files

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -1,8 +1,12 @@
 # compiled object files
+*.slo
+*.lo
 *.o
 
 # compiled dynamic libraries
 *.so
 
 # compiled static libraries
+*.lai
+*.la
 *.a


### PR DESCRIPTION
Cool initiative, guys. :)

Pull request for a 4-liner that ignores apxs2 / libtoolize build files.
