### PR TITLE
Ignore Netbeans run configuration file

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -1,1 +1,2 @@
 nbproject/
+nbactions.xml


### PR DESCRIPTION
The file nbactions.xml will be created in the root directory of a Netbeans project. It contains information specific to run configuration (think eclipse foo.launch files).

Extract from an example nbactions.xml:

```
<?xml version="1.0" encoding="UTF-8"?>
<actions>
    <action>
        <actionName>run</actionName>
        <goals>
            <goal>process-classes</goal>
            <goal>org.codehaus.mojo:exec-maven-plugin:1.1.1:exec</goal>
        </goals>
        <properties>
            <exec.classpathScope>runtime</exec.classpathScope>
            <exec.args>-classpath %classpath de.bripkens.svgexport.Exporter ./src/test/resources/Soccerball.svg target/soccerball.pdf PDF</exec.args>
            <exec.executable>java</exec.executable>
        </properties>
    </action>
    <action>
        <actionName>debug</actionName>
        <goals>
            <goal>process-classes</goal>
            <goal>org.codehaus.mojo:exec-maven-plugin:1.1.1:exec</goal>
        </goals>
        <properties>
            <exec.classpathScope>runtime</exec.classpathScope>
            <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath de.bripkens.svgexport.Exporter ./src/test/resources/Soccerball.svg target/soccerball.pdf PDF</exec.args>
            <jpda.listen>true</jpda.listen>
            <exec.executable>java</exec.executable>
        </properties>
    </action>
    <action>
        <actionName>profile</actionName>
        <goals>
            <goal>process-classes</goal>
            <goal>org.codehaus.mojo:exec-maven-plugin:1.1.1:exec</goal>
        </goals>
        <properties>
            <exec.args>${profiler.args} -classpath %classpath de.bripkens.svgexport.Exporter ./src/test/resources/Soccerball.svg target/soccerball.pdf PDF</exec.args>
            <profiler.action>profile</profiler.action>
            <exec.executable>${profiler.java}</exec.executable>
        </properties>
    </action>
</actions>
```
