### PR TITLE
Dotfiles credentials

### DIFF
--- a/Dotfiles.gitignore
+++ b/Dotfiles.gitignore
@@ -45,6 +45,7 @@
 # History files
 /.ash_history
 /.bash_history
+/.fluxbox/fbrun_history
 /.gnuplot_history
 /.history
 /.irb_history


### PR DESCRIPTION
Add a `Dotfiles.gitignore` for people wanting to host their dotfiles, but not their sensitive credentials.
