### PR TITLE
Revert "Remove OSX-specific rule from ObjectiveC template"

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,3 +1,6 @@
+# OS X
+.DS_Store
+
 # Xcode
 #
 build/


### PR DESCRIPTION
I propose this revert for the following reasons:
1. `.DS_Store` files are created by the finder on OS X to track window position and icon sizes of the containing folder when it was last displayed in the Finder. This is primarily so that each folder can have a custom appearance. These files are sprayed spuriously over the filesystem on OS X and will be different for each user. They should not be tracked.
2. Most Objective-C projects will be worked on using OS X. You have to go out of your way to support developing in this language on another platform.
3. While every OS X developer should have `.DS_Store` in their global gitignore that does not come by default. The convenience factor of having it in this file, preventing team members from tracking and committing `.DS_Store` files is immense.

This reverts commit 1446bd004483542cc2e003cd446718518cd3c8d0.
