### PR TITLE
add Silicon Laboratories ignore file

### DIFF
--- a/SiliconLaboratories.gitignore
+++ b/SiliconLaboratories.gitignore
@@ -1,0 +1,7 @@
+# Silicon Laboratories for C8051 project
+*.HEX
+*.#*
+*.OBJ
+tmp.out
+*.LST
+*.M51


### PR DESCRIPTION
added a gitignore file for Silicon Labs IDE, which is used for C8051 (C or ASM).
- latest version: [Silicon Labs](http://www.silabs.com/products/mcu/Pages/simplicity-studio.aspx)

---

Silicon Labs IDE is widely used in our school. I used this ignore file in projects, so I contribute to share it with others.
[a example repo using Silicon Labs IDE (mine)](https://github.com/DefineFC/eSys2011)

---
- *.HEX & *.OBJ are known ignorable files
- _.#_ is generated when compiling
- tmp.out is a temp file for Silicon Labs
- *.LST is list filetype, it is also ignored in `Tasm.gitignore`
- *.M51 is generated when compiling, it stores the stack status
