### PR TITLE
Create RVM-specific gitignore

### DIFF
--- a/Global/RVM.gitignore
+++ b/Global/RVM.gitignore
@@ -1,0 +1,1 @@
+bundler_stubs


### PR DESCRIPTION
RVM provides a way to avoid typing 'bundler exec' before every binary you run
at the shell prompt. This creates a file in the application root to hold the
wrappers, and since it is a local-only setting, should be ignored.

See:
- http://www.beginrescueend.com/integration/bundler/
- http://ruby.railstutorial.org/chapters/static-pages?version=3.2#sec:rvm_bundler_integration
