### PR TITLE
Add target-eclipse for grails gitignore

### DIFF
--- a/Grails.gitignore
+++ b/Grails.gitignore
@@ -28,3 +28,4 @@
 
 # "temporary" build files
 /target
+/target-eclipse


### PR DESCRIPTION
I've been using GGTS and it creates a target-eclipse folder with a lot of generated code, to avoid this, I added target-eclipse to my .gitignore too
