### PR TITLE
ignore file for BlackBerry Java 

### DIFF
--- a/BlackBerry.gitignore
+++ b/BlackBerry.gitignore
@@ -6,6 +6,3 @@ deliverables/
 
 # generated files
 bin/
-
-# Local configuration file (sdk path, etc)
-local.properties


### PR DESCRIPTION
Ignore file for generated build files when using the BlackBerry Java SDK (Eclipse plugin).
