### PR TITLE
Update Clojure.gitignore

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -3,6 +3,8 @@ pom.xml
 /lib/
 /classes/
 /target/
+/checkouts/
 .lein-deps-sum
 .lein-repl-history
 .lein-plugins/
+.lein-failures


### PR DESCRIPTION
Extended Clojure.gitignore to exclude platform/project specific info
