### PR TITLE
Ignored Pods/ in obj-c

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -16,3 +16,4 @@ profile
 *.moved-aside
 DerivedData
 .idea/
+Pods/


### PR DESCRIPTION
If we are ignoring `.bundle` in ruby,
then we should be ignoring `Pods/` in obj-c.
