### PR TITLE
missing security_token.rb inhibits development

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -10,6 +10,8 @@ capybara-*.html
 **.orig
 rerun.txt
 pickle-email-*.html
+
+# TODO Comment out this rules if you are OK with secrets been uploaded to the repo
 config/initializers/secret_token.rb
 config/secrets.yml
 


### PR DESCRIPTION
It is a security issue BUT it shouldn't be on gitignore. Adding it to the gitignore inhibits development (the app won't boot without it)
