### PR TITLE
Added bin-release folder to FlexBuilder .gitignore

### DIFF
--- a/Global/FlexBuilder.gitignore
+++ b/Global/FlexBuilder.gitignore
@@ -1,2 +1,3 @@
 bin/
 bin-debug/
+bin-release/


### PR DESCRIPTION
Updated the .gitignore for FlexBuilder to include 'bin-release' folder, another folder for generated binary builds (bin-release is the target for the final .swf files).
