### PR TITLE
Add Global/SlickEdit.gitignore file

### DIFF
--- a/Global/SlickEdit.gitignore
+++ b/Global/SlickEdit.gitignore
@@ -1,14 +1,6 @@
 # SlickEdit workspace and project files are ignored by default because
 # typically they are considered to be developer-specific and not part of a
-# project.  However, if multiple SlickEdit users are collaborating on a
-# project, it is possible to store these files in the repository and share
-# them among all developers because they do not contain user-specific data.
-# To store these files in a repository, add the following two lines to the
-# project’s .gitignore file:
-# ----------
-# !*.vpw
-# !*.vpj
-# ----------
+# project.
 *.vpw
 *.vpj
 


### PR DESCRIPTION
This commit adds a global ignore file for SlickEdit, a commercial editor.

SlickEdit will create the following files when the user sets up a workspace:

*.vpw       Workspace file. Contains a list of project files associated with
            the workspace.
*.vpj       Project file. Contains the project’s settings, including the list
            of source files.
*.vpwhist   Workspace history file for Windows. Contains user session
            information (list of open files, debugger breakpoints, etc.)
*.vpwhistu  Workspace history file for UNIX/Linux/MacOSX. (Same as above.)
*.vtg       Workspace tag file. Contains a database of source code symbols.

It is assumed that GitHub users will generally not want to store their
workspace and project files in a repository, so those files are ignored
globally.  However, those files do not contain user-specific data so they
could be stored in a repository and shared among developers if desired for
a particular project.  This can be done by adding rules like ’!_.vpw’ and
‘!_.vpj’ to the project’s .gitignore file.

The workspace history and tag files contain user-specific data, so they
should not be stored in a repository.

For more information, download the PDF user guide from:
http://www.slickedit.com/products/slickedit/product-documentation

Note: The user guide is 1400 pages long and over 13MB in size.

Searching for ‘vpwhist’ will lead to the section that discusses storing
these files in a repository.
