### PR TITLE
Gitignore for qooxdoo apps

### DIFF
--- a/Qooxdoo.gitignore
+++ b/Qooxdoo.gitignore
@@ -1,0 +1,5 @@
+cache
+cache-downloads
+inspector
+api
+source/inspector.html


### PR DESCRIPTION
Here's a simple .gitignore for [qooxdoo](http://qooxdoo.org/) applications.
