### PR TITLE
Fix comments in Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,11 +1,11 @@
-// Don’t commit the following files and directories created by pub and dart2js
+# Don’t commit the following files and directories created by pub and dart2js
 packages/
 *.js_
 *.js.deps
 *.js.map
 
-// Include when developing application packages
+# Include when developing application packages
 pubspec.lock
 
-// Avoid committing generated JavaScript files
+# Avoid committing generated JavaScript files
 *.dart.js


### PR DESCRIPTION
.gitignore uses `#` for comments, not `//`
