### PR TITLE
[Objective-C] No longer ignore `xcworkspace` documents.

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -9,8 +9,6 @@
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-*.xcworkspace
-!default.xcworkspace
 xcuserdata
 profile
 *.moved-aside


### PR DESCRIPTION
Workspaces are real documents that can be opened, just like `xcodeproj`
documents. These documents are also generated/used by CocoaPods to
configure a project’s dependencies. For these reasons, there does not
seem a good reason to ignore these any longer.
