### PR TITLE
Ignore files created by Etags and Ctags

### DIFF
--- a/Global/Tags.gitignore
+++ b/Global/Tags.gitignore
@@ -1,0 +1,3 @@
+# Ignore tags created by etags and ctags
+TAGS
+tags


### PR DESCRIPTION
The file Globals/Tags.gitignore has the default filenames of the files created by etags and ctags.
