### PR TITLE
Ignore files created by maven-release-plugin

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -1,2 +1,5 @@
 target/
- *.releaseBackup
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.next
+release.properties


### PR DESCRIPTION
Maven Release Plugin provides a standard mechanism to release project 
artifacts.

During the various phases of the execution the plugin create various 
files, especially if you do a dry run that allows you to see the changes
that the plugin will perform on your pom files

```
mvn release:prepare -D dryRun=true
```

It will create
- `release.properties` - copy of the properties to be used
- `pom.xml.releaseBackup` - the pom.xml prior to any changes
- `pom.xml.tag` - the pom.xml as it will look when tagged
- `pom.xml.next` - the pom.xml as it will look for the next iteration
