### PR TITLE
Ignore Pygmentize (used by "minted" TeX package) files.

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -18,6 +18,7 @@
 *.out
 *.pdfsync
 *.ps
+*.pyg
 *.snm
 *.synctex.gz
 *.toc


### PR DESCRIPTION
TeX [`minted`](http://code.google.com/p/minted/) package uses Pygmentize for highlighting source code. As product, it produces `*.pyg` files, which should be ignored.
