### PR TITLE
Ignore Spring IDE-specific .springBeans file in Eclipse projects

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -24,3 +24,6 @@ local.properties
 
 # PDT-specific
 .buildpath
+
+# SpringIDE-specific
+.springBeans


### PR DESCRIPTION
Spring IDE makes the Eclipse IDE Spring-aware. The
{project}/.springBeans XML file provides information for a Spring Beans
project.
This file is automatically generated when the Spring Nature is added to
a project. It should not be versioned.
