### PR TITLE
Update Eclipse.gitignore

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -13,7 +13,6 @@ local.properties
 .classpath
 .project
 
-
 # External tool builders
 .externalToolBuilders/
 


### PR DESCRIPTION
`.classpath` and `.project` are Eclipse-specific files that should likely not be checked into version control.
