### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -131,19 +131,16 @@ publish/
 *.pubxml
 
 # NuGet Packages
-packages/*
 **/packages/*
 *.nupkg
 ## TODO: If the tool you use *requires* repositories.config, (note that this file is normally regenerated so you should not need it in source control)
-## uncomment the next two lines
-#!packages/repositories.config
+## uncomment the next line
 #!**/packages/repositories.config
 
 # Enable "build/" folder in the NuGet Packages folder since
 # NuGet packages use it for MSBuild targets.
-# These two line needs to be after the ignore of the build folder
+# This line needs to be after the ignore of the build folder
 # (and the packages folder if the line above has been uncommented)
-!packages/build/
 !**/packages/build/
 
 # Windows Azure Build Output


### PR DESCRIPTION
The current pattern for NuGet doesn't work for sub-folders, also commented elsewhere here, and since by  default Visual Studio creates the packages folder one level below the root, the current exclude here doesn't work in those cases.
Fixed pattern for excluding nuget packages so that it works both for top level package folder and for any lower level package folders.  Re-include patterns fixed the same way.
I have written a blogpost here http://geekswithblogs.net/terje/archive/2014/07/03/gitignorendashhow-to-exclude-nuget-packages-at-any-level-and-make.aspx  with all the details, also what effect the different patterns have. 
I have also discussed this with the product group at MS, and got affirmative from them. 
