### PR TITLE
Delete duplicated "eclipse" and support ignoring IDEA's metafile such as 

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -12,5 +12,6 @@ logs
 precompiled
 tmp
 test-result
-eclipse
 server.pid
+*.iml
+*.eml


### PR DESCRIPTION
Delete duplicated "eclipse" and support ignoring IDEA's metafile such as *.iml, *.eml
