### PR TITLE
Add ".externalToolBuilders/" and "*.launch" 

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -13,5 +13,11 @@ local.properties
 .settings/
 .loadpath
 
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
 # CDT-specific
 .cproject


### PR DESCRIPTION
**\* .externalToolBuilders/
This directory stores project-specific launch configurations for external tool builders, such as ant tasks that have to be executed to fulfill the build lifecycle

**\* *.launch
It is possible to store "eclipse launch configurations" in external files. These (XML-)files may be stored anywhere within your projects and will be discovered by Eclipse automagically.
