### PR TITLE
For CodeIgeniter, development directory is not included anymore. User_guide also should be ignored.

### DIFF
--- a/CodeIgniter.gitignore
+++ b/CodeIgniter.gitignore
@@ -1,5 +1,6 @@
-*/config/development
+*/config/*
 */logs/log-*.php
 */logs/!index.html
 */cache/*
 */cache/!index.html
+user_guide


### PR DESCRIPTION
... ignored.
