### PR TITLE
Add JetBrains Idea based IDEs gitignore file

### DIFF
--- a/Idea.gitignore
+++ b/Idea.gitignore
@@ -1,0 +1,8 @@
+#
+# IDEA based IDE (IDEA, WebStorm, PhpStorm, RubyMine)
+# https://intellij-support.jetbrains.com/entries/23393067-How-to-manage-projects-under-Version-Control-Systems
+#
+
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries


### PR DESCRIPTION
Add gitignore file for JetBrains Idea based IDEs like: WebStorm, PhpStorm, Idea, RubyMine.

Reference documentation:
https://intellij-support.jetbrains.com/entries/23393067-How-to-manage-projects-under-Version-Control-Systems
