### PR TITLE
Added .gitgnore for Vim plugins.

### DIFF
--- a/VimPlugin.gitignore
+++ b/VimPlugin.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
This ignores generated helptags for vim plugins in vundle/pathogen setups.
