### PR TITLE
Added cabal-dev dir.

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -1,4 +1,5 @@
 dist
+cabal-dev
 *.o
 *.hi
 *.chi


### PR DESCRIPTION
cabal-dev is a per-project Cabal repository, but you don't include it in your source control tool, it should be ignored.
