### PR TITLE
Adding .lock-wscript

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -23,3 +23,6 @@ build/Release
 # Commenting this out is preferred by some people, see
 # https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+# Users Environment Variables
+.lock-wscript


### PR DESCRIPTION
There are security ramifications to having the `.lock-wscript` file checked in potentially exposes sensitive environment variables. 
