### PR TITLE
Move Objective-C.gitignore to Global/Xcode.gitignore

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,0 +1,15 @@
+# Xcode
+build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,15 +1,1 @@
-# Xcode
-build/*
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-*.xcworkspace
-!default.xcworkspace
-xcuserdata
-profile
-*.moved-aside
+Global/Xcode.gitignore


### PR DESCRIPTION
The rules which were previously located in Objective-C.gitignore are
purely Xcode related, and therefore should be located in
Global/Xcode.gitignore, as are the rules for every other IDE.

This comes in handy because one may be working with Xcode in another
language (e.g. C/C++) and would probably not look in the Objective-C.gitignore
file for the rules.

Then again, I have to admit that most people working with Objective-C
are in fact working with Xcode, which is why I created an alias to the
Xcode rules with the old name, that is, Objective-C.gitignore
