### PR TITLE
add todo note for packages/* rule

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -130,6 +130,9 @@ publish/
 *.pubxml
 
 # NuGet Packages
+## TODO: Update the following path to your packages folder if it
+## is not in the same folder as this .gitignore file, keep the /*
+## at the end or the below include specific items will not work
 packages/*
 *.nupkg
 ## TODO: If the tool you use requires repositories.config


### PR DESCRIPTION
TODO note needed because rule only works if the folder is located in the same folder as the `.gitignore` file. For example if your packages folder is located in `\myapp\mypartoftheapp\packages\` it will unintentionally be included using this rule.
