### PR TITLE
Added Windows Store app package directory

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -85,6 +85,9 @@ packages
 csx
 *.build.csdef
 
+# Windows Store app package directory
+AppPackages/
+
 # Others
 [Bb]in
 [Oo]bj


### PR DESCRIPTION
This directory is created when Windows Store app package is created using "Create App Package" wizard in Visual Studio 2012.

App packages and deployment (Windows Store apps)
http://msdn.microsoft.com/en-us/library/windows/apps/hh464929.aspx

Packaging your Windows Store app
http://msdn.microsoft.com/en-us/library/windows/apps/hh454036.aspx
