### PR TITLE
Update for users of Macs, Jetbrains and SimpleCov

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -24,3 +24,14 @@ config/secrets.yml
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# For those using Mac OS X
+.DS_Store
+
+#simplecov gem and tests
+coverage/
+/spec/tmp
+
+#used for any jetbrains IDE to store App settings
+.idea
+


### PR DESCRIPTION
Nobody wants the .DS_Store from their mac user companions or even the project settings for JetBrains IDE.

If you are using SimpleCov, who needs the coverage folder!
