### PR TITLE
Update the Symfony2 to ignore composer

### DIFF
--- a/Symfony2.gitignore
+++ b/Symfony2.gitignore
@@ -2,7 +2,6 @@
 app/bootstrap*
 
 # Symfony directories
-vendor/*
 */logs/*
 */cache/*
 web/uploads/*
@@ -11,3 +10,8 @@ web/bundles/*
 # Configuration files
 app/config/parameters.ini
 app/config/parameters.yml
+
+# Composer dependencies
+vendor/*
+composer.phar
+bin/*


### PR DESCRIPTION
Also ignore the new doctrine bin folder

This is a change for symfony 2.1 which is currently in RC stage.
