### PR TITLE
.classpath and .project files are *meant to be versioned*

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -1,5 +1,4 @@
 *.pydevproject
-.project
 .metadata
 bin/**
 tmp/**
@@ -9,7 +8,6 @@ tmp/**/*
 *.swp
 *~.nib
 local.properties
-.classpath
 .settings/
 .loadpath
 


### PR DESCRIPTION
As is clearly stated in the [eclipse documentation](http://wiki.eclipse.org/FAQ_How_do_I_set_up_a_Java_project_to_share_in_a_repository%3F).  
This gitignore has lead to much confusion in SO - please ammend

I would guess the same is true for .pydevproject and .cproject but can't
be sure/do not have any references on those

Also .launch configurations are generally meant to be versioned when
saved under project location. See for instance :
http://stackoverflow.com/a/337317/281545
