### PR TITLE
Set the right cache file

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -10,4 +10,4 @@ project/boot/
 project/plugins/project/
 
 # Scala-IDE specific
-.scala_dependencies
+.cache


### PR DESCRIPTION
The `.scala_dependencies` file was used by the old Scala IDE builder (refined builder). This builder is no more maintain and will be removed in the coming months.

The new default builder (since the 2nd half of 2011, pre version 2.0.0) is based on sbt, and uses the `.cache` file.

We don't have documentation about this file. But we have a ticket open to mitigate the problems created when sharing the file: [assembla 1001524](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/tickets/1001524). And our own projects have it defined in [`.gitignore`](https://github.com/scala-ide/scala-ide/blob/master/.gitignore).
