### PR TITLE
"profile" doesn't belong in Objective-C.gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -13,7 +13,6 @@ build/
 !default.perspectivev3
 xcuserdata
 *.xccheckout
-profile
 *.moved-aside
 DerivedData
 *.hmap


### PR DESCRIPTION
I've never seen a valid argument for keeping this line in this file, yet I've seen dozens of people complain about it. It's bitten me and lots of others in the past.
