### PR TITLE
Update .gitignore for Symfony2

### DIFF
--- a/Symfony2.gitignore
+++ b/Symfony2.gitignore
@@ -13,7 +13,7 @@
 /bin/
 /vendor/
 
-# Assets
+# Assets and user uploads
 /web/bundles/
 /web/uploads/
 


### PR DESCRIPTION
Updates `Symfony2.gitignore` to reflect changes to [Symfony's `.gitignore`](https://github.com/symfony/symfony-standard/blob/master/.gitignore).

Changes include adding the `bin` folder to the list of ignored folders and adding an exception for `app/cache/.gitkeep` and `app/logs/.gitkeep`.

Also reordered the entries and improved the documentation so it makes more sense, especially for new users of Symfony.
