### PR TITLE
Add output directory of sbteclipse plugin, which is ".target" directory.

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -23,5 +23,8 @@ local.properties
 # PDT-specific
 .buildpath
 
+# sbteclipse plugin 
+.target
+
 # TeXlipse plugin
 .texlipse


### PR DESCRIPTION
`sbteclipse` plugin creates `.target` directory as its output folder. This folder should not be included in the source control as it is analogous to Maven's `target` or sbt's `target` directory.

References:
- Short explanation about `sbteclipse`'s `.target` folder: https://github.com/typesafehub/sbteclipse/issues/63
- Stackoverflow discussion about `.target` folder: http://stackoverflow.com/questions/16574128/where-did-the-target-directory-come-from-in-my-play-2-1-1-project
