### PR TITLE
Ignore Rails directories instead of their files

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -6,12 +6,12 @@ capybara-*.html
 .rvmrc
 /.bundle
 /vendor/bundle
-/log/*
-/tmp/*
+/log
+/tmp
 /db/*.sqlite3
-/public/system/*
+/public/system
 /coverage/
-/spec/tmp/*
+/spec/tmp
 **.orig
 rerun.txt
 pickle-email-*.html


### PR DESCRIPTION
Some shell prompts use `git ls-files --other --exclude-standard --directory` to detect if there is any untracked changes. If only files under directories are ignored, shell prompt will still report existence of unstaged changes, which is a false positive.
