### PR TITLE
Added ignore pattern to ignore *.rdl.data file. This file is genrated by Business Development Studio when report is previewed.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -149,3 +149,6 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+
+#BIDS - SSRS project data file caches
+*.rdl.data


### PR DESCRIPTION
*.rdl.data file is created by Business Development Studio when report is viewed. This file is used to cache data for report.

I have been working on SSRS and came across this file and thought this file need not be source controlled. Lots of people on google are looking to get rid of this file from source control. 

Following links explains how to get rid of this file from source control.
http://sathyadb.blogspot.com/2013/03/sql-server-reporting-services.html
http://social.msdn.microsoft.com/Forums/sqlserver/en-US/52bd33e2-1f07-43f5-a942-e7ac7b1a79e9/how-to-remove-the-dataset-cached-rdldata-file-for-a-ssrs-report-from-bids
http://jasonfaulkner.com/ClearDataCacheBIS.aspx

Hope this ignore pattern is useful to others.
