### PR TITLE
Added PyCharm project folder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -46,3 +46,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# PyCharm folder
+.idea


### PR DESCRIPTION
Application: http://www.jetbrains.com/pycharm/
Documentation about project folder and files: http://www.jetbrains.com/pycharm/webhelp/project.html

Since PyCharm Community Edition got released, more and more people are using it. Since there is already section for pydev, it makes sense to add one for another popular IDE.
