### PR TITLE
Ignore venv/ dir in Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/


### PR DESCRIPTION
Ignores `venv/` in `Python.gitignore`, typically used as a virtualenv directory. E.g. in this tutorial: http://docs.python-guide.org/en/latest/starting/install/osx/
