### PR TITLE
Adding Monodevelop specific file ignores

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -94,3 +94,7 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+
+# MonoDevelop Specific Files
+*.userprefs
+*.pidb


### PR DESCRIPTION
Monodevelop is a popular C# IDE for Win, Mac and Linux. Since VS ignores
are in the CSharp file, MD ignores fit in there as well.
