### PR TITLE
Ignore Simulink code generation output

### DIFF
--- a/Global/Matlab.gitignore
+++ b/Global/Matlab.gitignore
@@ -9,3 +9,5 @@
 # OSX / *nix default autosave extension
 *.m~
 
+# Simulink Code Generation
+slprj/


### PR DESCRIPTION
Simulink creates a temporary directory where it dumps the code generation source/compiled target files prior to model execution.

Adding this temporary directory under `Matlab.ignore` since there is no specific `.gitignore` for the Simulink environment. 
