### PR TITLE
Add .gitignore for Vim text editor

### DIFF
--- a/Vim.gitignore
+++ b/Vim.gitignore
@@ -1,0 +1,2 @@
+# ignore temporary vim files
+*.swp


### PR DESCRIPTION
There is a single rule included, to ignore temporary vim files
ending in '.swp'. These files are present in the repository
while any file is edited, and can easily be added by mistake.
