### PR TITLE
VisualStudio: Add Business Intelligence projects

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -130,6 +130,11 @@ UpgradeLog*.htm
 App_Data/*.mdf
 App_Data/*.ldf
 
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+
 # =========================
 # Windows detritus
 # =========================


### PR DESCRIPTION
Added files generated by Visual Studio Business Intelligence projects used for SQL Server development. Confirmed that Visual Studio doesn't add these files to other source control systems like TFS.
