### PR TITLE
Make Python .gitignore directory entries match only directories

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -1,31 +1,31 @@
 # Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
 
 # C extensions
 *.so
 
-# Packages
-*.egg
-*.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
+# Distribution / packaging
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
 .installed.cfg
-lib
-lib64
-__pycache__
+*.egg
 
 # Installer logs
 pip-log.txt
 
 # Unit test / coverage reports
+.tox/
 .coverage
-.tox
 nosetests.xml
 
 # Translations


### PR DESCRIPTION
This commit makes Python `.gitignore` directory entries match only directories (by adding a terminal slash as appropriate).

This commit also alphabetizes the distribution/packaging section after separating the directory entries from the file entries.  I left alone a few entries that may or may not be directories (e.g. *.egg and the "Mr Developer" section).
