### PR TITLE
Visual Studio.gitignore updated

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -63,6 +63,9 @@ ipch/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 
+# JetBrains coding add-ins settings
+*.DotSettings
+
 # TeamCity is a build add-in
 _TeamCity*
 


### PR DESCRIPTION
JetBrains .NET add-ins settings file ignore mask has been added.

Settings are saved in *.dotsettings.user file (that is ignored already) and in *.dotsettings.
