### PR TITLE
Gitignore for Qt core developers

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -8,7 +8,7 @@
 *.lai
 *.so
 *.dll
-*.dynlib
+*.dylib
 
 # Qt-es
 


### PR DESCRIPTION
Now, a lot of software developers use Qt libraries to create dynamic and fast cross-platform applications. But actually this gitignore for Qt CORE developers (in the next requests it will work with Qt Quick also).

So, I have created it for them. It must be the first version).

**NOTICE**: Qt Creator doesn't commit this files, but if developer use console instead of main Qt Creator Git interface it is pushing ALL files.

Thanks for such a good repository.
