### PR TITLE
Clarify what commenting *.pubxml does

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -125,8 +125,8 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your
-# web deploy settings but any saved passwords will be unencrypted
+# TODO: Comment the next line if you want to checkin your web deploy settings 
+# but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 
 # NuGet Packages


### PR DESCRIPTION
https://github.com/github/gitignore/commit/08def965cd1c0241a7cffbe7c26a74b3cab61243 incorrect states that commenting `*.pubxml` will keep your passwords hidden when it will actually do the opposite. This clarifies what commenting `*.pubxml` does and warns you of the dangers.
