### PR TITLE
Update Grails.gitignore to include default files

### DIFF
--- a/Grails.gitignore
+++ b/Grails.gitignore
@@ -1,7 +1,7 @@
 # .gitignore for Grails 1.2 and 1.3
 
 # web application files
-/web-app/WEB-INF
+/web-app/WEB-INF/classes
 
 # IDE support files
 /.classpath


### PR DESCRIPTION
[Grails](http://grails.org) generates a few default files under `/web-app/WEB-INF/` (`applicationContext.xml`, `sitemesh.xml`, a bunch of `*.tld`) that need to be present for some default targets to work.
I ran into this issue while trying to run the `grails war` target against a Grails 2.3.1 application that had this `.gitignore`, so I change it here to only ignore files under `/web-app/WEB-INF/classes` (build output) . See [here](https://stackoverflow.com/questions/14910388/grails-push-to-heroku-failed-applicationcontext-xml-doesnt-exist) for reference.
