### PR TITLE
Change "Icon" to "Icon^M^M", add .VolumeIcon.icns .fseventsd

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -1,7 +1,8 @@
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon
+Icon^M^M
+.VolumeIcon.icns
 
 
 # Thumbnails
@@ -10,3 +11,4 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+.fseventsd


### PR DESCRIPTION
#### Icon^M^M

See http://blog.bitfluent.com/post/173740409/ignoring-icon-in-gitignore:
The actual file name is "Icon\r" with a CRLF(!). You have to enter two literal ^M control characters to match CRLF.
"Icon" would also ignore e.g. a "Icons" directory etc.
#### .VolumeIcon.icns

See http://superuser.com/a/298798:
Changing a volume's icon creates a hidden .VolumeIcon.icns file instead of Icon^M^M.
#### .fseventsd

fseventsd is the file services events daemon. (See http://en.wikipedia.org/wiki/FSEvents, https://developer.apple.com/library/mac/documentation/Darwin/Conceptual/FSEvents_ProgGuide/FileSystemEventSecurity/FileSystemEventSecurity.html)
