### PR TITLE
Ignore .idea/ folder for AppCode users.

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -14,3 +14,4 @@ xcuserdata
 profile
 *.moved-aside
 DerivedData
+.idea/


### PR DESCRIPTION
JetBrains' AppCode leaves a .idea folder in the project root, containing lots of files of (what appears to be) transient state.
