### PR TITLE
Ignore *.tdo files generated by the todonotes package

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -29,3 +29,4 @@
 *.toc
 *.vrb
 *.xdy
+*.tdo


### PR DESCRIPTION
The [todonotes package](http://www.tex.ac.uk/tex-archive/macros/latex/contrib/todonotes/todonotes.pdf) generates "tdo" files when you use the \listoftodos command.
