### PR TITLE
Update to remove .pubxml

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -91,7 +91,6 @@ publish/
 
 # Publish Web Output
 *.Publish.xml
-*.pubxml
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line


### PR DESCRIPTION
In the VisualStudio.gitignore file `.pubxml` file is present. This file is designed to be shared with team members. It should not be excluded by default.
