### PR TITLE
Added Bricx Command Center gitignore

### DIFF
--- a/Global/BricxCC.gitignore
+++ b/Global/BricxCC.gitignore
@@ -1,2 +1,4 @@
+# Bricx Command Center IDE
+# http://bricxcc.sourceforge.net
 *.bak
 *.sym


### PR DESCRIPTION
Added gitignore for Bricx Command Center (BricxCC) IDE – http://bricxcc.sourceforge.net

BricxCC always generates a `.bak` and `.sym` file for every program - they are just backup files and should be ignored.

You might say that BricxCC is a bit niche, but it's widely used throughout the (Lego) robotics industry.
