### PR TITLE
Including META.json & MYMETA.json to Perl.gitignore.

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -11,5 +11,7 @@ Makefile.old
 MANIFEST.bak
 META.yml
 MYMETA.yml
+META.json
+MYMETA.json
 nytprof.out
 pm_to_blib


### PR DESCRIPTION
These are just the JSON variants like their YAML brothers generated by Makefile.PL and can be ignored safely. 
