### PR TITLE
[Python] Remove rules for bin/, Mr Developer, and Rope

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -34,10 +34,10 @@ coverage.xml
 
 # Translations
 *.mo
+*.pot
 
 # Django stuff:
 *.log
-*.pot
 
 # Sphinx documentation
 docs/_build/


### PR DESCRIPTION
I presume `bin/` was initially ignored based on the project layout dictated by some packaging tool, however not all python projects use these layouts. `bin/` is normally for executables, so ignoring it by default seems like a bad idea.

As for [Mr Developer](https://pypi.python.org/pypi/mr.developer) and [Rope](http://rope.sourceforge.net/): I don't know that they are particularly widespread tools and even if they were, the rules here look suspiciously like those IDE project files that people like to ignore but really shouldn't.
