### PR TITLE
Visual Studio performance profiler

### DIFF
--- a/Global/VisualStudio.gitignore
+++ b/Global/VisualStudio.gitignore
@@ -18,6 +18,10 @@ ipch/
 *.opensdf
 *.sdf
 
+# Visual Studio profiler
+*.psess
+*.vsp
+
 # ReSharper is a .NET coding add-in
 _ReSharper*
 


### PR DESCRIPTION
The Visual Studio performance profiler writes its data to the project directory by default, but these files should not be committed to version control.
