### PR TITLE
Ignoring compiled MEX binaries for all platforms

### DIFF
--- a/Global/Matlab.gitignore
+++ b/Global/Matlab.gitignore
@@ -9,3 +9,5 @@
 # OSX / *nix default autosave extension
 *.m~
 
+# Compiled MEX binaries (all platforms)
+*.mex*


### PR DESCRIPTION
Including mexglx, mexa64, mexmaci64, mexw32 & mex64 (see the [official list](http://www.mathworks.com/help/techdoc/matlab_external/f29502.html#bra56dy-1) from Mathworks).
