### PR TITLE
Ignore log of applied patches

### DIFF
--- a/Magento.gitignore
+++ b/Magento.gitignore
@@ -35,6 +35,7 @@ app/etc/modules/Mage_Widget.xml
 app/etc/modules/Mage_XmlConnect.xml
 app/etc/modules/Phoenix_Moneybookers.xml
 app/etc/modules/Cm_RedisSession.xml
+app/etc/applied.patches.list
 app/etc/config.xml
 app/etc/enterprise.xml
 app/etc/local.xml.additional


### PR DESCRIPTION
Magento keeps a log of official patches applied in `app/etc/applied.patches.list`. The log is used to check what patches are applied to the Magento instance, so it could cause some confusion if included in a repo.
