### PR TITLE
Include crash.log file in nanoc.gitignore

### DIFF
--- a/nanoc.gitignore
+++ b/nanoc.gitignore
@@ -5,3 +5,6 @@ output/
 
 # Temporary file directory
 tmp/
+
+# Crash Log
+crash.log


### PR DESCRIPTION
I've updated the nanoc.gitignore file to include the crash.log file added to nanoc in [Version 3.4 on June 9, 2012](http://nanoc.stoneship.org/release-notes/#3-4-2012-06-09)
