### PR TITLE
Update for Node.gitignore and npm 1.0

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -10,3 +10,6 @@ lib-cov
 pids
 logs
 results
+
+node_modules
+npm-debug.log


### PR DESCRIPTION
In npm 1.0, all modules are bundled by default into a folder called `node_modules`. Also a test failure after running `npm test` will result in a file called `npm-debug.log`. 

Best practices to ignore both of these. 
