### PR TITLE
ignore SQL server database files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -158,8 +158,8 @@ UpgradeLog*.XML
 UpgradeLog*.htm
 
 # SQL Server files
-App_Data/*.mdf
-App_Data/*.ldf
+*.mdf
+*.ldf
 
 # Business Intelligence projects
 *.rdl.data


### PR DESCRIPTION
The current logic does not correctly ignore nested SQL server database files as they are inserted by default in VS2013 and maybe other versions. The location in VS2013 is `AppName/App_Data/mydb.mdf` which is not correctly ignored using the current gitignore rule.
