### PR TITLE
Remove duplicate line in Objective-C.gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -17,7 +17,6 @@ profile
 *.moved-aside
 DerivedData
 *.hmap
-*.xccheckout
 
 # CocoaPods
 Pods


### PR DESCRIPTION
The pattern `*.xccheckout` is already ignored on [line 15](https://github.com/github/gitignore/blob/1ef80036f0f77ea92daa5e941d4bcf8722eb414b/Objective-C.gitignore#L15).
