### PR TITLE
Add npm-debug.log to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -15,3 +15,4 @@ build
 .grunt
 
 node_modules
+npm-debug.log


### PR DESCRIPTION
When a npm command fails a `npm-debug.log` file is being created with the trace of what lead to this failure.

You probably don't want to check this file into git.
