### PR TITLE
A gitignore file for the Finale suite of music notation software

### DIFF
--- a/Finale.gitignore
+++ b/Finale.gitignore
@@ -1,0 +1,14 @@
+*.bak
+*.db
+*.avi
+*.pdf
+*.ps
+*.mid
+*.midi
+*.mp3
+*.aif
+*.wav
+# Some versions of Finale have a bug and randomly save extra copies of
+# the music source as "<Filename> copy.mus"
+*copy.mus
+


### PR DESCRIPTION
This gitignore file is for songs saved with the Finale music notation software; exported files (wav, mp3, etc.) and extra copies of the source (often saved due to a bug in some versions of Finale Songwriter) are blocked, as well as backup files (*.bak) and other commonly saved files (pdf, postscript, etc.)
