### PR TITLE
Adds Cloud9 gitignore

### DIFF
--- a/Global/Cloud9.gitignore
+++ b/Global/Cloud9.gitignore
@@ -1,0 +1,2 @@
+.c9revisions/
+*.c9save


### PR DESCRIPTION
This commit adds a gitignore for the cloud9 IDE, c9.io.
