### PR TITLE
SBT 0.12: Additional files

### DIFF
--- a/Global/SBT.gitignore
+++ b/Global/SBT.gitignore
@@ -5,3 +5,5 @@ target/
 lib_managed/
 src_managed/
 project/boot/
+.history
+.cache


### PR DESCRIPTION
Starting with version 0.12, SBT creates two additional files, .history and .cache. These should be ignored as well.
