### PR TITLE
Ignor auctex auto-folder and contents

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -24,3 +24,6 @@ tramp
 
 # reftex files
 *.rel
+
+# AUCTeX auto folder
+/auto/


### PR DESCRIPTION
When working with multifile LaTeX-documents in AUCTeX in emacs, it creates the auto-folder to keep track of styles, macros etc. in the whole document. Unnecessary of versioning purposes.
