### PR TITLE
Slashify Ruby files and directories.

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -1,5 +1,5 @@
-/*.gem
-/*.rbc
+*.gem
+*.rbc
 /.config
 /coverage/
 /InstalledFiles
@@ -26,4 +26,4 @@
 # .ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
-/.rvmrc
+.rvmrc


### PR DESCRIPTION
This is an update of https://github.com/github/gitignore/pull/616. Since that pull request, many slashes have been added to the Ruby `.gitignore` file, which is most pleasing. There are still some which can be added, however, so I've rebased this branch onto an up-to-date master and am submitting a new pull request.

Peace, tiredpixel

---

Perhaps this is a little pedantic, but without the initial / all such matches within the repository get ignored, and without the trailing slash files as well as directories of that name get ignored. e.g. Specifying `tmp` and `test/tmp` without slashes is redundant, as `tmp` already ignores `test/tmp`, as well as every other `tmp` and `tmp/`.
