### PR TITLE
add Meta Programming System gitignore files

### DIFF
--- a/MetaProgrammingSystem.gitignore
+++ b/MetaProgrammingSystem.gitignore
@@ -1,0 +1,20 @@
+# General
+
+workspace.xml
+junitvmwatcher*.properties
+build.properties
+
+# generated java classes and java source files
+# custom artifacts that can't be generated from the models you
+# should add them manually
+# see http://confluence.jetbrains.com/display/MPSD25/HowTo+--+MPS+and+Git
+# for further reference
+classes_gen
+source_gen
+source_gen.caches
+
+# generated test code and test results
+test_gen
+test_gen.caches
+TEST-*.xml
+junit*.properties


### PR DESCRIPTION
The Meta Programming System is a language workbench created by JetBrains.

http://jetbrains.com/mps/

By default this file will ignore the generated java source and the compiled java classes that are
produced by the language compiler. It will only add the Models which contain all information
necessary to reproduce the the java source code and the the resulting class files.

In addition to the generated source code it will ignore the test result files and test property files,
because those are also generated from the models.

The ignore file also prevents commiting the workspace.xml which contains the currently editor state,
like open files and cursor position.
