### PR TITLE
Create MinecraftForge.gitignore

### DIFF
--- a/MinecraftForge.gitignore
+++ b/MinecraftForge.gitignore
@@ -1,0 +1,16 @@
+*.class
+*.iml
+*.ipr
+*.iws
+*.txt
+.classpath/
+.project/
+.settings/
+.gradle/
+build/
+minecraft/
+out/
+bin
+config/
+logs/
+saves/


### PR DESCRIPTION
A .gitignore file for minecraft forge gradle, eclipse and intellij
