### PR TITLE
added node_modules

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -142,6 +142,7 @@ ClientBin/
 *.[Pp]ublish.xml
 *.pfx
 *.publishsettings
+node_modules/
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
As there are now Node.js tools for Visual Studio, we should ignore the node_modules directory.
https://nodejstools.codeplex.com/
