### PR TITLE
Update .gitignore for most recent Rails version

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -11,9 +11,9 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 
-# TODO Comment out these rules if you are OK with secrets being uploaded to the repo
-config/initializers/secret_token.rb
-config/secrets.yml
+# TODO Uncomment these lines if you are using Rails < 4.1
+# config/initializers/secret_token.rb
+# config/secrets.yml
 
 ## Environment normalisation:
 /.bundle


### PR DESCRIPTION
This is no longer a security threat in the most recent version of Rails as the production secret comes from an environmental variable. Further, deployment systems utilizing git (heroku) will often require this file.
