### PR TITLE
Added Laravel 

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -1,3 +1,3 @@
 /bootstrap/compiled.php
 /vendor
-composer.pha
+composer.phar


### PR DESCRIPTION
Main project repo : https://github.com/laravel/laravel
I added this because default .gitignore (https://github.com/laravel/laravel/blob/master/.gitignore)  is not helpful for development purpose . 
