### PR TITLE
Add gitignore for Compass CSS framework

### DIFF
--- a/Compass.gitignore
+++ b/Compass.gitignore
@@ -1,0 +1,1 @@
+.sass-cache


### PR DESCRIPTION
[Compass](http://compass-style.org) creates a `.sass-cache` directory inside of a Compass project directory. This is ignored by the attached gitignore file.
