### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,11 +1,13 @@
-# Don’t commit the following files and directories created by pub and dart2js
+# Don’t commit the following directories created by pub.
+build/
 packages/
+
+# Or the files created by dart2js.
+*.dart.js
+*.dart.precompiled.js
 *.js_
 *.js.deps
 *.js.map
 
-# Include when developing application packages
+# Include when developing application packages.
 pubspec.lock
-
-# Avoid committing generated JavaScript files
-*.dart.js


### PR DESCRIPTION
- add the `build/` directory to the .gitignore list (now created by pub).
- add the `.dart.precompiled.js` files (created by dart2js) to the ignore list.

And, sort and re-order the file.
