### PR TITLE
Added META & MYMETA.json to Perl.gitignore

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -10,6 +10,8 @@ Makefile
 Makefile.old
 MANIFEST.bak
 META.yml
+META.json
 MYMETA.yml
+MYMETA.json
 nytprof.out
 pm_to_blib


### PR DESCRIPTION
META & MYMETA.json are generated by recent build utils ( using [CPAN::Meta](https://metacpan.org/module/CPAN::Meta), etc ).
