### PR TITLE
Ignore LaTeX generated files of extension .fls.

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -6,6 +6,7 @@
 *.blg
 *.dvi
 *.fdb_latexmk
+*.fls
 *.glg
 *.glo
 *.gls


### PR DESCRIPTION
From [latexmk_4.35-0ubuntu1_all manpage](http://manpages.ubuntu.com/manpages/raring/man1/latexmk.1L.html) about the -recorder option:

Use the -recorder option with latex and pdflatex. In (most) modern
versions of these programs, this results in a file of extension .fls
containing a list of the files that these programs have read and
written. Latexmk will then use this file to improve its detection of
source files and generated files after a run of latex or pdflatex.
