### PR TITLE
Qt Creator template

### DIFF
--- a/QtCreator.gitignore
+++ b/QtCreator.gitignore
@@ -1,0 +1,15 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+
+# Compiled Dynamic libraries
+*.so
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+
+# Local build information
+*.pro.user


### PR DESCRIPTION
Created a gitignore template for Qt Creator. The *.pro.user file should not be tracked as it only contains local build information. Includes common c++ ignores.
