### PR TITLE
Add Ghost .gitignore file.

### DIFF
--- a/Ghost.gitignore
+++ b/Ghost.gitignore
@@ -1,2 +1,3 @@
+*/content/data/*
 */node_modules/*
 */config.js


### PR DESCRIPTION
Ghost is fairly new, but it's pretty clear that downloadable modules, the database, and configuration settings shouldn't be included in a repository.
