### PR TITLE
Global/Windows: Recycle Bins on network shares

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -3,3 +3,6 @@ Thumbs.db
 
 # Folder config file
 Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/


### PR DESCRIPTION
On network shares(with a Samba server especially), Windows will create a $RECYCLE.BIN directory to emulate the Recycle Bin behavior of NTFS. These should be ignored.
