### PR TITLE
Ignore worksheet directory

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -14,3 +14,4 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.worksheet


### PR DESCRIPTION
Since Scala IDE V3.0 has worksheets which are like a REPL session on steroids. For the worksheet to function `*.scala` files get created in a hidden `.worksheet` directory. As these are auto-generated the directory should be ignored.
