### PR TITLE
Ignore vim session file

### DIFF
--- a/Global/vim.gitignore
+++ b/Global/vim.gitignore
@@ -1,2 +1,3 @@
 .*.sw[a-z]
 *.un~
+Session.vim


### PR DESCRIPTION
When we use :mks to save vim session, it generates a Session.vim file, which should be ignored in git projects.
