### PR TITLE
Adding a gitIgnore I use for Laravel projects

### DIFF
--- a/Laravel4.gitignore
+++ b/Laravel4.gitignore
@@ -1,0 +1,8 @@
+# Configuration Files
+app/config/database.php
+app/config/app.php
+
+# Composer Files
+vendor/
+bootstrap/compiled.php
+composer.lock


### PR DESCRIPTION
This is a sample gitignore I use for laravel projects which excludes the configuration files for the database and composer generated files.
