### PR TITLE
Added Windows specific .obj for objects to ignore.

### DIFF
--- a/C.gitignore
+++ b/C.gitignore
@@ -1,6 +1,7 @@
 # Object files
 *.o
 *.ko
+*.obj
 
 # Libraries
 *.lib


### PR DESCRIPTION
Windows based compilers make .obj files for objects, like .o in linux.
