### PR TITLE
latex: ignore file from filename recorder

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -6,6 +6,7 @@
 *.blg
 *.dvi
 *.fdb_latexmk
+*.fls
 *.glg
 *.glo
 *.gls


### PR DESCRIPTION
a .fls file is generated by tex, pdftex, latex, pdflatex, etc when using the -recorder option. This leaves a trace of the files opened for input and output in a file during build of the document. It is sort of the TeX analogue of gcc's "-MD" flag.
