### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -11,5 +11,4 @@ pids
 logs
 results
 
-npm-debug.log
 node_modules


### PR DESCRIPTION
npm-debug.log is not needed since *.log matches it
