### PR TITLE
added another path (Symfony.gitignore)

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -12,3 +12,4 @@ lib/model/doctrine/base/Base*
 lib/model/doctrine/*Plugin/base/Base*
 lib/model/om/*
 lib/model/map/*
+web/*Plugin/*


### PR DESCRIPTION
when you run plugin:publish-assets, this creates symlinks in the web folder such as "web/sfDoctrinePlugin" which is a symlink that points back to "plugins/sfDoctrinePlugin/web" This update will ignore those symlinks
