### PR TITLE
Add file for Atari 2600 / Atari 7800 assemblers

### DIFF
--- a/stella.gitignore
+++ b/stella.gitignore
@@ -1,0 +1,12 @@
+# Atari 2600 (Stella) support for multiple assemblers
+# - DASM
+# - CC65
+
+# Assembled binaries and object directories
+obj/
+a.out
+*.bin
+*.a26
+
+# Add in special Atari 7800-based binaries for good measure
+*.a78


### PR DESCRIPTION
Hello!

Though not a frequent use-case, I compile my Atari 2600 / 7800 programs with a couple of assemblers, and keep my files in git.  I have tried to provide a useful gitignore file, so that any old-school Atari programmers could benefit.

1) If using the ca65 assembler from the cc65 package, you'll use a makefile that creates object files in directory "obj"
The makefile that mose folks use is here: http://wiki.cc65.org/doku.php?id=cc65:atari_2600
You can see that:
OBJDIR := obj
hence, the inclusion of:
obj/

2) In "dasm", the default output of an unspecified assembly file is:
a.out
You can find the documentation here:
ftp://ftp.back2roots.org/pub/back2roots/cds/xetec/fish_n_more_vol1/fish/languages/dasm/doc/dasm.doc
    asm srcfile [options]

```
options:    -f#     select output format 1-3 (default 1, see below)
        -oname  select output file name (else a.out)
```

3) Atari 2600 games are usally "bin" or "a26" files.  That's what most people use instead of a.out.
Here's a page that outlines it:
https://atariage.com/2600/emulation/z26_tutorial/#PartOne
"Atari 2600 Game ROMs: Atari 2600 game ROMs typically have the extension .BIN or .A26."
These are generally emulator inputs, so most folks set "bin" as the output, hence the addition of:
*.bin

4) *.a26
- This is one version of an Atari 2600 compiled binary
  See http://www.file-extensions.org/a26-file-extension for reference.
  You can also read this from https://atariage.com/2600/emulation/z26_tutorial/#PartOne

5) *.a78
- this is the Atari 7800 compiled binary with headers added in:
  See http://www.file-extensions.org/a78-file-extension for reference
  These can be compiled as well with ca65 (from cc65's bundle) and dasm.

Thanks!
