### PR TITLE
(TeX) Exclude files generated by using backref.

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -20,6 +20,7 @@
 *.blg
 *-blx.aux
 *-blx.bib
+*.brf
 *.run.xml
 
 ## Build tool auxiliary files:


### PR DESCRIPTION
When doing \usepackage[backref]{hyperref} the pages of the references are shown in the bibliography.
Those files can be safely ignored.

Info: http://tex.stackexchange.com/a/7772/828
