### PR TITLE
Added Roslyn cache directory to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -183,3 +183,7 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# Roslyn cache
+*.sln.ide/
+


### PR DESCRIPTION
The .sln.ide folder (created by Roslyn) should be ignored
