### PR TITLE
Removed *.sdf from VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -48,7 +48,6 @@ ipch/
 *.aps
 *.ncb
 *.opensdf
-*.sdf
 *.cachefile
 
 # Visual Studio profiler


### PR DESCRIPTION
*.sdf is a database file and goes beyond the base C++ usage.

C++ users should add this exception manually, or a new file should be created for C++ Visual Studio projects.
