### PR TITLE
Add ignore file for Chef cookbooks

### DIFF
--- a/ChefCookbook.gitignore
+++ b/ChefCookbook.gitignore
@@ -1,0 +1,17 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+/cookbooks
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml


### PR DESCRIPTION
These ignores are generated by berkshelf, a tool commonly used in the
Chef community for managing cookbooks. This .gitignore is used by
Opscode across publicly available cookbooks.
