### PR TITLE
Ignores the preview files generated by AUCTeX

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -30,3 +30,4 @@
 *.vrb
 *.xdy
 *.tdo
+_region_*


### PR DESCRIPTION
Added an ignore for for _region_ files that get generated by emacs in AUCTeX mode.
