### PR TITLE
(TeX) Exclude files generated by morewrites

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -78,6 +78,9 @@
 # minted
 *.pyg
 
+# morewrites
+*.mw
+
 # nomencl
 *.nlo
 


### PR DESCRIPTION
To overcome the "No room for a new \write", the morewrites package (http://www.ctan.org/pkg/morewrites) uses a file with the .mw extension

In the docs of the morewritespackage, this is explicitly mentioned on page 5, `\g__morewrites_tmp_file_tl` is defined as `\jobname.mw`
