### PR TITLE
Added Visual C++ 2010 support

### DIFF
--- a/Global/VisualStudio.gitignore
+++ b/Global/VisualStudio.gitignore
@@ -18,6 +18,10 @@ ipch/
 *.opensdf
 *.sdf
 
+# Visual Studio profiler
+*.psess
+*.vsp
+
 # ReSharper is a .NET coding add-in
 _ReSharper*
 


### PR DESCRIPTION
Visual C++ 2010 changed the file extensions for IntelliSense databases from _.ncb to *.opensdf/_.sdf. It also creates a new ipch folder, which should be ignored.
