### PR TITLE
Update CSharp.gitignore - NuGet PackageRestore

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -80,6 +80,7 @@ publish
 
 # NuGet Packages Directory
 packages
+!packages/repositories.config
 
 # Windows Azure Build Output
 csx


### PR DESCRIPTION
I agree to ignore the NuGet packages folder, but I really think you should check in the repositories.config so NuGet PackageRestore can do it's magic when someone pulls the code and tries to build it...
