### PR TITLE
combined environment config rules

### DIFF
--- a/Laravel4.gitignore
+++ b/Laravel4.gitignore
@@ -1,3 +1,2 @@
 /bootstrap/compiled.php
-.env.*.php
-.env.php
+.env*.php


### PR DESCRIPTION
I noticed the laravel 4 addition - I was already using `.env*.php` which should cover both cases listed. The fewer lines, the better, right?
