### PR TITLE
exclude encoding and codeStyle

### DIFF
--- a/Global/IntelliJ.gitignore
+++ b/Global/IntelliJ.gitignore
@@ -1,4 +1,6 @@
 *.iml
 *.ipr
 *.iws
-.idea/
+.idea/*
+!.idea/codeStyleSettings.xml
+!.idea/encodings.xml


### PR DESCRIPTION
when working in a team it is important to have the same encoding settings for files in the project and to use the same coding style, with this configuration the files IntelliJ uses to store those settings are not ignored
