### PR TITLE
plugin.xml shouldn't be in source control.  This is a Grails plugin artifact

### DIFF
--- a/Grails.gitignore
+++ b/Grails.gitignore
@@ -28,8 +28,9 @@
 # project release file
 /*.war
 
-# plugin release file
+# plugin release files
 /*.zip
+/plugin.xml
 
 # older plugin install locations
 /plugins


### PR DESCRIPTION
The command "grails package-plugin" will re-generate plugin.xml.  There are some cases where having this file in source control can cause problems.

Let me know what else you need to merge this pull request.
