### PR TITLE
Ignore additional Netbeans configuration file

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -1,2 +1,3 @@
 nbproject/
 nbactions.xml
+nb-configuration.xml


### PR DESCRIPTION
Additional ignore information for the nb-configuration.xml file. I couldn't find any documentation on the official page about the file's purposes but you can validate it's existence through this Google search http://www.google.com/search?q=site:netbeans.org+nb-configuration.xml.
