### PR TITLE
Ignore information for lein plugin directory. 

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -3,3 +3,4 @@ pom.xml
 /lib/
 /classes/
 .lein-deps-sum
+.lein-plugins/


### PR DESCRIPTION
The directory is similar to the lib/ directory as it also contains downloaded dependencies (or in this case plugins).
