### PR TITLE
Update VisualStudio.gitignore for vs 2012 web deploy setting.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -84,6 +84,7 @@ publish
 
 # Publish Web Output
 *.Publish.xml
+*.pubxml
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line


### PR DESCRIPTION
New web deploy file name - *.pubxml? VS2012 added this to my solution and it shouldn't go to an open repo.
