### PR TITLE
Ignoring "bld" directory

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -12,6 +12,7 @@
 [Rr]elease/
 x64/
 build/
+bld/
 [Bb]in/
 [Oo]bj/
 


### PR DESCRIPTION
Store apps (or at least the Javascript ones) build to a "bld" directory.

Although "debug" and "release" are ignored, any custom build Configuration (created through configuration manager) will be added, unless we ignore the whole bld dir.
