### PR TITLE
Add comment to prevent *.sublime-project being ignored.

### DIFF
--- a/Global/SublimeText.gitignore
+++ b/Global/SublimeText.gitignore
@@ -1,4 +1,6 @@
-# SublimeText project files
+# workspace files are user-specific
 *.sublime-workspace
 
-# *.sublime-project should be checked into the repository as a general rule
+# project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using SublimeText
+# *.sublime-project


### PR DESCRIPTION
Based on advice in [the documentation](http://www.sublimetext.com/docs/2/projects.html) and added due to the number of PRs re-introducing this line.
