### PR TITLE
add pom.xml.versionsBackup that is created using "mvn versions:set"

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -1,1 +1,2 @@
 target/
+pom.xml.versionsBackup


### PR DESCRIPTION
The maven plugin org.codehaus.mojo:versions-maven-plugin creates temporary files as backup copies of the pom.xml file when updating the versions for a project before and after each release. There doesn't seem to be any reason that these files would need to be in source control, as they are created as a cheap local backup. Hence, they could be useful for the maven .gitignore template for other users.
