### PR TITLE
Add Visual Studio ignore rule for files generated by Microsoft Fakes.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -139,6 +139,9 @@ App_Data/*.ldf
 *.bim.layout
 *.bim_*.settings
 
+# Microsoft Fakes
+FakesAssemblies/
+
 # =========================
 # Windows detritus
 # =========================


### PR DESCRIPTION
Ignores generated Fakes assemblies and related files placed under the FakesAssemblies directory.
These files are generated at build time from the *.fakes configuration files.
