### PR TITLE
Visual Studio: Ignore Chutzpah testrunnerfiles

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -43,6 +43,9 @@ build/
 *.log
 *.scc
 
+# Chutzpah Test files
+_Chutzpah*
+
 # Visual C++ cache files
 ipch/
 *.aps


### PR DESCRIPTION
Ignores the compiled typescript files that chutzpah creates. Alot of files are created, so ignoring them have an high impact on repository health.
