### PR TITLE
[Objective-C] Remove global rule

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,6 +1,3 @@
-# OS X
-.DS_Store
-
 # Xcode
 build/
 *.pbxuser


### PR DESCRIPTION
This belongs in `Global/OSX.gitignore`.
