### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -11,5 +11,4 @@ pids
 logs
 results
 
-npm-debug.log
 node_modules


### PR DESCRIPTION
There is no need to ignore `npm-debug.log` because `*.log` entry above ignores it already.
