### PR TITLE
Update latex ignores

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -9,6 +9,7 @@
 *.ilg
 *.ind
 *.ist
+*.lof
 *.log
 *.nlo
 *.out


### PR DESCRIPTION
I noticed that *.div, *.nlo and *.lof files are produced as intermediate files in some latex setups and added them to the gitignore.
