### PR TITLE
Add new .gitignore for Elixir

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -1,0 +1,4 @@
+/_build
+/deps
+erl_crash.dump
+*.ez


### PR DESCRIPTION
I have added a new .gitignore for the programming language Elixir (http://elixir-lang.org/).
The content is the default content, which will be generated if the build tool mix is used (http://elixir-lang.org/getting_started/mix/1.html).
