### PR TITLE
Update Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -12,8 +12,11 @@
 
 # Qt-es
 
+/.qmake.cache
+/.qmake.stash
 *.pro.user
 *.pro.user.*
+*.moc
 moc_*.cpp
 qrc_*.cpp
 ui_*.h


### PR DESCRIPTION
- Ignore '*.moc' files (foo.moc created when foo.cpp contains a Q_OBJECT.)
- Ignore '/.qmake.cache' and '/.qmake.stash' as does the official Qt Creator project.
