### PR TITLE
Add Exception for htaccess file denying access to the cache folder

### DIFF
--- a/CodeIgniter.gitignore
+++ b/CodeIgniter.gitignore
@@ -3,3 +3,4 @@
 */logs/!index.html
 */cache/*
 */cache/!index.html
+*/cache/!.htaccess


### PR DESCRIPTION
CodeIgniter has got an htaccess file blocking direct access to the cache folder that should be part of the project and thus excluded from the ignore list
