### PR TITLE
Added .SUO and .USER file which is user-specific (window layouts... etc.) for C# gitginore

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -4,3 +4,7 @@ obj
 
 # mstest test results
 TestResults
+
+# user-specific preferences stuff saved by Visual Studio
+*.suo
+*.user


### PR DESCRIPTION
Added .SUO and .USER file which is user-specific (window layouts... etc.) and usually not needed in the project codebase. They are saved by Visual Studio whenever you open the project. I believe Team System editions have even more useless files in the base folder but I don't have it so I don't know.

They also sometimes cause confusion when merging because someone may be re-arranging his/her IDE window layout and committed those changes back into the repo causing everyone else 's window layouts to shift when they apply the commits.
