### PR TITLE
Add ignores for bower-rails

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -24,3 +24,8 @@ config/secrets.yml
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# if using bower-rails ignore default bower_components path bower.json files
+/vendor/assets/bower_components
+*.bowerrc
+bower.json


### PR DESCRIPTION
bower-rails integrates bower.io into Rails, it allows you to have every vendor dependecy(jquery, normalize, modernizr, polymer, angular, etc) in a Bowerfile and install them with rake bower:install
