### PR TITLE
Ignoring PyBuilder's target directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -42,3 +42,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# PyBuilder
+target/


### PR DESCRIPTION
PyBuilder is a build tool for python (see http://pybuilder.github.io/). When executing the command line script `pyb` it will store all corresponding project data in a directory called `target`. This directory should never be part of the project's git repository.
