### PR TITLE
Add gitignore for the Elixir language

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -1,0 +1,3 @@
+/ebin
+/deps
+erl_crash.dump


### PR DESCRIPTION
> Elixir is a functional meta-programming aware language built on top of the Erlang VM

_From [elixir-lang.org](http://elixir-lang.org/)_
