### PR TITLE
Update Magento.gitignore

### DIFF
--- a/Magento.gitignore
+++ b/Magento.gitignore
@@ -45,7 +45,7 @@ get.php
 includes/
 index.php
 index.php.sample
-install.php
+/install.php
 js/blank.html
 js/calendar/
 js/enterprise/


### PR DESCRIPTION
The line for `install.php` blocks adding _any_ file with that name. In this instance, it caused Git to ignore a file for the Aitoc_Aitsys module located at: `app/code/local/Aitoc/Aitsys/Model/Module/Install.php`
