### PR TITLE
Adding build to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -10,6 +10,7 @@ lib-cov
 pids
 logs
 results
+build
 
 npm-debug.log
 node_modules


### PR DESCRIPTION
This is to exclude compiled binaries from nodejs addons.
