### PR TITLE
Ignoring [._]*.s[a-w][a-z] instead of *.s[a-w][a-z]

### DIFF
--- a/Global/vim.gitignore
+++ b/Global/vim.gitignore
@@ -1,5 +1,5 @@
-.*.s[a-w][a-z]
-.s[a-w][a-z]
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
 *.un~
 Session.vim
 .netrwhist


### PR DESCRIPTION
The old pattern was too broad and was making VIM ignore Scheme (*.scm) files. Now it only matches files that start with `.` or `_`, which according to http://vimdoc.sourceforge.net/htmldoc/recover.html should be enough.
