### PR TITLE
Add Eclipse project settings directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -34,3 +34,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.settings


### PR DESCRIPTION
Eclipse adds a directory called `.settings` under the project root. I always ignore it in Git.
