### PR TITLE
[ChefCookbook] Remove global rules and lockfiles

### DIFF
--- a/ChefCookbook.gitignore
+++ b/ChefCookbook.gitignore
@@ -1,9 +1,7 @@
 .vagrant
-Berksfile.lock
 /cookbooks
 
 # Bundler
-Gemfile.lock
 bin/*
 .bundle/*
 


### PR DESCRIPTION
Remove the rules which belong under `Global/` and also lockfiles which should in general be checked in to normalise the environment (see [docs for Berksfile.lock](http://berkshelf.com/)).
