### PR TITLE
Ignore Emacs write-lock files

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -5,3 +5,4 @@
 .elc
 auto-save-list
 tramp
+.\#*


### PR DESCRIPTION
Emacs creates for every modified file a special write-lock file as described here: http://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html#Interlocking
