### PR TITLE
Ignore rope files.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -39,6 +39,9 @@ coverage.xml
 .project
 .pydevproject
 
+# Rope
+.ropeproject
+
 # Django stuff:
 *.log
 *.pot


### PR DESCRIPTION
Rope (https://bitbucket.org/zjes/rope_py3k/overview) is a refactoring tool for Python. It creates temporary files in `.ropeproject` to cache data. These files should be ignored by default.
