### PR TITLE
Ignore emacs flymake-mode temp files.

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -10,3 +10,6 @@ tramp
 # Org-mode
 .org-id-locations
 *_archive
+
+# flymake-mode
+*_flymake.*


### PR DESCRIPTION
[Flymake](http://www.emacswiki.org/emacs/FlyMake) is built-in widely used emacs mode that performs on-the-fly syntax check. It [creates temporary copies](http://www.emacswiki.org/emacs/FlyMake#toc14) of checked files by adding `_flymake` before the file extension, so we can safely ignore these copies.
