### PR TITLE
VisualStudio default to NOT commit packages to repository

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -94,8 +94,8 @@ publish/
 *.pubxml
 
 # NuGet Packages Directory
-## TODO: If you have NuGet Package Restore enabled, uncomment the next line
-#packages/
+## TODO: If you don't have NuGet Package Restore enabled, comment the next line so you can commit packages to repository
+packages/
 
 # Windows Azure Build Output
 csx


### PR DESCRIPTION
I think it is easier to add missing packages to a repository than remove accidental commit from a repository.

Also, it has been a while since NuGet Package Restore was launched, and maybe the majority has already used it (?)

Also, committing packages to a repository bloats the repository.
