### PR TITLE
(Symfony) add ignores for lib/form/base/* and lib/filter/base/* directories

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -4,8 +4,10 @@ web/uploads/*
 config/databases.yml
 config/propel.ini
 data/sql/*
+lib/filter/base/*
 lib/filter/doctrine/base/Base*
 lib/filter/doctrine/*Plugin/base/Base*
+lib/form/base/*
 lib/form/doctrine/base/Base*
 lib/form/doctrine/*Plugin/base/Base*
 lib/model/doctrine/base/Base*


### PR DESCRIPTION
add ignores for lib/form/base/\* and lib/filter/base/\* directories (created by Propel forms and filters)
