### PR TITLE
Added *.synctex.gz(busy)

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -25,6 +25,7 @@
 ## Build tool auxiliary files:
 *.fdb_latexmk
 *.synctex.gz
+*.synctex.gz(busy)
 *.pdfsync
 
 ## Auxiliary and intermediate files from other packages:


### PR DESCRIPTION
Sometimes it happens that you'd like to commit during a long LaTeX run. During this run, the document.synctex.gz is renamed to document.synctex.gz(busy). And you don't want to commit this file.
