### PR TITLE
Don't ignore Xcode Schemes

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -10,6 +10,7 @@
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+!*.xcscheme
 profile
 *.moved-aside
 DerivedData


### PR DESCRIPTION
Currently, command line builds with Cocoapods usually fail if schemes aren't explicit.
