### PR TITLE
Add "dist" and ".cache" folders for Play 2.2.x

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -15,3 +15,5 @@ test-result
 server.pid
 *.iml
 *.eml
+dist
+.cache


### PR DESCRIPTION
There are 2 additional folders that listed in Play documentation, but not listed in current github/gitignore, they are: 
- `dist`
- `.cache`

Original link to the documentation: http://www.playframework.com/documentation/2.2.x/Anatomy
