### PR TITLE
Update Global/VisualStudio.gitignore

### DIFF
--- a/Global/VisualStudio.gitignore
+++ b/Global/VisualStudio.gitignore
@@ -10,11 +10,9 @@
 
 [Dd]ebug*/
 [Rr]elease/
-
 build/
 
-
-[Tt]est[Rr]esult
+[Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
 *_i.c
@@ -56,7 +54,7 @@ ipch/
 
 # ReSharper is a .NET coding add-in
 _ReSharper*/
-
+# Some recommend against the RS rule below - excludes useful info?
 *.[Rr]e[Ss]harper
 
 # NCrunch
@@ -64,7 +62,7 @@ _ReSharper*/
 .*crunch*.local.xml
 
 # Installshield output folder
-[Ee]xpress
+[Ee]xpress/
 
 # DocProject is a documentation generator add-in
 DocProject/buildhelp/
@@ -77,26 +75,25 @@ DocProject/Help/Html2
 DocProject/Help/html
 
 # Click-Once directory
-publish
+publish/
 
 # Publish Web Output
 *.Publish.xml
 
 # Others
-[Bb]in
-[Oo]bj
-sql
-TestResults
-[Tt]est[Rr]esult*
+[Bb]in/
+[Oo]bj/
+sql/
 *.Cache
-ClientBin
+ClientBin/
 [Ss]tyle[Cc]op.*
 ~$*
 *.dbmdl
 
 *.[Pp]ublish.xml
 
-Generated_Code #added for RIA/Silverlight projects
+# RIA/Silverlight projects
+Generated_Code/
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)


### PR DESCRIPTION
Add trailing slashes to folders, RS rule comment, remove dupes. 

NB: quite a bit of overlap here with "CSharp.gitignore" .. but given that GitHub's .gitignore deployment mechanism only supports a single file, perhaps this isn't a bad thing (C# vs general VS). I've also added additional entries to the C# version (subject to acceptance) that not included here.
