### PR TITLE
Add Swift.gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -1,0 +1,26 @@
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+# Pods/


### PR DESCRIPTION
I just copied `Objective-C.gitignore`. It seemed to do the job with a small Swift project. Given that there's no `Swift.gitignore` yet, this should at least do as a starting point.
