### PR TITLE
Shapefiles

### DIFF
--- a/Shapefile.gitignore
+++ b/Shapefile.gitignore
@@ -1,7 +1,8 @@
 # ESRI shapefiles .gitignore
-# Sources:
+# *Sources*
 # http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf
 # http://resources.arcgis.com/en/help/main/10.2/index.html#/Shapefile_file_extensions/005600000003000000/
+# http://en.wikipedia.org/wiki/Shapefile
 
 # shapefile
 *.shp


### PR DESCRIPTION
GitHub community:

I am proposing an addition to the gitignore for ESRI shapefiles. Shapefiles are a vector based geospatial file format commonly used in geographic information systems software. It is a common way to share spatial data, such as [for download from government data portals](https://data.cityofchicago.org/browse?tags=shapefiles).

However, shapefiles are [only semi-open](http://gis.stackexchange.com/questions/20613/are-there-any-attempts-to-replace-the-shapefile). Some of the parts are proprietary to ESRI. There are a number of fully open source formats that are much more appropriate for sharing spatial data on GitHub (like [geoJSON](http://geojson.org/) and [topoJSON](https://github.com/mbostock/topojson)), that promote data transparency. GitHub has recently added [visualizations for geoJSON ](https://github.com/blog/1528-there-s-a-map-for-that) and [topoJSON files](https://github.com/blog/1541-geojson-rendering-improvements).

Ignoring shapefiles in repos allows anyone that wishes to share spatial data on GitHub to ignore these closed files. Users that wish to convert shapefiles to open formats may want to have those shapefiles in the local repo directory, but not shared publicly, because they are not beneficial to GitHub. Adding a default .gitignore for shapefiles may also encourage new GIS users to realize the benefit of using an open standard instead.

**Provide a link to the application or project’s homepage**
[ESRI](http://www.esri.com/) is located in Redlands, CA, USA. They [published a whitepaper on the format in 1998](http://www.esri.com/library/whitepapers/pdfs/shapefile.pdf) . There is [more specific documentation on ESRI's help site](http://resources.arcgis.com/en/help/main/10.2/index.html#/Shapefile_file_extensions/005600000003000000/), and [on Wikipedia](http://en.wikipedia.org/wiki/Shapefile).

**Provide links to documentation**
Sharing geospatial data on GitHub is a new. There is some discussion of this in the [private github-for-government repo](https://github.com/government/open-data/issues/4). There are [posts](http://blog.thematicmapping.org/2013/06/converting-shapefiles-to-topojson.html) on the web about the benefits of using geoJSON as opposed to shapefiles.

**Explain why you’re making a change**
I like the share open spatial data from around the web on GitHub. I also share data on behalf of my organization. Sharing data can require having many shapefiles in a directory for conversion. Rather than deleting them before committing, it would be to everyone's benefit if they were simply ignored.

**Please consider the scope of your change**
The scope of this change is fairly narrow. People don't have to use it, and if they do, they would want the files to be ignored. It only affects one type of file, not all GIS software.

**Please only modify _one template_ per pull request**
Done. There are 4 commits because I realized the filename should be TitleCase.
