### PR TITLE
Added DS_Store files to the list of files to ignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -28,3 +28,7 @@ proguard/
 *.iws
 .idea/
 
+# DS_Store files created by Mac OS X
+# http://en.wikipedia.org/wiki/.DS_Store
+*.DS_Store
+


### PR DESCRIPTION
These files are created by the Mac OS X for housekeeping purposes and are not needed for the repository. I just thought it would be cleaner to keep them out, specially for developers from other platforms.
