### PR TITLE
Remove weird OS X specific .gitignore rule which behaves very unexpectedly

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-Icon?
 
 # Thumbnails
 ._*


### PR DESCRIPTION
The .gitignore rule "Icon?" will also match directories such as
"icons/", at least on a case-insensitive file-system (this happened to
me on OS X 10.7). I only noticed this several days later because a
developer was complaining about missing icons in his repository. I don't
really know what type of files this rule is supposed to match, but I
guess the described behavior is not expected.
