### PR TITLE
Don't ignore .rvmrc

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -3,7 +3,6 @@
 .sass-cache
 capybara-*.html
 .rspec
-.rvmrc
 /.bundle
 /vendor/bundle
 /log/*


### PR DESCRIPTION
We shouldn't be encouraging people to ignore their `.rvmrc` in a Rails project. It's a good idea to ignore it (along with `.rbenv-version`, and the others) in a in a gem which may be used under many ruby versions, but Rails apps usually target a single version, to avoid nasty surprises when deploying.
