### PR TITLE
Rename Wordpress.gitignore to WordPress.gitignore

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,0 +1,13 @@
+.htaccess
+wp-config.php
+wp-content/uploads/
+wp-content/blogs.dir/
+wp-content/upgrade/
+wp-content/backup-db/
+wp-content/advanced-cache.php
+wp-content/wp-cache-config.php
+sitemap.xml
+*.log
+wp-content/cache/
+wp-content/backups/
+sitemap.xml.gz


### PR DESCRIPTION
WordPress should _always_ have a capital P. 
http://justintadlock.com/archives/2010/07/08/lowercase-p-dangit
