### PR TITLE
Ignore sensitive data

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -10,3 +10,4 @@ sitemap.xml
 wp-content/cache/
 wp-content/backups/
 sitemap.xml.gz
+wp-config.php


### PR DESCRIPTION
There's a file missing in the `Wordpress.gitignore`: you also need to ignore `wp-config.php` since it contains some  sensitive data  (such as your database password in plain text). Ignoring this also allows each developers to create their own configuration.
