### PR TITLE
Mercury.gitignore: Add Erlang .beams,

### DIFF
--- a/Mercury.gitignore
+++ b/Mercury.gitignore
@@ -7,5 +7,6 @@ Mercury/
 *.a
 *.so
 *.dylib
+*.beams
 *.d
 *.c_date


### PR DESCRIPTION
 as this is an additional compiler target, forgot to add this in #1057
