### PR TITLE
Ignore Go test files

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+*.test


### PR DESCRIPTION
Go 1.1 leaves `foo.test` binaries in the project directory after running tests.
