### PR TITLE
Add stamp-h1 to ignored files

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -11,3 +11,4 @@ Makefile.in
 /depcomp
 /install-sh
 /missing
+/stamp-h1


### PR DESCRIPTION
The file stamp-h1 only contains a timestamp for config.h - actually the
files timestamp itself serves with this information. Therefore it
actually cannot be of interest not to ignore it.
