### PR TITLE
add .ruby-version and .ruby-gemset extensions

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -3,6 +3,8 @@
 .sass-cache
 capybara-*.html
 .rspec
+.ruby-gemset
+.ruby-version
 /.bundle
 /vendor/bundle
 /log/*


### PR DESCRIPTION
I added .ruby-version and .ruby-gemset as these extensions work with most ruby version managers and are faster than .rvmrc
