### PR TITLE
Added Org-mode section to Emacs ignore file

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -6,3 +6,7 @@
 auto-save-list
 tramp
 .\#*
+
+# Org-mode
+.org-id-locations
+*_archive


### PR DESCRIPTION
Org-mode stores archived TODOs from todo.org into todo.org_archive. It also
creates .org-id-locations in some cases.
