### PR TITLE
Add *.thm for LaTeX

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -26,6 +26,7 @@
 *.ps
 *.snm
 *.synctex.gz
+*.thm
 *.toc
 *.vrb
 *.xdy


### PR DESCRIPTION
*.thm files come from the theorem environment.
We use the ntheorem package which created the file.
More information can be found here
http://www.ctan.org/tex-archive/macros/latex/contrib/ntheorem/ntheorem.pdf
