### PR TITLE
Ignore grunt and lcov build files in Node projects

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -1,4 +1,5 @@
 lib-cov
+lcov.info
 *.seed
 *.log
 *.csv
@@ -11,5 +12,6 @@ pids
 logs
 results
 build
+.grunt
 
 node_modules


### PR DESCRIPTION
Grunt creates a .grunt folder during builds holding build metadata, which is always deleted afterwards for successful builds (I think), but does hang about if the build aborts.

lcov.info is the default output file name for LCOV, which is used to provide human readable coverage results in most JS coverage tools (e.g. Istanbul)
