### PR TITLE
Ignore the Python binary from virtualenv on Mac

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -11,6 +11,7 @@ build
 eggs
 parts
 bin
+.Python
 var
 sdist
 develop-eggs


### PR DESCRIPTION
This is the location of the Python interpreter that's installed to the root of a virtualenv that's created at the root of a git repository.

<pre>$ virtualenv -v test
....
Creating test/bin
New python executable in test/bin/python
Changed mode of test/bin/python to 0755
Symlinking test/.Python
....
$ file Test/.Python
Test/.Python: Mach-O universal binary with 2 architectures
Test/.Python (for architecture i386):   Mach-O dynamically linked shared library i386
Test/.Python (for architecture x86_64): Mach-O 64-bit dynamically linked shared library x86_64
</pre>
