### PR TITLE
priv is a legitimate part of an OTP application

### DIFF
--- a/Erlang.gitignore
+++ b/Erlang.gitignore
@@ -1,6 +1,5 @@
 .eunit
 deps
-priv
 *.o
 *.beam
 *.plt


### PR DESCRIPTION
Ignoring priv directory in Erlang projects is not a good idea as it is used as a way for an application to carry some files around.
