### PR TITLE
Create .gitignore template for Sencha Touch 2.1.x html5 framework.

### DIFF
--- a/SenchaTouch2_1.gitignore
+++ b/SenchaTouch2_1.gitignore
@@ -6,6 +6,3 @@ build/
 
 # sass cache folder
 resources/sass/.sass-cache/
-
-# Library
-touch/


### PR DESCRIPTION
Create .gitignore template for Sencha Touch 2.1.x html5 framework. This .gitignore file is intended for use in projects generated using the Sencha Cmd command line tool.

The structure of a Sencha Touch 2.1.x project, generated by the Sencha Cmd tool is described here:

http://docs.sencha.com/touch/2-1/#!/guide/command_app
