### PR TITLE
Adding explanatory/informative commentary

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -1,3 +1,4 @@
+## Mac OS X
 .DS_Store
 .AppleDouble
 .LSOverride
@@ -11,3 +12,4 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+

--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,3 +1,4 @@
+## Xcode
 build/
 *.pbxuser
 !default.pbxuser

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,3 +1,5 @@
+## See Global/Xcode.gitignore
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However


### PR DESCRIPTION
Seems there's already confusion over the Objective-C.gitignore - direct devs to the new location of the related patterns.
Some minor headings and formatting indicating the source of the particular patterns when combining into a single ignore list.

Fixes #1022
