### PR TITLE
Update SugarCRM.gitignore

### DIFF
--- a/SugarCRM.gitignore
+++ b/SugarCRM.gitignore
@@ -29,3 +29,6 @@ custom/working/*
 silentUpgrade*.php
 # Logs files can safely be ignored.
 *.log
+# Ignore Files Built By Other Files
+custom/modules/*/Ext/
+custom/application/Ext/*


### PR DESCRIPTION
Adding these two lines allow for git to ignore all the files that are built when you run repair and rebuild from inside the system.  The master files are stored in custom/Extension/modules/*/Ext/.
