### PR TITLE
Updated rules of 'VisualStudio.gitignore' about ATL Project.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -27,6 +27,11 @@ bld/
 *.VisualState.xml
 TestResult.xml
 
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
 *_i.c
 *_p.c
 *_i.h


### PR DESCRIPTION
　I added three new rules to **VisualStudio.gitignore** for Visual Studio **ATL Project**.
- [Dd]ebugPS/
- [Rr]eleasePS/
- dlldata.c

　**DebugPS** and **ReleasePS** rules are needed when you create an ATL Project and debug it with the web browser. **dlldata.c** rule is needed when you just work on ATL Project. Those two directories and the C file are automatically generated/updated everytime you build the project. You might don't want to add those to your commit.
　I know ActiveX is old creepy technology, but someone still gets benefit from it. :)
