### PR TITLE
Added Python Tools for Visual Studio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -169,6 +169,9 @@ App_Data/*.ldf
 # Microsoft Fakes
 FakesAssemblies/
 
+# Python Tools for Visual Studio
+*.pyproj
+
 # =========================
 # Windows detritus
 # =========================


### PR DESCRIPTION
Python Tools for Visual Studio (PTVS) is a free, open source plugin that turns Visual Studio into a Python IDE. It has been designed, developed, and is supported by Microsoft and the community.

PTVS uses .pyproj files to reference all source and content files associated with a project (see http://pytools.codeplex.com/wikipage?title=Features%20Projects). These files are environment-specific and, much like .sln files, should not be included in version control.

More info: https://pytools.codeplex.com/
