### PR TITLE
ActionScript: Added "bin" folder

### DIFF
--- a/Actionscript.gitignore
+++ b/Actionscript.gitignore
@@ -1,4 +1,5 @@
 # Build and Release Folders
+bin/
 bin-debug/
 bin-release/
 


### PR DESCRIPTION
By default, FDT5 just uses a "bin" folder, rather than the "bin-debug" and "bin-release" folders common to Flash Builder.
