### PR TITLE
Must ignore x86 directory as well

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -12,6 +12,7 @@
 [Rr]elease/
 [Rr]eleases/
 x64/
+x86/
 build/
 bld/
 [Bb]in/


### PR DESCRIPTION
When installing SQLite embebed on my C# project I've noted that it generates both directories,
`x86` and `x64` but only `x64` was present on `.gitignore`.
