### PR TITLE
VIM: Replacing .s[a-w][a-z] with .swp 

### DIFF
--- a/Global/vim.gitignore
+++ b/Global/vim.gitignore
@@ -1,4 +1,4 @@
-*.s[a-w][a-z]
+*.swp
 *.un~
 Session.vim
 .netrwhist


### PR DESCRIPTION
as it matches .sln (visual studio solution file) and .swf (flash player file) and .svg and .sql files
