### PR TITLE
Java: Ignore most IDE files, build folders

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -17,9 +17,10 @@
 /dist
 
 # Eclipse
-/.classpath
-/.project
 /.settings
+# ! Uncomment these lines if you are not using Eclipse exclusively in the project
+#/.classpath
+#/.project
 
 # Netbeans
 /nbproject


### PR DESCRIPTION
The default Java `.gitignore` should include the files generated by each of the popular IDEs, as it's very possible for different developers for an open-source project to prefer different tools.

The additions were mostly taken from the CraftBukkit project: [<code>.gitignore @ ff7c371a81</code>](https://github.com/Bukkit/CraftBukkit/blob/ff7c371a81437ec9f88b1134bcc322308b796a4e/.gitignore). I just reordered them and took out the entries specific to that project.
- IDE files for Eclipse, Netbeans, and IntelliJ
- .DS_Store files
- Maven /target folder
- Other general build folders: /build, /bin, /dist
