### PR TITLE
elisp: adding .cask files to gitignore

### DIFF
--- a/Elisp.gitignore
+++ b/Elisp.gitignore
@@ -1,2 +1,5 @@
 # Compiled
 *.elc
+
+# Packaging
+.cask


### PR DESCRIPTION
cask is a dependency/package management tool for Emacs lisp packages. Adding
.cask to gitignore template to avoid tracking of installed packages not
a part of repository
