### PR TITLE
Create Momentics.gitignore

### DIFF
--- a/Global/Momentics.gitignore
+++ b/Global/Momentics.gitignore
@@ -1,3 +1,4 @@
 # Built files
 x86/
 arm/
+arm-p/


### PR DESCRIPTION
Momentics: BlackBerry 10 IDE
https://developer.blackberry.com/native/download/

This ignore file ignores the x86/, arm-p/ and arm/ folders. Those folders are for compiled output files (device or simulator), which should be outside of the git repo and on the Releases tab.
