### PR TITLE
don't match directories called tags or TAGS

### DIFF
--- a/Global/Tags.gitignore
+++ b/Global/Tags.gitignore
@@ -1,3 +1,5 @@
 # Ignore tags created by etags and ctags
 TAGS
+!TAGS/
 tags
+!tags/


### PR DESCRIPTION
This file is a little bit too broad in its matching and will match directories like 'lib/tags/' 'spec/lib/tags' etc which is not really what is wanted.
