### PR TITLE
add .xccheckout to Objective-C gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -15,6 +15,7 @@ profile
 DerivedData
 .idea/
 *.hmap
+*.xccheckout
 
 #CocoaPods
 Pods


### PR DESCRIPTION
This is a file that Xcode 5 uses for version control, doesn't need to be checked in. Also see http://stackoverflow.com/a/18448100/1877078
