### PR TITLE
Deployed file ignore

### DIFF
--- a/Jboss.gitignore
+++ b/Jboss.gitignore
@@ -13,3 +13,7 @@ jboss/server/minimal/log/*.log
 jboss/server/minimal/tmp/**/*
 jboss/server/minimal/data/**/*
 jboss/server/minimal/work/**/*
+
+# deployed package files #
+
+*.DEPLOYED


### PR DESCRIPTION
when war files or ear files are deployed by the Jboss server, DEPLOYED files are created in the deployments folder which should be ignored.

Thanks
