### PR TITLE
Ignores Gradle files in Android projects

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -28,3 +28,6 @@ proguard/
 *.iws
 .idea/
 
+# Gradle files
+build/
+.gradle


### PR DESCRIPTION
These files are generated when automating builds of Android applications with Gradle. They can be safely ignored.
