### PR TITLE
Ignore .fls files

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -6,6 +6,7 @@
 *.blg
 *.dvi
 *.fdb_latexmk
+*.fls
 *.glg
 *.glo
 *.gls


### PR DESCRIPTION
.fls files list all input/output files consumed/produced by LaTeX during compilation. It uses local paths, so it doesn't make sense to put in a repository.
