### PR TITLE
added sphinx to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Sphinx documentation
+docs/_build


### PR DESCRIPTION
Added `docs/_build` to `Python.gitignore` for [Sphinx](http://sphinx-doc.org) default build files.
