### PR TITLE
Added common Rails credential files to Rails.gitignore.

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -16,3 +16,8 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 .project
+/config/database.yml
+/config/mailer.yml
+/config/paypal.yml
+/config/active_merchant.yml
+/config/initializers/secret_token.rb


### PR DESCRIPTION
Add common Rails credentials files to `Rails.gitignore`. This is assuming someone is generating a Rails project that is hosted publicly, where the user adds their own unique credentials.
