### PR TITLE
the current version of Cakephp (2.x) renamed the config folder to Config

### DIFF
--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -1,5 +1,7 @@
 tmp/*
-config/database.php
+Config/core.php
+Config/database.php
 app/tmp/*
-app/config/database.php
+app/Config/core.php
+app/Config/database.php
 !empty


### PR DESCRIPTION
Also adding core to the list of files to ignore as this contains the app security salt, and shouldn't ordinarily be in a repo.
