### PR TITLE
Add fortran ignore file

### DIFF
--- a/Fortran.gitignore
+++ b/Fortran.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 *.dll
+*.mod
 
 # Compiled Static libraries
 *.lai


### PR DESCRIPTION
[FORTRAN](https://en.wikipedia.org/wiki/Fortran) isn't the first language ever written, but it is one of the more enduring ones.

Since gfortran is mostly a front-end for gcc, just use their list with a small addition for module files.
