### PR TITLE
lib/ and modules/

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -7,8 +7,10 @@
 # Ignore Play! working directory #
 db
 eclipse
+lib
 log
 logs
+modules
 precompiled
 tmp
 test-result


### PR DESCRIPTION
As listed in this official [guide](http://www.playframework.org/documentation/1.2.4/guide1).
Both the lib/ (containing binaries) and modules/ directory should be excluded from VCS.
