### PR TITLE
Ignoring IDE project files and PyBuilder's target

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -42,3 +42,15 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# PyCharm IDE
+.idea
+
+# Eclipse / PyDev IDE
+.project
+.pydevproject
+
+# PyBuilder
+target/
+
+


### PR DESCRIPTION
**PyCharm** is a Python IDE by Jetbrains (see http://www.jetbrains.com/pycharm/).
Seems like they've built PyCharm on Intellij IDEA (see http://www.jetbrains.com/idea/).
This is why the project directory is called `.idea`

**Eclipse** stores it's project data in a file called `.project` (see http://www.eclipse.org/).
For python developers there is a Eclipse extension callled PyDev (see http://pydev.org/).
**PyDev** stores it's project data in a file called `.pydevproject`.

**PyBuilder** is a build tool for python (see http://pybuilder.github.io/).
During the build process it creates a directory called `target`.
