### PR TITLE
Rails: Ignore config/secrets.yml

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -13,7 +13,7 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 config/initializers/secret_token.rb
-config/secret.yml
+config/secrets.yml
 
 ## Environment normalisation:
 /.bundle


### PR DESCRIPTION
Adds `config/secrets.yml` to the Rails .gitignore template because friends don't let friends commit secrets.
