### PR TITLE
Added ignore for directory config under KDE

### DIFF
--- a/Global/Linux.gitignore
+++ b/Global/Linux.gitignore
@@ -1,1 +1,4 @@
 *~
+
+# KDE directory preferences
+.directory


### PR DESCRIPTION
Dolphin, the KDE file manager, writes specific directory configuration in .directory files.
