### PR TITLE
Remove trailing spaces from Drupal's gitignore file

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -25,7 +25,7 @@ update.php
 xmlrpc.php
 /includes
 /misc
-/modules     
+/modules
 /profiles
 /scripts
 /themes


### PR DESCRIPTION
There are some trailing white spaces in the modules line. This prevents from ignoring that folder.
