### PR TITLE
Releases should also be ignored

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -9,7 +9,8 @@
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
-[Rr]elease[s]/
+[Rr]elease/
+[Rr]eleases/
 x64/
 build/
 bld/


### PR DESCRIPTION
**"Releases"** directory is created by Shimmer/Squirrel installer for example. It also should be ignored.
