### PR TITLE
Ignoring Pycharm project settings folder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -41,6 +41,7 @@ coverage.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea
 
 # Rope
 .ropeproject


### PR DESCRIPTION
Ignoring this folder to avoid conflicts, once it contains only Pycharm local settings, just like de .pydevproject for Pydev
