### PR TITLE
Ignore Klokwork and WinMerge files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -172,3 +172,9 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# Klocwork
+.klocwork
+
+# WinMerge
+*.bak


### PR DESCRIPTION
Ignore Klokwork (http://www.klocwork.com/) and WinMerge (http://winmerge.org/) files.
