### PR TITLE
LaTeX.gitignore: Ignore PDF files generated by pdflatex

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -22,6 +22,7 @@
 *.nav
 *.nlo
 *.out
+*.pdf
 *.pdfsync
 *.ps
 *.snm


### PR DESCRIPTION
Currently, PDF files are not ignored. Since PDF files can be easily generated using pdflatex, it is best to keep them out of the repository.
