### PR TITLE
PyInstaller .manifest

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -25,7 +25,6 @@ var/
 # PyInstaller
 #  Usually these files are written by a python script from a template 
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.exe.manifest
 *.manifest
 *.spec
 


### PR DESCRIPTION
## PyInstaller

Usually these files are written by a python script from a template
before PyInstaller builds the exe, so as to inject date/other infos
into it.

```
*.exe.manifest
*.manifest
```

Example template

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
  <assemblyIdentity
    type="win32"
    name="SourceCoder"
    version="14.2.22.0"
    processorArchitecture="x86"
  />
  <description>Description</description>
  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
    <security>
      <requestedPrivileges>
        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
      </requestedPrivileges>
    </security>
  </trustInfo>
  <dependency>
    <dependentAssembly>
      <assemblyIdentity
         type="win32"
         name="Microsoft.Windows.Common-Controls"
         version="6.0.0.0"
         processorArchitecture="x86"
         publicKeyToken="6595b64144ccf1df"
         language="*"
       />
    </dependentAssembly>
  </dependency>
  <dependency>
    <dependentAssembly>
      <assemblyIdentity
         type="win32"
         name="Microsoft.VC90.CRT"
         version="9.0.21022.8"
         processorArchitecture="x86"
         publicKeyToken="1fc8b3b9a1e18e3b"
       />
    </dependentAssembly>
  </dependency>
</assembly>
```
