### PR TITLE
Create Atom.gitignore

### DIFF
--- a/Atom.gitignore
+++ b/Atom.gitignore
@@ -1,0 +1,3 @@
+# http://atom.io/docs/v0.61.0/customizing-atom
+
+storage


### PR DESCRIPTION
Wondering if we should put these meta-dotfiles (dotfiles for your settings [dotfile] directories) in a special directory in this repo, e.g. `Meta/Atom.gitignore`?  I have some other examples in my personal dotfiles repo:

https://github.com/afeld/dotfiles/blob/master/.gitignore

/cc @github/atom 
