### PR TITLE
Ignore additional temporary files in LaTeX projects

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -3,7 +3,10 @@
 *.alg
 *.aux
 *.bbl
+*.bcf
 *.blg
+*-blx.aux
+*-blx.bib
 *.dvi
 *.fdb_latexmk
 *.fls


### PR DESCRIPTION
From the [latexmk build script](http://manpages.ubuntu.com/manpages/raring/man1/latexmk.1L.html):
- `*.fls`

From the [biblatex package](http://ctan.unsw.edu.au/macros/latex/contrib/biblatex/doc/biblatex.pdf):
- `*-blx.aux`
- `*-blx.bib`
- `*.bcf`
