### PR TITLE
Ignore _vimrc_local.vim files in vim.gitignore

### DIFF
--- a/Global/vim.gitignore
+++ b/Global/vim.gitignore
@@ -4,3 +4,6 @@
 Session.vim
 .netrwhist
 *~
+
+#Ignore local_vimrc files http://www.vim.org/scripts/script.php?script_id=727
+_vimrc_local.vim


### PR DESCRIPTION
- The local_vimrc.vim plugin allows you to have a vimrc that is local to a
  folder, this will ignore those files
