### PR TITLE
Added Actionscript ignores for FlashDevelop project files

### DIFF
--- a/Actionscript.gitignore
+++ b/Actionscript.gitignore
@@ -3,8 +3,17 @@ bin/
 bin-debug/
 bin-release/
 
-# Project property files
+# Flash Builder project file, comment out if desired
 .actionScriptProperties
+
+# FlashDevelop project file, comment out if desired
+.as3proj
+
+# Flash Builder project property files
 .flexProperties
 .settings/
 .project
+
+# FlashDevelop project property files
+obj/
+.lxml


### PR DESCRIPTION
Also explicitly called out the project file for FD and FB, which some projects or teams may not want to have in .gitignore
