### PR TITLE
Add Visual Studio ignore for Microsoft Fakes generated files.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -133,6 +133,12 @@ UpgradeLog*.htm
 App_Data/*.mdf
 App_Data/*.ldf
 
+# Microsoft Fakes
+*.Fakes.dll
+*.Fakes.fakesconfig
+*.Fakes.messages
+*.Fakes.xml
+
 # =========================
 # Windows detritus
 # =========================


### PR DESCRIPTION
Ignores files that are generated from the Fakes/*.fakes file at build time.
