### PR TITLE
Adds gitignore for Leiningen projects

### DIFF
--- a/Clojure.gitignore
+++ b/Clojure.gitignore
@@ -1,0 +1,1 @@
+Leiningen.gitignore

--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -1,0 +1,5 @@
+pom.xml
+*jar
+/lib/
+/classes/
+.lein-deps-sum


### PR DESCRIPTION
[Leiningen](https://github.com/technomancy/leiningen) is build tool for [Clojure](http://clojure.org/).

`lein new qqq` automatically creates qqq/.gitignore, but when repository is created manually it should be provided by user.
