### PR TITLE
some some additional node files to ignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -12,3 +12,6 @@ logs
 results
 
 npm-debug.log
+.lock-wscript
+node_modules/**/out
+node_modules/**/build


### PR DESCRIPTION
The wscript lock file plus module binary build dirs. These will likely change sync gyp is the new standard, but still useful I think.
