### PR TITLE
ignore web deploy settings by default

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -116,7 +116,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-## TODO: Comment the next line if you want to checkin your web deploy settings but do not that will include unencrypted passwords
+## TODO: Comment the next line if you want to checkin your web deploy settings but do note that will include unencrypted passwords
 *.pubxml
 
 # NuGet Packages Directory


### PR DESCRIPTION
Allowing the `*.pubxml` files currently allows unencrypted database connection passwords to be stored in plain text. By default I don't think we should encourage people to store unencrypted passwords in repositories.

This relates to https://github.com/github/gitignore/pull/674, https://github.com/github/gitignore/pull/517, https://github.com/github/gitignore/pull/775, & https://github.com/github/gitignore/issues/837.

/cc @sayedihashimi, @niik, @steveoh, @Haacked, @ArturDorochowicz. I don't expect you all to agree with me but I am CCing you for the sake of transparency. Again I don't think passwords should be stored in repos by default.
