### PR TITLE
Move Aptana's .project into its own gitignore.

### DIFF
--- a/Global/Aptana.gitignore
+++ b/Global/Aptana.gitignore
@@ -1,0 +1,1 @@
+.project

--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -15,5 +15,4 @@ capybara-*.html
 **.orig
 rerun.txt
 pickle-email-*.html
-.project
 config/initializers/secret_token.rb


### PR DESCRIPTION
.project was added to Rails' gitignore, but this is actually generated by
Aptana, a Rails IDE.
