### PR TITLE
Updated desktop.ini for lowercase UNIX Systems

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -4,6 +4,7 @@ ehthumbs.db
 
 # Folder config file
 Desktop.ini
+desktop.ini
 
 # Recycle Bin used on file shares
 $RECYCLE.BIN/


### PR DESCRIPTION
Sometimes the Desktop.ini not work properly in UNIX systems. We have to add a lowercase desktop.ini ref.

Source: https://github.com/joeblau/gitignore.io/pull/35
