### PR TITLE
Fixes uncomplete CTools

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -2,7 +2,6 @@
 sites/*/*settings*.php
 
 # Ignore paths that contain generated content.
-cache/
 files/
 sites/*/files
 sites/*/private


### PR DESCRIPTION
Ignoring cache/ makes also necessary files ignored:
modules/ctools/page_manager/plugins/cache/page_manager_context.inc
modules/ctools/plugins/cache/simple.inc
modules/ctools/plugins/cache/export_ui.inc

See: https://drupal.org/comment/7001628#comment-7001628
