### PR TITLE
Add `output.diff` to nanoc gitignore.

### DIFF
--- a/nanoc.gitignore
+++ b/nanoc.gitignore
@@ -5,3 +5,6 @@ output/
 
 # Temporary file directory
 tmp/
+
+# Diff file from `enable_output_diff`
+output.diff


### PR DESCRIPTION
If `enable_output_diff` is true, nanoc will generate a diff of the compiled content when compiling a site.
