### PR TITLE
Ignore packages folder contents in a negatable way

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -131,11 +131,11 @@ publish/
 *.pubxml
 
 # NuGet Packages
-packages/*
+**/packages/**
 *.nupkg
 ## TODO: If the tool you use requires repositories.config
 ## uncomment the next line
-#!packages/repositories.config
+#!**/packages/repositories.config
 
 # Enable "build/" folder in the NuGet Packages folder since
 # NuGet packages use it for MSBuild targets.


### PR DESCRIPTION
Ignore package folder contents regardless of folder nesting, in a way that allows negating for the repositories.config file.
