### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -5,7 +5,7 @@ packages/
 *.js.map
 
 // Include when developing application packages
-pubspec.lock 
+pubspec.lock
 
 // Avoid committing generated JavaScript files
 *.dart.js


### PR DESCRIPTION
Removed space from end of line which prevented the `pubspec.lock` from being ignored.
