### PR TITLE
Improve NetBeans .gitignore rules 

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -1,2 +1,6 @@
-nbproject/
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
 nbactions.xml


### PR DESCRIPTION
According to [this](http://netbeans.org/kb/docs/java/import-eclipse.html#versioning) knowledge base article, the nbproject folder should be checked into the VCS in order to allow people to open the project without importing.
