### PR TITLE
JetBrains: Added some documentation and fixed subdirectory ignores

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,20 +1,23 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+# See https://intellij-support.jetbrains.com/entries/23393067 for more
+# information on how to manage projects under Version Control Systems
 
 ## Directory-based project format
 .idea/
 # if you remove the above rule, at least ignore user-specific stuff:
-# .idea/workspace.xml
-# .idea/tasks.xml
+# **/.idea/workspace.xml
+# **/.idea/tasks.xml
 # and these sensitive or high-churn files:
-# .idea/dataSources.ids
-# .idea/dataSources.xml
-# .idea/sqlDataSources.xml
-# .idea/dynamic.xml
+# **/.idea/dataSources.ids
+# **/.idea/dataSources.xml
+# **/.idea/sqlDataSources.xml
+# **/.idea/dynamic.xml
 
 ## File-based project format
 *.ipr
-*.iws
 *.iml
+# if you remove the above rules, at least ignore user-specific stuff:
+*.iws
 
 ## Additional for IntelliJ
 out/


### PR DESCRIPTION
I added a reference to the jetbrains documentation and fixed the alternative subdirectory ignores. Without the leading "**/" these rules would only match if the ".idea" file is in the root of the repository (which might not be the case). 
