### PR TITLE
Update Android.gitignore for Gradle builds

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -28,3 +28,7 @@ proguard/
 *.iws
 .idea/
 
+# Gradle build files
+.gradle
+.settings
+build/


### PR DESCRIPTION
The new Android build system is based upon Gradle and introduces a new set
of folders and files that should not be committed to version control systems.

Here is an article from the Gradle docs that explains the Gradle wrapper and
which file should and shouldn't be present in VSC:

http://www.gradle.org/docs/current/userguide/gradle_wrapper.html
