### PR TITLE
Update Cloud9.gitignore

### DIFF
--- a/Global/Cloud9.gitignore
+++ b/Global/Cloud9.gitignore
@@ -1,2 +1,3 @@
 # Cloud9 IDE - http://c9.io
 .c9revisions
+.c9


### PR DESCRIPTION
The next version of Cloud9 will use a top-level .c9 folder in the workspace for settings and metadata.
