### PR TITLE
Slashify Ruby files and directories.

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -1,18 +1,18 @@
-*.gem
-*.rbc
-.bundle
-.config
-coverage
-InstalledFiles
-lib/bundler/man
-pkg
-rdoc
-spec/reports
-test/tmp
-test/version_tmp
-tmp
+/*.gem
+/*.rbc
+/.bundle/
+/.config
+/coverage/
+/InstalledFiles
+/lib/bundler/man/
+/pkg/
+/rdoc/
+/spec/reports/
+/test/tmp/
+/test/version_tmp/
+/tmp/
 
 # YARD artifacts
-.yardoc
-_yardoc
-doc/
+/.yardoc/
+/_yardoc/
+/doc/


### PR DESCRIPTION
Perhaps this is a little pedantic, but without the initial / all
such matches within the repository get ignored, and without the
trailing slash files as well as directories of that name get ignored.
e.g. Specifying `tmp` and `test/tmp` without slashes is redundant, as
`tmp` already ignores `test/tmp`, as well as every other `tmp` and
`tmp/`.
