### PR TITLE
Vim: Ignore .*.s[a-w][a-z] and .s[a-w][a-z] swap files

### DIFF
--- a/Global/vim.gitignore
+++ b/Global/vim.gitignore
@@ -1,4 +1,4 @@
-*.s[a-w][a-z]
+.*.s[a-w][a-z]
 .s[a-w][a-z]
 *.un~
 Session.vim


### PR DESCRIPTION
.*.s[a-w][a-z] matches named swap files.
.s[a-w][a-z] matches unnamed swap files.
