### PR TITLE
Added SCons.gitignore

### DIFF
--- a/SCons.gitignore
+++ b/SCons.gitignore
@@ -1,0 +1,2 @@
+# for projects that use SCons for building: http://http://www.scons.org/
+.sconsign.dblite


### PR DESCRIPTION
SCons is a software construction tool.

http://www.scons.org/

The .sconsign.dblite file is a temporary database used by SCons to keep file signatures to speed up future builds.

http://stackoverflow.com/questions/12867783/what-is-the-file-sconsign-dblite-for
