### PR TITLE
Web Publishing Pipeline publish profiles should not be excluded.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -94,7 +94,6 @@ publish/
 
 # Publish Web Output
 *.Publish.xml
-*.pubxml
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line


### PR DESCRIPTION
*.pubxml files are WPP publish profiles which, after creation, are part of the given web project (Properties/PublishProfiles/). These are input to the web publishing process and should not be excluded by default.

This reverts #517.
