### PR TITLE
Removed *.jar from Java .gitignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -1,6 +1,5 @@
 *.class
 
 # Package Files #
-*.jar
 *.war
 *.ear


### PR DESCRIPTION
When one creates a repository in GitHub and indicates that the project will be in Java, the default .gitignore file is set to exclude *.jar files. As Java third-party libraries are most always distributed as jar files, this default setting refuses to let one add third-party libraries to the repository. This is, let's say, less than ideal. This setting shouldn't be there by default.
