### PR TITLE
Tarma InstallMate

### DIFF
--- a/Global/TarmaInstallMate.gitignore
+++ b/Global/TarmaInstallMate.gitignore
@@ -1,0 +1,7 @@
+
+# Workspace files
+*.iw7
+*.iw9
+
+# Build log files
+*.log


### PR DESCRIPTION
Added Global/TarmaInstallMate.gitignore

Official website for Tarma: http://www.tarma.com/

The best documentation I can find to confirm this is on this page http://www.tarma.com/support/ at the bottom under "What to Include" where it says "not the .iw7./iw9 workspace file"

The project files (that we do not want to ignore) is *.im7 and *.im9 and seen here: http://www.tarma.com/support/im9/using/panes/buildoutput.htm . This link also shows the log file.

I can't really find any other sources to confirm this.
