### PR TITLE
Add VS-specific changes to CSharp.gitignore, fix case-sensitivity bug

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -2,8 +2,8 @@
 _ReSharper*
 
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
-bin
-obj
+[Bb]in
+[Oo]bj
 
 # user preference files (remembering open files, etc.)
 *.user


### PR DESCRIPTION
Since Git on Windows is case-sensitive, make the bin and obj ignores case-insensitive because they can be named both upper-case and lower-case.

Also tell Git to ignore various other VS autogenerated files, *.suo for which files are open, *.user for user prefs and *.cache for the VS cache.

Feel free to cherry-pick either commit :)
