### PR TITLE
IntelliJ project files (same as under Android)

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -4,3 +4,10 @@
 *.jar
 *.war
 *.ear
+
+# Intellij project files
+*.iml
+*.ipr
+*.iws
+.idea/
+


### PR DESCRIPTION
Standard IntelliJ ignores for Java in general (same as the ones used in existing Android ignore file)
