### PR TITLE
added composer.phar to Symfony2 gitignore

### DIFF
--- a/Symfony2.gitignore
+++ b/Symfony2.gitignore
@@ -11,3 +11,6 @@ web/bundles/*
 # Configuration files
 app/config/parameters.ini
 app/config/parameters.yml
+
+# Composer
+composer.phar


### PR DESCRIPTION
the bleeding edge Symfony2 bundles use composer, so I added the composer.phar to its .gitignore
