### PR TITLE
Keep .cachefile out of the repo

### DIFF
--- a/Global/VisualStudio.gitignore
+++ b/Global/VisualStudio.gitignore
@@ -46,6 +46,7 @@ ipch/
 *.ncb
 *.opensdf
 *.sdf
+*.cachefile
 
 # Visual Studio profiler
 *.psess


### PR DESCRIPTION
Visual Studio 2010 Express for Windows Phone seems to generate .cachefile files, at least for XNA projects.
