### PR TITLE
Cleaning up Objective-C .gitignore and adding OS X section

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,5 +1,7 @@
-# Xcode
+# OS X
 .DS_Store
+
+# Xcode
 */build/*
 *.pbxuser
 !default.pbxuser
@@ -17,5 +19,5 @@ DerivedData
 *.hmap
 *.xccheckout
 
-#CocoaPods
+# CocoaPods
 Pods


### PR DESCRIPTION
Moves .DS_Store into it's own section for OS X specific rules.
