### PR TITLE
Ignore the Eclipse .cache file

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -9,6 +9,7 @@ tmp/**/*
 *.swp
 *~.nib
 local.properties
+.cache
 .classpath
 .settings/
 .loadpath


### PR DESCRIPTION
Rawr temporary cache file.  This definitely should be ignored!
