### PR TITLE
Add WCF tracing file, replace duplicate .log entry

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -43,7 +43,7 @@ build/
 *.vssscc
 .builds
 *.pidb
-*.log
+*.svclog
 *.scc
 
 # Visual C++ cache files


### PR DESCRIPTION
WCF tracing files (.svclog) are used by the Service Trace Viewer Tool.
