### PR TITLE
Ignore custom Finder folder icons (but leave disabled by default)

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -6,6 +6,8 @@
 # not to work in this case.
 # See http://blog.bitfluent.com/post/173740409/ignoring-icon-in-gitignore
 # for more info.
+# Uncomment the line below to enable.
+#Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
Added a rule to ignore custom folder icons, but leaving disabled by default as some may want custom icons tracked.

The non-printable characters in the entry are carriage returns (U+000D); including them—and two of them—literally is the only way I've found of actually getting the intended behaviour. Escaping the characters like `\015` or `\x0D` doesn't seem to work for this case.

See also [existing discussion](https://github.com/github/gitignore/commit/85de979a0392a1df538976548c418d0a3b6b17af#commitcomment-1415391).
