### PR TITLE
Unity: Also ignore pidb and userprefs files.

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -6,3 +6,5 @@
 *.csproj
 *.unityproj
 *.sln
+*.pidb
+*.userprefs


### PR DESCRIPTION
Re: Unity projects: the *.pidb and *.userprefs files are also auto-generated, and are at best unuseful committed and at worst a nuisance committed.
