### PR TITLE
Add Cloud9 gitignore

### DIFF
--- a/Global/Cloud9.gitignore
+++ b/Global/Cloud9.gitignore
@@ -1,0 +1,2 @@
+# Cloud9 IDE - http://c9.io
+.c9revisions


### PR DESCRIPTION
Cloud9 adds these .c9revision directories to every project. Ideally, they'd add this to their own global .gitignore, but in the  meantime this will have to do.
