### PR TITLE
Ignore sublime workspaces

### DIFF
--- a/Global/SublimeText.gitignore
+++ b/Global/SublimeText.gitignore
@@ -1,3 +1,4 @@
 
 # SublimeText project files
 /*.sublime-project
+/*.sublime-workspace


### PR DESCRIPTION
Workspace files store information about buffers, auto completion and more, which doesn't belong in a repository.
