### PR TITLE
Untitled

### DIFF
--- a/Wordpress.gitignore
+++ b/Wordpress.gitignore
@@ -1,3 +1,11 @@
 .htaccess
 wp-config.php
+wp-content/backup-db/*
+wp-content/cache/*
+wp-content/cache/supercache/*
+wp-content/upgrade/*
+wp-content/advanced-cache.php
+wp-content/wp-cache-config.php
 wp-content/uploads/
+sitemap.xml
+sitemap.xml.gz


### PR DESCRIPTION
I've added in rules for WP Super Cache (creates a ton of cache files that slow down repo cloning, committing, and pushing), Google XML SItemaps (sitemap.xml and sitemap.xml.gz are updated quite frequently and not important to collaboration), and WP-DBManager plugins.

Whether or not /uploads/ should be in this file is quite debatable, but I've left it in.
