### PR TITLE
Fixed bin and obj folders to support silverlight-style capitalization, an

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -1,6 +1,6 @@
 # Build Folders (you can keep bin if you'd like, to store dlls and pdbs)
-bin
-obj
+[Bb]in/
+[Oo]bj/
 
 # mstest test results
 TestResults


### PR DESCRIPTION
Fixed bin and obj folders to support silverlight-style capitalization, and added the trailing slash, so that Git treats these entries as directory entries.
