### PR TITLE
Ignore signed pom files in leiningen projects

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -1,4 +1,5 @@
 pom.xml
+pom.xml.asc
 *jar
 /lib/
 /classes/


### PR DESCRIPTION
Pom files are commonly signed before deploy as part of the build/signoff process
