### PR TITLE
Gitignore for Ninja build system dependency-cache and log

### DIFF
--- a/ninja.gitignore
+++ b/ninja.gitignore
@@ -1,0 +1,2 @@
+.ninja_deps
+.ninja_log


### PR DESCRIPTION
Added .gitignore for the [Ninja build system](http://martine.github.io/ninja/). `.ninja_dep` is a cache of dependencies; `.ninja_log` is a build log. These entries are used by, e.g., the ninja build system's .gitignore: https://github.com/martine/ninja/blob/master/.gitignore
