### PR TITLE
added NotepadPP.gitignore for Notepad++

### DIFF
--- a/Global/NotepadPP.gitignore
+++ b/Global/NotepadPP.gitignore
@@ -1,0 +1,2 @@
+# Notepad++ backups #
+*.bak


### PR DESCRIPTION
notepad++ creates files with the .bak extension as backups
