### PR TITLE
Add ".scala_dependencies" file generated by Scala-IDE 

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -8,3 +8,6 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies


### PR DESCRIPTION
This is a transient file generated by the Scala-IDE Eclipse plugin, which is regenerated on a clean build, and should not be checked into VCS (according to [this bug report comment](http://www.assembla.com/spaces/scala-ide/tickets/1000005-absolute-pathnames-in--scala_dependencies-should-be-relative-to-project)  by Miles Sabin)
