### PR TITLE
Adding gitignore to Titanium Mobile & Desktop Projects

### DIFF
--- a/Titanium.gitignore
+++ b/Titanium.gitignore
@@ -1,0 +1,6 @@
+# binaries gen by Ti Desktop
+dist/
+
+# build and build log gen by Ti Mobile
+build/
+build.log


### PR DESCRIPTION
I've created a gitignore for two opensource projects: 
- Titanium Mobile (https://github.com/appcelerator/titanium_mobile)
- Titanium Desktop (https://github.com/appcelerator/titanium_desktop)

It ignores binaries generated by each platform, and self-generated source code for Android & iOS systems.
