### PR TITLE
gitignore to ignore sftp Sublime Text config file

### DIFF
--- a/Global/SublimeText.gitignore
+++ b/Global/SublimeText.gitignore
@@ -4,3 +4,6 @@
 # project files should be checked into the repository, unless a significant
 # proportion of contributors will probably not be using SublimeText
 # *.sublime-project
+
+#sftp configuration file
+sftp-config.json

--- a/SublimeTextSFTP.gitignore
+++ b/SublimeTextSFTP.gitignore
@@ -1,1 +1,0 @@
-sftp-config.json


### PR DESCRIPTION
SFTP Sublime Text plugin make the config file in the directory to work, this file contains password, username, dir, and others data.
Here: http://wbond.net/sublime_packages/sftp about sftp plugin.
