### PR TITLE
add python compiled ".pyc" files to be ignored

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -49,3 +49,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Python Compiled
+*.pyc


### PR DESCRIPTION
all the pyc files are compiled by the local server, it does not need keep track of these
