### PR TITLE
Ignore Play.framework database + logs directory and server.pid

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -4,8 +4,11 @@
 # except for .gitignore
 !.gitignore
 
-# Ignore Play! working directory
-tmp
-log
-test-result
+# Ignore Play! working directory #
+db
 eclipse
+log
+logs
+server.pid
+test-result
+tmp


### PR DESCRIPTION
1. `db` When using a database stored onto the filesystem PlayFramework will pace it under the `db` directory
2. `logs` PlayFramework also uses the `logs` directory to log data
3. `server.pid` PlayFramework will store the `pid` of the server when using `play start` in the working dir
