### PR TITLE
Wordpress.gitignore

### DIFF
--- a/Wordpress.gitignore
+++ b/Wordpress.gitignore
@@ -1,5 +1,6 @@
 .htaccess
-wp-*.php
+./wp-*.php
+!wp-config.php
 xmlrpc.php
 wp-admin/
 wp-includes/


### PR DESCRIPTION
...to be included in repoo

only ignore root directory (./wp-*.php) Themes may be affected if not isolating the condition to the root.
