### PR TITLE
[Sublime Text] Adding cache files and binary files

### DIFF
--- a/Global/SublimeText.gitignore
+++ b/Global/SublimeText.gitignore
@@ -3,9 +3,6 @@
 *.tmPreferences.cache
 *.stTheme.cache
 
-# python code in binary format
-*.pyc
-
 # workspace files are user-specific
 *.sublime-workspace
 


### PR DESCRIPTION
all file extensions associated with sublime text such as:

```
.stTheme
.sublime-project
.sublime-snippet
```

etc…

Followed cache (e.g. `.stTheme.cache`) can be ignored, sublime text re generates these hides are needed, no problem. The same applies to extensions `.pyc` which are binary code packages python, sublime text re generates.

sorry for my bad English.
