### PR TITLE
Update Python ignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -8,6 +8,8 @@ build
 eggs
 parts
 bin
+var
+sdist
 develop-eggs
 .installed.cfg
 
@@ -17,3 +19,9 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+
+#Translations
+*.mo
+
+#Mr Developer
+.mr.developer.cfg


### PR DESCRIPTION
New globs for unit test and coverage reports tools, buildout directories.
