### PR TITLE
Fix ignore rule for Symfony.gitignore's data/sql, plugin-generated Doctrine models.

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -5,7 +5,10 @@ config/databases.yml
 config/propel.ini
 data/sql/*
 lib/filter/doctrine/base/Base*
+lib/filter/doctrine/*Plugin/base/Base*
 lib/form/doctrine/base/Base*
+lib/form/doctrine/*Plugin/base/Base*
 lib/model/doctrine/base/Base*
+lib/model/doctrine/*Plugin/base/Base*
 lib/model/om/*
 lib/model/map/*


### PR DESCRIPTION
- `sf_root_dir/data/sql` is a directory, so the ignore rule s/b `data/sql/*`, not `data/sql`.
- `sf_lib_dir/{filter,form,model}/doctrine` can also contain generated files for models defined in plugins which should also be ignored.
