### PR TITLE
Ignore file for SugarCRM

### DIFF
--- a/SugarCRM.gitignore
+++ b/SugarCRM.gitignore
@@ -12,6 +12,7 @@ cache/include/*
 cache/jsLanguage/*
 cache/modules/*
 !cache/modules/emails
+!cache/modules/Emails
 cache/pdf/*
 cache/smarty/cache/*
 cache/smarty/templates_c/*


### PR DESCRIPTION
SugarCRM is a php based crm system which is very popular. Keeping it under version control is kind of tricky because it permanently rewrites a lot of stuff in the cache directory which can't be ignored completely.
The included setup is tested and didn't produce any problems for me so far.
