### PR TITLE
Add BitTorrent Sync

### DIFF
--- a/Global/BitTorrentSync.gitignore
+++ b/Global/BitTorrentSync.gitignore
@@ -1,8 +1,9 @@
 # BitTorrent Sync
-*.!sync
 .SyncArchive/
 .SyncTrash/
 .SyncID
 .SyncIgnore
-.SyncPart
-.SyncTemp
+*.!sync
+*.Sync
+*.SyncPart
+*.SyncTemp


### PR DESCRIPTION
Created a .gitignore file that covers files and folders currently dropped by [BitTorrent's Sync](http://labs.bittorrent.com/experiments/sync.html) app.

A list of these files can be found in the [Official FAQ](http://forum.bittorrent.com/topic/16410-bittorrent-sync-faq/) and the [Unofficial FAQ](http://forum.bittorrent.com/topic/17782-bittorrent-sync-faq-unofficial/).
