### PR TITLE
Ignore elf and hex files in C.gitignore

### DIFF
--- a/C.gitignore
+++ b/C.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.ko
 *.obj
+*.elf
 
 # Libraries
 *.lib
@@ -17,3 +18,4 @@
 *.exe
 *.out
 *.app
+*.hex


### PR DESCRIPTION
Ignore .hex and .elf files that are generated when doing embedded development in C.

One example tool chain that creates these is Microchip's XC16 compiler documented a http://ww1.microchip.com/downloads/en/DeviceDoc/50002071C.pdf on page 49.
