### PR TITLE
Leiningen by default creates a 'target' directory, not 'targets'

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -2,7 +2,7 @@ pom.xml
 *jar
 /lib/
 /classes/
-/targets/
+/target/
 .lein-deps-sum
 .lein-repl-history
 .lein-plugins/


### PR DESCRIPTION
https://github.com/technomancy/leiningen/blob/master/leiningen-core/src/leiningen/core/project.clj#L179
