### PR TITLE
Add QtCreator qmlproject temp files ignoring

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -26,3 +26,7 @@ Makefile*
 # QtCreator
 
 *.autosave
+
+#QtCtreator Qml
+*.qmlproject.user
+*.qmlproject.user.*


### PR DESCRIPTION
QtCreator add temportary qmlproject files with names like project_name.qmlproject.user or project_name.qmlproject.user.version. We shoudl add this files to ignore too.
