### PR TITLE
Do not ignore .ncrunch* in Visual Studio projects.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -91,7 +91,6 @@ _TeamCity*
 *.dotCover
 
 # NCrunch
-*.ncrunch*
 _NCrunch_*
 .*crunch*.local.xml
 


### PR DESCRIPTION
This was ignoring .ncrunchproject and .ncrunchsolution files.
NCrunch recommend that both of these files are checked in to source control.
