### PR TITLE
Added IPython checkpoints

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -42,3 +42,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# IPython
+.ipynb_checkpoints


### PR DESCRIPTION
Added `.ipynb_checkpoints` to the Python gitignore.

[IPython](http://ipython.org/) is a light-weight, web-based Python IDE that is gaining in popularity. Code is executed in separate cells within an IPython notebook (not terribly dissimilar to a Mathematica notebook). IPython also acts as a REPL in that the output for each cell is produced below the given cell when the code within the cell is executed. Notebooks are saved in JSON format, so they're quite amenable to version control via git.

Whenever checkpoints are created for an IPython, a folder named `.ipynb_checkpoints` is created containing metadata related to the checkpoint. This change adds this folder to the Python gitignore.
