### PR TITLE
[Global/SBT] Fix documentation URL

### DIFF
--- a/Global/SBT.gitignore
+++ b/Global/SBT.gitignore
@@ -1,5 +1,5 @@
-# SBT .gitignore
-# recommended: http://code.google.com/p/simple-build-tool/wiki/Setup#Version_Control
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
 
 target/
 lib_managed/


### PR DESCRIPTION
I noticed that the URL in the SBT template points to an unmaintained project site. I've found the equivalent documentation on the new site, and the `target/` rule is still recommended. Does anyone who uses the tool have an insight as to whether the other rules are still relevant while we're at it?
