### PR TITLE
Delphi - added .dsk and .bpi and comments

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -1,14 +1,23 @@
-*.dcu
+# IDE - History and Backup Files
 *.~*
+__history
+
+# IDE - Machine Specific Settings
 *.local
 *.identcache
-__history
+*.dsk
+
+# Output Directory
+bin/*
+
+# Compiler / Linker output
+*.dcu
 *.drc
 *.map
 *.exe
 *.dll
+*.bpi
 *.bpl
 *.dcp
 *.so
 *.apk
-bin/*


### PR DESCRIPTION
Change the grouping of the file with # comments to clearly identify areas like other languages have done.

Added
.dsk  - IDE/Project Settings - Specific to each developer.    Has no bearing on the resulting compiler output.
.bpi  - Produced during compile when targeting OS X.

Current file extensions for Delphi are documented here:
http://docwiki.embarcadero.com/RADStudio/XE5/en/File_Extensions_of_Files_Generated_by_RAD_Studio

Another source, that covers older versions of Delphi.
http://delphi.wikia.com/wiki/Delphi_File_Extensions
