### PR TITLE
Add OSX-specific Icon\r rule

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
If you have a git repository in OSX in a directory with a custom icon (Dropbox, for example), git will try to track a file called `Icon\r`. That `\r` is not a backslash followed by an r, it is a carriage return, sometimes shown as `^M` or `\015`.

There used to be an overly-broad rule to exclude this file but it was removed in #183 for excluding too much. My fix was generated using the following commands in `irb`:

```
f = File.open("Global/OSX.gitignore", "a+") #append
f.write("Icon\r\r")
f.close
```

Note that the _Diff_ tab does not show the change properly because of the control character. You'll want to actually pull this down, use `cat -e Global/OSX.gitignore` where the `-e` flag displays non-printing characters. You'll see that the line actually says 

```
Icon^M^M$
```

where `^M` is the carriage return and `$` is the line feed.

Credit goes to @kamal for his [writeup](http://blog.bitfluent.com/post/173740409/ignoring-icon-in-gitignore). More information about [Icon\r](http://superuser.com/questions/298785/icon-file-on-os-x-desktop) for anyone interested.
