### PR TITLE
Changed parameters.ini to parameters.*.

### DIFF
--- a/Symfony2.gitignore
+++ b/Symfony2.gitignore
@@ -10,3 +10,4 @@ web/bundles/*
 
 # Configuration files
 app/config/parameters.ini
+app/config/parameters.yml


### PR DESCRIPTION
Symfony 2.0.4 changed standard to using a parameters.yml file, so this change allows for both variants.
