### PR TITLE
Add Sourcegear Vault/Fortres ghost folders.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -73,6 +73,10 @@ ipch/
 # TFS 2012 Local Workspace
 $tf/
 
+# Sourcegear Vault/Fortress Ghost Folders
+_sgvault/
+_sgbak/
+
 # Guidance Automation Toolkit
 *.gpState
 


### PR DESCRIPTION
http://download.sourcegear.com/misc/vault/help/client.3.5.1/ghostfoldersandfiles.htm
These are folders created by Sorucegear's versioning system Vault (A.K.A. Fortress) for its tracking purposes. It's the same as ignoring $tf/ for Microsoft's Team Foundation Server, which is right above the lines I added.
