### PR TITLE
Ignore IntelliJ IDEA project files in Scala

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -11,3 +11,9 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+
+# Intellij project files
+*.iml
+*.ipr
+*.iws
+.idea/


### PR DESCRIPTION
Intellij is quite popular among scala programmers, so I thought including those is a good idea.
It's easier to cut them out if you don't need them than to type them in each time I guess... :-)

Cheers and :+1: for the great idea with supplied .gitignores!
