### PR TITLE
Option to unignore repositories.config

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -96,6 +96,8 @@ publish/
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
 #packages/
+## TODO: If the tool you use requires repositories.config, also uncomment the next line
+#!packages/repositories.config
 
 # Windows Azure Build Output
 csx


### PR DESCRIPTION
Some tools like TeamCity depend on repositories.config being checked-in under `packages/` for the restore to work.
