### PR TITLE
added entry for Jetbrains Pycharm IDE

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -51,3 +51,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Pycharm
+.idea


### PR DESCRIPTION
I just added an entry for Jetbrains IDE for python on the gitignore, as it's a folder created and used by the IDE for keeping track of the changes on the project.
