### PR TITLE
More detailed symfony2 gitignore.

### DIFF
--- a/Symfony2.gitignore
+++ b/Symfony2.gitignore
@@ -1,4 +1,7 @@
+app/bootstrap*
 */logs/*
 */cache/*
 web/uploads/*
 web/bundles/*
+vendor/
+app/config/parameters.ini


### PR DESCRIPTION
Here's a cleaner gitignore for symfony2.  I take out a few more directories as apparently symfony2 projects are supposed to be bootstrapped each time.  Also, parameters.ini will almost always contain sensitive information.
