### PR TITLE
Added node_modules

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -12,3 +12,5 @@ logs
 results
 
 npm-debug.log
+
+node_modules


### PR DESCRIPTION
We should also ignore node_modules, as they are quite common in node repositories.
