### PR TITLE
Fix having TYPO3 core-files as symlinks and fixed product-name

### DIFF
--- a/Typo3.gitignore
+++ b/Typo3.gitignore
@@ -1,4 +1,4 @@
-## Typo3
+## TYPO3 v4
 # Ignore serveral upload and file directories.
 /fileadmin/user_upload/
 /fileadmin/_temp_/


### PR DESCRIPTION
The .gitignore file for TYPO3 does not support having the core-files as symlinks. Symlinks in git are treated as files, not directories.

In addition, the product name has changed. Now it's called TYPO3 CMS and this is for version 4.0, which was also known as TYPO3.
http://typo3.org/the-brand/the-typo3-family/#c2765
http://typo3.org/the-brand/style-guide/the-typo3-spelling/
