### PR TITLE
ignored /bin/* generated by bundle install --binstubs

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -14,3 +14,4 @@ capybara-*.html
 **.orig
 rerun.txt
 pickle-email-*.html
+/bin/*


### PR DESCRIPTION
The '--binstubs' option is useful to skip 'bundle exec' command. `bundle install` with this option generates /bin directory and executables, and so these files should be ignored with /bundle/*.
