### PR TITLE
Change options for ignoring packages directory in Visual Studio.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -127,8 +127,9 @@ publish/
 *.pubxml
 
 # NuGet Packages Directory
-packages/*
-## TODO: If the tool you use requires repositories.config uncomment the next line
+packages/
+## TODO: If the tool you use requires repositories.config comment the line above and uncomment the next two lines
+#packages/*
 #!packages/repositories.config
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets


### PR DESCRIPTION
Directory is fully ignored using `packages/` by default (so survives git clean -fd for example)
Option to ignore using `packages/*` and add exception `!packages/reposirories.config` if required
See this thread for context: http://git.io/izzh3g
