### PR TITLE
Update Java to exclude J2ME Mobile Tools for Java

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -1,7 +1,7 @@
 *.class
 
 # Mobile Tools for Java (J2ME)
-.mtj-tmp
+.mtj.tmp/
 
 # Package Files #
 *.jar


### PR DESCRIPTION
Exclude J2ME specific build directory (.mtj-tmp)

Link to "Mobile Tools for Java" documentation showing .mtj-tmp directory objects:
http://help.eclipse.org/helios/topic/org.eclipse.mtj.doc.user/html/reference/advanced_topics/buildingRef.html?resultof=%22mtj-tmp%22%20

This directory is created by both Eclipse IDE and also command line ant/antenna builds for J2ME using the Wireless Toolkit (WTK) for J2ME.

Oddly enough, some of us still do commercial development for J2ME.  :)
