### PR TITLE
Add *.xcodeproj/project.xcworkspace/contents.xcworkspacedata

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -18,6 +18,7 @@ profile
 DerivedData
 *.hmap
 *.ipa
+*.xcodeproj/project.xcworkspace/contents.xcworkspacedata
 
 # CocoaPods
 Pods


### PR DESCRIPTION
Xcode 5 creates these files even for basic projects that are not part of another workspace, and they are starting to litter pending changes area.
