### PR TITLE
Ignore Intellij Idea dir in Scala projects

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# Intellij IDEA specific
+.idea


### PR DESCRIPTION
[Intellij Idea](http://www.jetbrains.com/idea/) is a proprietary IDE. It stores its own project metadata into the _.idea_ directory.

It is a good convention for open source projects to be IDE agnostic. Consequently, ignore the _.idea_ directory for Scala projects.
