### PR TITLE
Android.gitignore is ignoring more files then it is supposed to.

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -9,4 +9,4 @@
 *.class
 
 # generated GUI files
-*R.java
+/gen


### PR DESCRIPTION
Instead of ignoring
*R.java
the file must ignore
/gen

The reason is that if you have a class which name ends in R, it will be ignored.

/gen will ignore only the Android generated files folder.
