### PR TITLE
Added gitignore for AVR C projects

### DIFF
--- a/AVR-C.gitignore
+++ b/AVR-C.gitignore
@@ -1,0 +1,17 @@
+## AVR build gitignore
+
+# Dependencies directory
+.dep
+
+# Build-generated files
+*.hex
+*.eep
+*.cof
+*.elf
+*.map
+*.obj
+*.o
+*.a90
+*.sym
+*.lnk
+*.lss


### PR DESCRIPTION
Ignores the files generated when building an AVR C project with the 'standard' WinAVR Makefile template ([http://todbot.com/projects/smart-leds/softpwm_t13/Makefile](http://todbot.com/projects/smart-leds/softpwm_t13/Makefile)).

This can really be used with any generic C Makefile though, as it ignores most of the files that could be built in an AVR project:
- *.dep (make dependencies directory)
- *.hex (AVR hex files)
- *.obj, *.o (Object files)
- *.eep (eeprom data file)
- *.map (linker info)
- other AVR build files
