### PR TITLE
Fix IntelliJ ignores for Android

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -23,8 +23,6 @@ local.properties
 proguard/
 
 # Intellij project files
-*.iml
-*.ipr
-*.iws
-.idea/
-
+.idea/**/*.iws
+.idea/workspace.xml
+.idea/tasks.xml


### PR DESCRIPTION
- don't ignore `.idea` folder
- ignore files according to http://devnet.jetbrains.com/docs/DOC-1186
- Note: `**`-syntax requires git 1.8.2+ though
