### PR TITLE
Perl ignore META.json

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -11,5 +11,6 @@ Makefile.old
 MANIFEST.bak
 META.yml
 MYMETA.yml
+META.json
 nytprof.out
 pm_to_blib


### PR DESCRIPTION
Added another META file created by Module::Build, META.json, to Perl.gitignore
