### PR TITLE
Adds Intellij specific files to the Scala.gitignore template

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# IntelliJ specific
+.idea


### PR DESCRIPTION
.idea is a folder which is used for Intellij specific files. As IntelliJ is a very popular IDE for Scala projects(*), I am suggesting to add this folder to the Scala.gitignore template.

(*) http://stackoverflow.com/questions/419207/which-is-the-best-ide-for-scala-development
