### PR TITLE
Update to also ignore .DS_Store files

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,4 +1,5 @@
 # Xcode
+.DS_Store
 build/*
 *.pbxuser
 !default.pbxuser


### PR DESCRIPTION
On a Mac, you won’t be interested in tracking `.DS_Store` files.
