### PR TITLE
[VisualStudio] Remove Windows OS rules

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -172,17 +172,3 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
-
-# =========================
-# Windows detritus
-# =========================
-
-# Windows image file caches
-Thumbs.db
-ehthumbs.db
-
-# Folder config file
-Desktop.ini
-
-# Recycle Bin used on file shares
-$RECYCLE.BIN/


### PR DESCRIPTION
I know that VS is tied to Windows, but we keep the editor/OS-specific rules in `Global/`. Since we assume that Windows users have `Global/Windows.gitignore` in their global git config anyway, this duplication is unnecessary.

I also feel that the VS template has become a bit of a mess - but I'm not sure what to do about that.
