### PR TITLE
Add .cache to the Python .gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.cache
 nosetests.xml
 
 # Translations


### PR DESCRIPTION
`.cache` is generated when unittests are run with `py.test` with the `pytest-cache` plugin installed.
