### PR TITLE
Bumpy case StyleCop file wasn't being ignored

### DIFF
--- a/Global/VisualStudio.gitignore
+++ b/Global/VisualStudio.gitignore
@@ -64,7 +64,7 @@ sql
 TestResults
 *.Cache
 ClientBin
-stylecop.*
+[Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects


### PR DESCRIPTION
Enhanced the support for the StyleCop file so when it was bumpy case it would be ignored as well.
