### PR TITLE
gitignore for Opa

### DIFF
--- a/Opa.gitignore
+++ b/Opa.gitignore
@@ -1,0 +1,13 @@
+_build
+_tracks
+
+opa-debug-js
+
+*.opp
+*.opx
+*.opx.broken
+*.dump
+*.api
+*.api-txt
+*.exe
+*.log


### PR DESCRIPTION
A .gitignore template for the Opa language http://opalang.org
