### PR TITLE
add 'build' to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -10,5 +10,6 @@ lib-cov
 pids
 logs
 results
+build
 
 node_modules


### PR DESCRIPTION
This is to exclude compiled code from nodejs addons.
Reference: http://nodejs.org/api/addons.html
