### PR TITLE
Added config files that should not be placed into repos by default as th...

### DIFF
--- a/ExpressionEngine.gitignore
+++ b/ExpressionEngine.gitignore
@@ -8,6 +8,10 @@ images/member_photos/
 images/signature_attachments/
 images/pm_attachments/
 
+# For security do not publish the following files
+system/expressionengine/config/database.php
+system/expressionengine/config/config.php
+
 # Caches
 sized/
 thumbs/


### PR DESCRIPTION
I added two main config files to the gitignore for Expression Engine. I added them for 2 reasons, the constants in config.php change from repo to repo (as they set the URL) and the database.php for obvious security reasons.
