### PR TITLE
Exclude all build directories

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,6 +1,6 @@
 # Xcode
 .DS_Store
-*/build/*
+build
 *.pbxuser
 !default.pbxuser
 *.mode1v3


### PR DESCRIPTION
`*/build/*` maybe excludes file in subdirectories but build directory in project root is visibile with git status. It can be useful to exclude all build directories when project is builded by xcodebuild instead of xcode directly
