### PR TITLE
ignoring *.dylib (dynamic link libraries in MacOS X)

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -5,6 +5,7 @@
 
 # Compiled Dynamic libraries
 *.so
+*.dylib
 
 # Compiled Static libraries
 *.lai

--- a/C.gitignore
+++ b/C.gitignore
@@ -7,6 +7,7 @@
 # Shared objects (inc. Windows DLLs)
 *.dll
 *.so
+*.dylib
 
 # Executables
 *.exe


### PR DESCRIPTION
*.dylib is an extension for dynamic link library in MacOS X.
These should be ignored.
