### PR TITLE
Add Composer.gitignore for composer packages

### DIFF
--- a/Composer.gitignore
+++ b/Composer.gitignore
@@ -1,0 +1,6 @@
+composer.phar
+vendor/
+
+# Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+# composer.lock


### PR DESCRIPTION
Libraries/Projects using [Composer](http://getcomposer.org) for dependency management should include a `.gitignore` file like this.

It ignores the vendor folder which Composer uses for dependencies, classmaps and others. Composer keeps git repositories in this folder so it is cleaner if it is ignored.

[`composer.lock` should not be ignored.](http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file)

> **Commit your application's `composer.lock` (along with `composer.json`) into version control.**
> 
> For your library you may commit the `composer.lock` file if you want to. This can help your team to always test against the same dependency versions. However, this lock file will not have any effect on other projects that depend on it. It only has an effect on the main project.
