### PR TITLE
Unignore "packages/*/build" in VisualStudio.gitignore.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -15,6 +15,9 @@ build/
 [Bb]in/
 [Oo]bj/
 
+# Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
+!packages/*/build/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
NuGet recently added functionality to support "build/" folders within packages which contain MSBuild .targets files that will be added to projects that install the package. (http://docs.nuget.org/docs/reference/support-for-native-projects)

While most people hopefully use package restore, the default VisualStudio.gitignore assumes you are going to check in the packages folder. However, it has a line that ignores any "build/" folder, meaning some of the package content will not be checked in.

The easiest solution here seems to be to "unignore" the "build/" folder when encountered inside the NuGet "packages/" folder. Which is what this PR does.
