### PR TITLE
CMakeLists user files support in Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -14,6 +14,7 @@
 
 # Qt-es
 
+CMakeLists.txt.user
 *.pro.user
 *.pro.user.*
 moc_*.cpp


### PR DESCRIPTION
Please, accept this pull, because we (Qt Developers) don't need those files (CMakeLists.txt.user) in Git repos and it would be great if default Qt gitignore really ignore it.
