### PR TITLE
Dreamweaver .gitignore contribution.

### DIFF
--- a/Global/Dreamweaver.gitignore
+++ b/Global/Dreamweaver.gitignore
@@ -1,0 +1,2 @@
+# Ignore scattered _notes directories that Dreamweaver uses to keep track of its edits and concurrency
+*/_notes


### PR DESCRIPTION
DW really places a lot of emphasis on xml metadata held in a generated _notes directory. Ignoring them. It's worth noting that the directory generation can be turned off, but this file makes that setting not relevant.

Hope it helps! -nn
