### PR TITLE
LaTeX.gitignore adding extensions

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -25,3 +25,6 @@
 *.maf
 *.mtc
 *.mtc0
+*.pdf
+*.tex~
+*.tex.backup


### PR DESCRIPTION
Add more extensions to ignore *.pdf, and *.tex~, *.tex.backup which may be
produced from working with a rich text editor
