### PR TITLE
Include NuGet.exe for remote build / deployment.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -97,8 +97,9 @@ publish/
 *.pubxml
 
 # NuGet Packages Directory
-## TODO: If you have NuGet Package Restore enabled, uncomment the next line
+## TODO: If you have NuGet Package Restore enabled, uncomment the next two lines
 #packages/
+#!NuGet.exe
 
 # Windows Azure Build Output
 csx


### PR DESCRIPTION
NuGet.exe is excluded by default based on the current ignore rule. This will break build task for services such as AppHarbor or Azure which rely on NuGet Package Restore (and the existence of NuGet.exe) for dependencies.
