### PR TITLE
Update Wordpress.gitignore

### DIFF
--- a/Wordpress.gitignore
+++ b/Wordpress.gitignore
@@ -1,5 +1,5 @@
 .htaccess
-wp-*.php
+/wp-*.php
 xmlrpc.php
 wp-admin/
 wp-includes/


### PR DESCRIPTION
Hi, 

I think wp-\* files should be excluded only from the root of the repo, I had some issues with the WPML plugin because it also uses this naming convention but inside the plugins folder, It shouldn't be exluded.
