### PR TITLE
PlayFramework: Ignoring `precompiled` directory

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -9,6 +9,7 @@ db
 eclipse
 log
 logs
+precompiled
 tmp
 test-result
 eclipse


### PR DESCRIPTION
The `precompiled` directory gets created when deploying a war (`play war -o path`). Normally you wouldn't want it to include in your repo. 
