### PR TITLE
Ignore phpunit.xml in Symfony2 applications

### DIFF
--- a/Symfony2.gitignore
+++ b/Symfony2.gitignore
@@ -12,5 +12,8 @@ web/bundles/*
 app/config/parameters.ini
 app/config/parameters.yml
 
+# PHPUnit
+app/phpunit.xml
+
 # Composer
 composer.phar


### PR DESCRIPTION
Symfony2 application sometimes use ".dist" file to distribute template configuration, and invite the developer to create a custom local copy from scratch.

Quoting the documentation (http://symfony.com/doc/current/book/testing.html#phpunit-configuration):

> Store the app/phpunit.xml.dist file in your code repository and ignore the app/phpunit.xml file.

You already done the same for `parameters.yml` and `parameters.ini`, so I think that there are no drawbacks in including this one.

What do you think?
