### PR TITLE
TeamCity ignore for CSharp

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -55,6 +55,9 @@ ipch/
 # ReSharper is a .NET coding add-in
 _ReSharper*
 
+# TeamCity is a CI server with an add-in for Visual Studio
+_TeamCity*
+
 # NCrunch
 *.ncrunch*
 .*crunch*.local.xml


### PR DESCRIPTION
TeamCity leaves some cache files in your workspace that don't belong in source control. This pull request adds the ignore for _TeamCity\* for the CSharp gitignore.
