### PR TITLE
Fix OSX-specific Icon\r rule

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -1,8 +1,9 @@
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon
 
+# Icon must ends with two \r.
+Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
Rule for the file `Icon\r` of MacOSX is broken since https://github.com/github/gitignore/commit/174c45e796b57d79ac1b8a400559d6b7a272a4a5 .
It must ends with two `\r` (Carriage return).

Current rule matches all `icon` folder/file, not `Icon\r` file.
