### PR TITLE
Add Podfile.lock to Objective-C.gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -18,3 +18,4 @@ DerivedData
 
 #CocoaPods
 Pods
+Podfile.lock


### PR DESCRIPTION
CocoaPods generates a supporting Podfile.lock file when installing pods.
Since this file frequently changes and will be regenerated when installing pods, it should be ignored.
