### PR TITLE
Revert "Packages folder is ignored correctly".

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -124,7 +124,7 @@ publish/
 *.pubxml
 
 # NuGet Packages Directory
-packages/
+packages/*
 ## TODO: If the tool you use requires repositories.config uncomment the next line
 #!packages/repositories.config
 


### PR DESCRIPTION
Without the asterisk at the end of the directory's path, an exception for a file within this directory does not work.

Using `!packages/repositories.config` after the line that was reverted, would not work unless reverted.

This reverts commit 0fb0fbefa5fcd62ea5b6fe0f433588df270dcd71.
