### PR TITLE
Adding the .gitignore for PhpED project files

### DIFF
--- a/PhpED.gitignore
+++ b/PhpED.gitignore
@@ -1,0 +1,4 @@
+*.ppj
+*.ppx
+*.dsk
+*.ppw


### PR DESCRIPTION
Ignores the automatically generated project files when using Nusphere's
PHP IDE PhpED
