### PR TITLE
"TheFind Feed" module removed

### DIFF
--- a/Magento.gitignore
+++ b/Magento.gitignore
@@ -1,10 +1,8 @@
 .modgit/
-app/code/community/Find/
 app/code/community/Phoenix/
 app/code/community/Cm/
 app/code/core/
 app/design/adminhtml/default/default/
-app/design/adminhtml/default/find/
 app/design/frontend/base/
 app/design/frontend/default/blank/
 app/design/frontend/default/default/
@@ -13,7 +11,6 @@ app/design/frontend/default/modern/
 app/design/frontend/enterprise/default
 app/design/install/
 app/etc/modules/Enterprise_*
-app/etc/modules/Find_Feed.xml
 app/etc/modules/Mage_All.xml
 app/etc/modules/Mage_Api.xml
 app/etc/modules/Mage_Api2.xml


### PR DESCRIPTION
According to [this](http://www.magentocommerce.com/magento-connect/thefind-feed-1.html) TheFind Feed module does not come with the latest versions of Magento( > 1.6).

Thank you
