### PR TITLE
Remove node_modules from Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -11,5 +11,4 @@ pids
 logs
 results
 
-node_modules
 npm-debug.log


### PR DESCRIPTION
checking in the node_modules dir is best practice for app developers according to the community since recent changes.

see: http://www.mikealrogers.com/posts/nodemodules-in-git.html
by @mikeal
(cherry picked from commit 44b47ec5bd0222ccf55efe5bcdb8bd3c55271803)
