### PR TITLE
Change Android.gitignore to comply with JetBrains standards

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -23,8 +23,6 @@ local.properties
 proguard/
 
 # Intellij project files
-*.iml
-*.ipr
 *.iws
-.idea/
-
+.idea/workspace.xml
+.idea/tasks.xml


### PR DESCRIPTION
Serge Baranov, a JetBrains employee, [has stated here](http://devnet.jetbrains.com/docs/DOC-1186) that all .ipr and all .iml should be checked in in version control. Also the .idea folder has to be checked in, except for the workspace.xml and tasks.xml files.
