### PR TITLE
Updated rules of 'VisualStudio.gitignore' about Web workbench add-on.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -94,6 +94,9 @@ _NCrunch_*
 *.mm.*
 AutoTest.Net/
 
+# Web workbench (sass)
+.sass-cache/
+
 # Installshield output folder
 [Ee]xpress/
 


### PR DESCRIPTION
I added one new rule to **VisualStudio.gitignore** for **Web Workbench** add-on :
- .sass-cache/

It allow to ignore files cached by sass preprocessor.
