### PR TITLE
Qt additions

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -16,5 +16,6 @@
 *.pro.user.*
 moc_*.cpp
 qrc_*.cpp
+ui_*.h
 Makefile*
 *-build-*


### PR DESCRIPTION
I did 2 modifications to "Qt.gitignore":
1. Added wild-card suffix to "Makefile" since often "Makefile.Debug" and "Makefile.Release" are generated from .pro file by qmake utility.
1. Added new entry "ui_*.h" for auto-generated by moc utility headers.
