### PR TITLE
Remove space after Thumbs.db

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -1,5 +1,5 @@
 # Windows image file caches
-Thumbs.db 
+Thumbs.db
 
 # Folder config file
 Desktop.ini


### PR DESCRIPTION
Because there's a space after the Thumbs.db line in the Windows.gitignore, it doesn't actually ignore the files.
