### PR TITLE
Added .gitignore for the DM language.

### DIFF
--- a/DM.gitignore
+++ b/DM.gitignore
@@ -1,0 +1,5 @@
+*.dmb
+*.rsc
+*.int
+*.lk
+*.zip


### PR DESCRIPTION
The DM language is used by the [BYOND](http://www.byond.com/) platform and was recently added to the Linguist repository, so I figured I'd better whip up a `.gitignore` specifically for BYOND projects. The files I've added to `DM.gitignore` are either compiled binary files (`.dmb`, `.rsc`) or files used by BYOND's IDE (either for internal purposes [`.lk`], or user-specific configration files [`.int`]). Lastly, `.zip` files can be generated using the IDE for distributing binaries and other files necessary to run a project, so they have been excluded as well.
