### PR TITLE
add .project files to .gitignore

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -14,3 +14,4 @@ capybara-*.html
 **.orig
 rerun.txt
 pickle-email-*.html
+.project


### PR DESCRIPTION
.project files come from Aptana Studio, a Rails IDE.
