### PR TITLE
One addition to python's unittest/coverage ignores: nosetests.xml

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -19,6 +19,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+nosetests.xml
 
 #Translations
 *.mo


### PR DESCRIPTION
nosetests.xml is created by the 'nose' test runner when you want xml output, for instance for integration with jenkins.
