### PR TITLE
Ignore .ruby-version and .ruby-gemset

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -4,6 +4,8 @@
 capybara-*.html
 .rspec
 .rvmrc
+.ruby-version
+.ruby-gemset
 /.bundle
 /vendor/bundle
 /log/*


### PR DESCRIPTION
Now that rvm prefers these more compatible alternatives
http://stackoverflow.com/questions/15708916/use-rvmrc-or-ruby-version-file-to-set-a-project-gemset-with-rvm
