### PR TITLE
Support for Phalcon, a PHP Framework

### DIFF
--- a/Phalcon.gitignore
+++ b/Phalcon.gitignore
@@ -1,2 +1,2 @@
-*/cache/*
-*/config/development/*
+/cache/*
+/config/development/*


### PR DESCRIPTION
Gitignore file for Phalcon Framework, a fast-growing framework developed in C for PHP. Excluding here:
- Cache files;
- Development config files.

More information available in phalconphp.com
