### PR TITLE
Updated the windows ignore file

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -1,5 +1,6 @@
 # Windows image file caches
-Thumbs.db 
+Thumbs.db
+ehthumbs.db
 
 # Folder config file
 Desktop.ini


### PR DESCRIPTION
Updated the windows ignore file to exclude windows media center edition thumbnail cache.

File to be ignored is "ehthumbs.db"
