### PR TITLE
Added Vagrant.ignore. Omits all files associated with Vagrant init

### DIFF
--- a/Vagrant.gitignore
+++ b/Vagrant.gitignore
@@ -1,0 +1,6 @@
+#Vagrant files
+Vagrantfile
+.vagrant/
+
+#Common vagrant script
+bootstrap.sh


### PR DESCRIPTION
Vagrant files often are very useful for testing, but shouldn't necessarily be included in the git repo. 

This pull request ignores the Vagrant config file, the vagrant cache information, and the commonly used bootstrap.sh

Information about how to use vagrant is located here:
http://docs.vagrantup.com/v2/
