### PR TITLE
visual studio gitignore correction 

### DIFF
--- a/Global/VisualStudio.gitignore
+++ b/Global/VisualStudio.gitignore
@@ -96,7 +96,8 @@ ClientBin
 
 *.[Pp]ublish.xml
 
-Generated_Code #added for RIA/Silverlight projects
+#added for RIA/Silverlight projects
+Generated_Code/
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)


### PR DESCRIPTION
the generated_code entry was not matching it's intended target, the Generated_Code/ directories of silverlight projects.

Also, the comment on the same line was causing the entry to not take effect.
