### PR TITLE
Add RubyMine project (/.idea) to Rails ignore

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -8,6 +8,7 @@ capybara-*.html
 /vendor/bundle
 /log/*
 /tmp/*
+/.idea/*
 /db/*.sqlite3
 /public/system/*
 /coverage/


### PR DESCRIPTION
.idea is the directory when RubyMine store project files.
