### PR TITLE
Add schemaview extension to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -115,6 +115,7 @@ ClientBin/
 ~$*
 *~
 *.dbmdl
+*.dbproj.schemaview
 *.[Pp]ublish.xml
 *.pfx
 *.publishsettings


### PR DESCRIPTION
Files ending in .dbproj.schemaview contain state persistence settings
for the Schema View utility within Visual Studio.

http://stackoverflow.com/questions/3937160/in-the-new-visual-studio-2010-sql-server-project-type-what-is-the-dbproj-schem
http://foocompelsyou.wordpress.com/2012/05/06/visual-studio-2010-database-projects-why-use-them/
