### PR TITLE
Ignore Vim untitled and unsaved buffer swapfiles

### DIFF
--- a/Global/vim.gitignore
+++ b/Global/vim.gitignore
@@ -1,4 +1,4 @@
-.*.s[a-w][a-z]
+*.s[a-w][a-z]
 *.un~
 Session.vim
 .netrwhist


### PR DESCRIPTION
Vim creates buffer swapfiles starting at .swp for buffers that are
active but untitled and unsaved.
