### PR TITLE
Add .gitignore for Arch Linux Packages

### DIFF
--- a/ArchLinuxPackages.gitignore
+++ b/ArchLinuxPackages.gitignore
@@ -1,0 +1,7 @@
+*.tar
+*.tar.*
+*.log
+*.log.*
+*.sig
+pkg/
+src/


### PR DESCRIPTION
Mandatory files for a Arch Linux package are
- PKGBUILD
- install scripts, if any
- user defined configs/patches, if any

This .gitignore ignores files that are
generated/downloaded by makepkg automatically.

Refs:
- https://wiki.archlinux.org/index.php/Creating_Packages
- https://wiki.archlinux.org/index.php/Makepkg

Signed-off-by: Lance Chen cyen0312@gmail.com
