### PR TITLE
Add .cache to the Python .gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -27,6 +27,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 .tox/
 .coverage
+.cache
 nosetests.xml
 coverage.xml
 


### PR DESCRIPTION
`.cache` is generated when unittests are run with `py.test` with the `pytest-cache` plugin installed.
