### PR TITLE
Ignore npm-debug.log for Node apps

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -13,3 +13,4 @@ results
 build
 
 node_modules
+npm-debug.log


### PR DESCRIPTION
`npm-debug.log`, I find, is generally created when an npm-related error has occurred. They're different for each person. These logs don't belong in version control, I feel.
