### PR TITLE
Added the processing project

### DIFF
--- a/Processing.gitignore
+++ b/Processing.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+applet
+application.linux32
+application.linux64
+application.windows32
+application.windows64
+application.macosx


### PR DESCRIPTION
The normal files when you export a project are the application.\* folders.

There isn't very good documentation that I can find on their site, but it is what I used for my project.

http://wiki.processing.org/w/Main_Page
