### PR TITLE
Added more rules for non core Drupal developers

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -11,6 +11,23 @@ settings.php
 /LICENSE.txt
 /MAINTAINERS.txt
 /UPGRADE.txt
+robots.txt
 sites/all/README.txt
 sites/all/modules/README.txt
 sites/all/themes/README.txt
+.htaccess
+
+#for non core developer
+#only include "sites" folder without exclusions before
+cron.php
+index.php
+install.php
+update.php
+xmlrpc.php
+/includes
+/misc
+/modules     
+/profiles
+/scripts
+/themes
+


### PR DESCRIPTION
Hello

I have added (Drupal.gitignore) some other rules to ignore files which I think a non core Drupal developer will not use. Resuming, only the folder "sites" is not ignored, excluding files which were excluded before. I hope this could be useful.

Thanks David
