### PR TITLE
Global/Archives.gitignore

### DIFF
--- a/Global/Archives.gitignore
+++ b/Global/Archives.gitignore
@@ -1,7 +1,6 @@
 # It's better to unpack these files and commit the raw source because
 # git has its own built in compression methods.
 *.7z
-*.dmg
 *.jar
 *.rar
 *.zip
@@ -13,3 +12,11 @@
 #packing-only formats
 *.iso
 *.tar
+
+#package management formats
+*.dmg
+*.xpi
+*.gem
+*.egg
+*.deb
+*.rpm


### PR DESCRIPTION
*.gz makes *.tar.gz redundant
added archive extentions (lzma xz)
..

package management formats
