### PR TITLE
Removed empty files from ignore for deployment reasons

### DIFF
--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -2,4 +2,4 @@ tmp/*
 config/database.php
 app/tmp/*
 app/config/database.php
-
+!empty


### PR DESCRIPTION
Applications will break otherwise when certain directories, which should otherwise be "empty", are ignored. The use of empty files is standard in CakePHP applications as a placeholder to work-around GIT's lack of directory awareness (unlike svn). The practice is also used within the official CakePHP repository (https://github.com/cakephp/cakephp).
