### PR TITLE
Ignore intelliJ user-specific files when authoring go programs in intell...

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -21,3 +21,6 @@ _testmain.go
 
 *.exe
 *.test
+
+*/.idea/workspace.xml
+*/.idea/tasks.xml


### PR DESCRIPTION
A growing number of programmers are using IntelliJ IDEA to author Go programs.

unfortunately, the entire .idea folder cannot be excluded. This StackOverflow question addresses the files that need to be ignored: http://stackoverflow.com/questions/11968531/what-to-gitignore-from-the-idea-folder
