### PR TITLE
tighter and more perl entries

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -11,6 +11,9 @@ Build.bat
 /Makefile.old
 /MANIFEST.bak
 /META.yml
-/MYMETA.yml
+/META.json
+/MYMETA.*
 nytprof.out
 /pm_to_blib
+*.o
+*.bs


### PR DESCRIPTION
- leading / added for files or dirs that should only exist in the root of the repository
- META.json, MYMETA.json (metadata from the 2.x spec)
- artifacts of XS (C for perl guts) builds
