### PR TITLE
Fix ignoring the NuGet Packages directory

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -98,7 +98,7 @@ publish/
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
-#packages/
+#packages/*
 
 # Windows Azure Build Output
 csx


### PR DESCRIPTION
In order to ignore the contents of a folder except for a few files, the `folderName/*` syntax should be used instead of `folderName/`. See http://stackoverflow.com/a/14824494/124538
