### PR TITLE
Removed packages folder from Visual Studio Global ignore

### DIFF
--- a/Global/VisualStudio.gitignore
+++ b/Global/VisualStudio.gitignore
@@ -87,6 +87,3 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
-
-# NuGet
-packages/


### PR DESCRIPTION
As noted in pull request #233, the packages folder is part of NuGet and not specifically part of Visual Studio. Adding this to a Visual Studio global ignore is not correct and will have a chance to break in projects which do not use nuget but do use a packages folder.
