### PR TITLE
Added the new upload directories and ignore the cache directory completely

### DIFF
--- a/SugarCRM.gitignore
+++ b/SugarCRM.gitignore
@@ -1,7 +1,11 @@
 ## SugarCRM
 # Ignore custom .htaccess stuff.
 /.htaccess
-# Ignore the cache directory completely. ATTENTION! This will break things!
+# Ignore the cache directory completely.
+# This will break the current behaviour. Which was often leading to
+# the misuse of the repository as backup replacement.
+# For development the cache directory can be safely ignored and
+# therefore it is ignored.
 /cache/
 # Ignore some files and directories from the custom directory.
 /custom/history/


### PR DESCRIPTION
With SugarCRM 6.4 the `cache/upload` directory moved to `upload` and
`upload_backup`. These directories can safely be ignored.

Additionally the `cache` directory is now ignored completely because it
leads to the behaviour to use the git repository as a kind of backup
tool if several parts of it are included. Furthermore the directory
structure beneath `cache` is victim of enduring changes by the
developers.

I did also some code cleanup regarding the path names e.g. adding a `/`
before most file and directory names.
