### PR TITLE
Add RubyMotion gitignore to Github's defaults

### DIFF
--- a/RubyMotion.gitignore
+++ b/RubyMotion.gitignore
@@ -1,0 +1,13 @@
+.repl_history
+build
+tags
+
+# common annoyance editors
+.DS_Store
+nbproject
+.redcar
+*.swp
+*.swo
+~
+.eprj
+


### PR DESCRIPTION
Just stuff that we've found we never want to commit for RubyMotion projects.
