### PR TITLE
Update SeamGen.gitignore

### DIFF
--- a/SeamGen.gitignore
+++ b/SeamGen.gitignore
@@ -1,13 +1,24 @@
 /bootstrap/data
 /bootstrap/tmp
-/classes/			# all class files
-/dist/				# contains generated war files for deployment
-/exploded-archives/		# war content generation during deploy (or explode)
-/test-build/			# test compilation (ant target for Seam)
-/test-output/			# test results
-/test-report/			# test report generation for, e.g., Hudson
-/target/			# maven output folder
-temp-testng-customsuite.xml	# generated when running test cases under Eclipse
+/classes/
+/dist/
+/exploded-archives/
+/test-build/
+/test-output/
+/test-report/
+/target/
+temp-testng-customsuite.xml
+
+# based on http://stackoverflow.com/a/8865858/422476 I am removing inline comments
+
+#/classes/  		              all class files
+#/dist/                       contains generated war files for deployment
+#/exploded-archives/		      war content generation during deploy (or explode)
+#/test-build/                 test compilation (ant target for Seam)
+#/test-output/                test results
+#/test-report/                test report generation for, e.g., Hudson
+#/target/                     maven output folder
+#temp-testng-customsuite.xml	generated when running test cases under Eclipse
 
 # Thanks to @VonC and @kraftan for their helpful answers on a related question
 # on StackOverflow.com:


### PR DESCRIPTION
Inline comments break the ignore functionality. Comments should start from the beginning of the line.
