### PR TITLE
fix Generated_Code entry in CSharp.gitignore

### DIFF
--- a/CSharp.gitignore
+++ b/CSharp.gitignore
@@ -99,7 +99,8 @@ ClientBin
 [Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
-Generated_Code #added for RIA/Silverlight projects
+# added for RIA/Silverlight projects
+Generated_Code
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)


### PR DESCRIPTION
The existing entry for Generated_Code (with a space and then a comment afterwards) wasn't working for me (at least with msysgit version 1.7.11.msysgit.1).

Once I put the comment on a separate line and removed the trailing space after 'Generated_Code', it worked fine.

[The gitignore(5) man page](http://www.kernel.org/pub/software/scm/git/docs/gitignore.html) says a line starting with # is treated as a comment, but doesn't mention what # does if it's elsewhere in the line, so based on the previous behavior and trying a line of "Generated_Code#foo", it appears that the # and the rest of the line isn't ignored, so we need to move the comment to its own line that starts with #
