### PR TITLE
Ignore locally-built `*.nupkg` files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -129,8 +129,9 @@ publish/
 ## passwords
 *.pubxml
 
-# NuGet Packages Directory
+# NuGet Packages
 packages/*
+*.nupkg
 ## TODO: If the tool you use requires repositories.config
 ## uncomment the next line
 #!packages/repositories.config


### PR DESCRIPTION
Building NuGet packages locally with `NuGet.exe pack <name>.nuspec` generates a `<name>.<version>.nupkg` file which should never be versioned.
