### PR TITLE
Fix patterns - too general

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -16,6 +16,7 @@
 *.launch
 
 # Ignore Play! working directory #
+bin/
 /db
 .eclipse
 /lib/


### PR DESCRIPTION
The original ignore was far too general and results in eliminating packages named "db" or "project", for example. These are not that uncommon for package names. Also added a lot of other common, Playframework project related ignore patterns (Scala/Java/sbt/Eclipse).
