### PR TITLE
Add *.pdf to LaTeX.gitignore

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -22,6 +22,7 @@
 *.nav
 *.nlo
 *.out
+*.pdf
 *.pdfsync
 *.ps
 *.snm


### PR DESCRIPTION
In LaTeX repo, it should be better to ignore *.pdf files as they can be generated from tex code.
