### PR TITLE
Add .gitignore file for Symfony3

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -1,8 +1,14 @@
-# Cache and logs
+# Cache and logs (Symfony2)
 /app/cache/*
 /app/logs/*
 !app/cache/.gitkeep
 !app/logs/.gitkeep
+
+# Cache and logs (Symfony3)
+/var/cache/*
+/var/logs/*
+!var/cache/.gitkeep
+!var/logs/.gitkeep
 
 # Parameters
 /app/config/parameters.yml
@@ -10,7 +16,10 @@
 
 # Managed by Composer
 /app/bootstrap.php.cache
-/bin/
+/var/bootstrap.php.cache
+/bin/*
+!bin/console
+!bin/symfony_requirements
 /vendor/
 
 # Assets and user uploads
@@ -19,6 +28,7 @@
 
 # PHPUnit
 /app/phpunit.xml
+/phpunit.xml
 
 # Composer PHAR
 /composer.phar


### PR DESCRIPTION
Although version 3 of the Symfony Standard Distribution has not yet been released, version 2.5 already offers the possibility to start using the new directory structure that will come with version 3. The new directory structure introduces a new `var` folder (containing cache and log files and other files that are changed by Symfony itself) and some other changes.

This pull requests basically adds a copy of [`Symfony2.gitignore`](https://github.com/github/gitignore/blob/master/Symfony2.gitignore) that has been altered for this new directory structure.

The most important changes compared to the old directory structure are:
- `app/cache` and `app/logs` have been moved to `var/cache` and `var/logs`, respectively.
- `app/bootstrap.php.cache` has been moved to `var/bootstrap.php.cache`.
- `app/console` has been moved to `bin/console`.
- configuration for phpunit has been moved from `app` to the root folder.

The contents of the new `.gitignore` file can be found [here](https://github.com/sensiolabs/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php#L427). 
