### PR TITLE
LaTeX.gitignore: add .brf for files generated by hyperref

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -7,6 +7,7 @@
 *.blg
 *-blx.aux
 *-blx.bib
+*.brf
 *.dvi
 *.fdb_latexmk
 *.fls


### PR DESCRIPTION
.brf files are generated if the 'backref' or 'pagebackref' options of the hyperref package are enabled. These are intermediate files, so shouldn't be tracked.
