### PR TITLE
Removing line that incorrectly ignores `themes/classic/views/`.

### DIFF
--- a/Yii.gitignore
+++ b/Yii.gitignore
@@ -1,3 +1,2 @@
 assets/
 protected/runtime/
-themes/classic/views/


### PR DESCRIPTION
Removing line that incorrectly ignores `themes/classic/views/`.  Runtime files should be ignored, but there are no runtime files stored in that path.
