### PR TITLE
The Lithium app should be the root repo folder

### DIFF
--- a/Lithium.gitignore
+++ b/Lithium.gitignore
@@ -1,2 +1,2 @@
-app/libraries/*
-app/resources/tmp/*
+libraries/*
+resources/tmp/*


### PR DESCRIPTION
Hey there!

A while ago we changed the structure of the Lithium repository, and the new-app creation workflow to properly reflect a best-practice workflow.

As such, apps live in the root of the repository, not under `app/`. The default `.gitignore` has been updated to reflect that.

Thanks y'all!
