### PR TITLE
Ignoring invisible Emacs buffers

### DIFF
--- a/Global/emacs.gitignore
+++ b/Global/emacs.gitignore
@@ -1,4 +1,5 @@
 \#*#
+\.#*#
 /.emacs.desktop
 /.emacs.desktop.lock
 


### PR DESCRIPTION
I modified the Emacs file to ignore invisible buffers. I've also removed DS_Store as that should be covered by the OSX gitignore
