### PR TITLE
Added archlinux PKGBULD gitignore.

### DIFF
--- a/PKGBUILD.gitignore
+++ b/PKGBUILD.gitignore
@@ -1,0 +1,11 @@
+#pkg and src dirs
+pkg/
+src/
+
+#source packages and packge files
+*.tgz
+*.tar.gz
+*.xz
+
+#signature file
+*.sig


### PR DESCRIPTION
Useful when building archlinux packages.
