### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,5 +1,6 @@
 // Don’t commit the following files and directories created by pub and dart2js
 packages/
+packages
 *.js_
 *.js.deps
 *.js.map


### PR DESCRIPTION
Changed `.gitignore` to not track the symbolic links that dart creates to the `./packages` directory. These links are not needed because when `pub install` is run the symbolic links are re-generated.
