### PR TITLE
Added gitignore for EiffelStudio

### DIFF
--- a/Global/EiffelStudio.gitignore
+++ b/Global/EiffelStudio.gitignore
@@ -1,0 +1,3 @@
+EIFGENs/
+*.log
+*.ecf


### PR DESCRIPTION
Added a the following to the gitignore for the default Eiffel IDE _EiffelStudio 7.0_:
1. EIFGENs containing compiled C-code
2. log files
3. ECF project file (it does only contain relative paths, however it is IDE specific, so I felt like excluding it)
