### PR TITLE
FlashDevelop specific equivalents to Actionscript.gitignore

### DIFF
--- a/Actionscript.gitignore
+++ b/Actionscript.gitignore
@@ -8,3 +8,10 @@ bin-release/
 .flexProperties
 .settings/
 .project
+
+# FlashDevelop
+# Project file
+.as3proj
+
+# Build properties folder
+obj/


### PR DESCRIPTION
Current Actionscript.gitignore settings are specific to eclipse based IDE's. I've added in two additional files/folders to ignore that are created by [FlashDevelop](http://flashdevelop.org/).
