### PR TITLE
remove `npm-debug.log` entry

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -11,5 +11,4 @@ pids
 logs
 results
 
-npm-debug.log
 node_modules


### PR DESCRIPTION
There's no need of `npm-debug.log` entry because `*.log` above ignores it already.
