### PR TITLE
Remove opinion from Node.js .gitignore file

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -20,4 +20,6 @@ coverage
 build/Release
 
 # Dependency directory
+# Commenting this out is preferred by some people, see
+# https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules


### PR DESCRIPTION
This is a PR to remove the opinionated lines from the Node.js .gitignore file.

I do not believe that Github's pre-baked .gitignore files should be promulgating opinions, especially in a community that is as fresh as the Node.js community.  Questions of what should be checked in should be a decision made on an organization-by-organization basis, or left up to the individual.  Github's inclusion of opinion in these files puts unnecessary authority behind that opinion, which can have the negative side-effect of people following without thinking.
