### PR TITLE
Enable Ignore of NuGet Packages Folder By Default

### DIFF
--- a/IgnorePackages
+++ b/IgnorePackages
@@ -123,9 +123,8 @@ publish/
 *.azurePubxml
 
 # NuGet Packages Directory
-## TODO: If you have NuGet Package Restore enabled, uncomment the next line
-#packages/*
-## TODO: If the tool you use requires repositories.config, also uncomment the next line
+packages/*
+## TODO: If the tool you use requires repositories.config uncomment the next line
 #!packages/repositories.config
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets


### PR DESCRIPTION
Submitting this for consideration.

The first thing that I do on every new project is to go in and uncomment the packages folder. With the prevalence of NuGet and prominence of its use in the Visual Studio environment, along with how well package restore _just works_ now, I believe this should be the default.

While I understand that package restore isn't on by default, I would argue that the types of developers using NuGet _and_ a distributed SCM are the types of developers that would omit the binaries from source control.
