### PR TITLE
Emacs.gitignore: don't unnecessarily escape #

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -1,11 +1,11 @@
 *~
-\#*\#
+\#*#
 /.emacs.desktop
 /.emacs.desktop.lock
 .elc
 auto-save-list
 tramp
-.\#*
+.#*
 
 # Org-mode
 .org-id-locations


### PR DESCRIPTION
gitignore(5) clearly states that lines beginning with "#" are treated
as comments.  A "#" occurring anywhere else on the line does not need
to be escaped.
