### PR TITLE
Added .rel-files

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -21,3 +21,6 @@ tramp
 
 # elpa packages
 /elpa/
+
+# reftex files
+*.rel


### PR DESCRIPTION
Reftex adds these for internal processing, only auxillary files for composition and compilation of tex-documents.
