### PR TITLE
Ignore AppCode's .idea folder

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -17,6 +17,10 @@ DerivedData
 *.ipa
 *.xcuserstate
 
+# AppCode
+#
+.idea/
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However


### PR DESCRIPTION
Adds the AppCode `.idea` folder to the Objective-C `.gitignore`.

FWIW, we've done [the same thing in Mantle](https://github.com/Mantle/Mantle/commit/f94b7ecb6ec648f1ef643b4fed5c9005f45bc71e) before.
