### PR TITLE
Add global/BitTorrentSync.gitignore file

### DIFF
--- a/Global/BitTorrentSync.gitignore
+++ b/Global/BitTorrentSync.gitignore
@@ -1,0 +1,5 @@
+# BitTorrent Sync
+# http://www.bittorrent.com/sync
+.SyncArchive
+.SyncID
+.SyncIgnore


### PR DESCRIPTION
Adds support for the BitTorrent Sync file-syncing tool. Sync will create
the following files in synced folders:

.SyncAchive     Optional local trash folder.
.SyncID         Globally unique sync ID file. To be kept secret.
.SyncIgnore     Ignore file. Contains a list of globs of files not
                to sync.

An example of a sync'ed git repository is the user's "dotfiles"
collection. While he uses git to version his changes, he may prefer
btsync to push it to all his machines instead of having to git-pull
regularly everywhere.
