### PR TITLE
Completing the LaTeX.gitignore

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -21,3 +21,6 @@
 *.nav
 *.snm
 *.vrb
+*.maf
+*.mtc
+*.mtc0


### PR DESCRIPTION
Since *.fdb_latexmk is handled by this gitignore, I add three other extensions generated by latexmk : maf, mtc and mtc0.
