### PR TITLE
Removed JetBrains *.iws files

### DIFF
--- a/Grails.gitignore
+++ b/Grails.gitignore
@@ -3,16 +3,6 @@
 # web application files
 /web-app/WEB-INF/classes
 
-# IDE support files
-/.classpath
-/.launch
-/.project
-/.settings
-/*.launch
-/*.tmproj
-/ivy*
-/eclipse
-
 # default HSQL database files for production mode
 /prodDb.*
 


### PR DESCRIPTION
This entry should be (and is) rather in Global/JetBrains.gitignore
