### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -6,3 +6,6 @@
 *.csproj
 *.unityproj
 *.sln
+*.pidb
+*.userprefs
+*.booproj


### PR DESCRIPTION
Added *.userprefs, *.pidb, and *.booproj files to .gitignore for Unity3D projects.
