### PR TITLE
Create Pebble.gitignore

### DIFF
--- a/Pebble.gitignore
+++ b/Pebble.gitignore
@@ -1,0 +1,15 @@
+# Ignore waf build tool generated files
+.waf*
+build
+.lock-waf*
+
+# Ignore linked files/directories
+waf
+wscript
+tools
+include
+lib
+pebble_app.ld
+
+# Ignore other generated files
+serial_dump.txt


### PR DESCRIPTION
This is gitignore file for Pebble SDK which is officially supported SDK for making Pebble smartwatch apps. This file is quite similar to one shipped with SDK with only difference of not ignoring gitignore file.

Official Pebble smartwatch website; https://getpebble.com/
Official Pebble smartwatch developer website; https://developer.getpebble.com/
