### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -11,3 +11,6 @@
 /*.userprefs
 /*.pidb
 /*.booproj
+
+#Unity3D Generated File On Crash Reports
+sysinfo.txt


### PR DESCRIPTION
Sysinfo.txt is generated by unity if occurs any crashes. The content consist of  users system information, running process etc. I don't think that should be shared with others.
