### PR TITLE
[Objective-C] Remove CocoaPods ignores

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -15,3 +15,12 @@ profile
 DerivedData
 *.hmap
 *.ipa
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control?
+#
+# Pods/
+


### PR DESCRIPTION
These should not be ignored by default, it's down to the user and they shouldn't forced to ignore the `Pods/` directory by default.

[http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control?](http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control?)
