### PR TITLE
Add *~ to ignore vim temp file.

### DIFF
--- a/Global/vim.gitignore
+++ b/Global/vim.gitignore
@@ -2,3 +2,4 @@
 *.un~
 Session.vim
 .netrwhist
+*~


### PR DESCRIPTION
Add *~ to ignore vim temp file, at least on Windows, vim's temp file end with '~'.
