### PR TITLE
Add AppCodes workspace and tasks XML to gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -19,5 +19,9 @@ DerivedData
 *.hmap
 *.ipa
 
+# AppCode
+.idea/workspace.xml
+.idea/tasks.xml
+
 # CocoaPods
 Pods


### PR DESCRIPTION
As more and more iOS and Mac devs are using AppCode it should be present in the objective-c gitignore and not just in the IntelliJ gitignore.

As described in #332 only `workspace.xml` and `tasks.xml` should be ignored.
