### PR TITLE
Ignore source control plist files generated by Xcode.

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -10,6 +10,7 @@
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+*.xccheckout
 profile
 *.moved-aside
 DerivedData


### PR DESCRIPTION
When first opening projects cloned from a Git repository, newer versions of Xcode create a file called `PROJECT_NAME.xccheckout` containing information on the remote repository's location and version control system type.

It is my opinion that this sort of metadata should not be checked into source control, and hence should be added to the Objective-C .gitignore.
