### PR TITLE
Corrected 'wp-*.php' to '/wp-*.php'

### DIFF
--- a/Wordpress.gitignore
+++ b/Wordpress.gitignore
@@ -1,5 +1,5 @@
 .htaccess
-wp-*.php
+/wp-*.php
 xmlrpc.php
 wp-admin/
 wp-includes/


### PR DESCRIPTION
Without '/', the rule on line 2 ignores any files that match throughout the tree, including plugin files.

Two plugins affected by this issue in my current project are:

WP-Typography (http://wordpress.org/extend/plugins/wp-typography/)
_wp-typography.php_

Twitter-Widget-Pro (http://wordpress.org/extend/plugins/twitter-widget-pro/)
_wp-twitter-widget.php_

With '/' at the beginning we ignore only those matching files at the root of the repo.
