### PR TITLE
added converted-to-files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -9,6 +9,7 @@
 
 ## Intermediate documents:
 *.dvi
+*-converted-to.*
 # these rules might exclude image files for figures etc.
 # *.ps
 # *.eps


### PR DESCRIPTION
PDFLaTeX and PDFTex create converted-to-files if one includes for example eps images. There is no need to push these because they are automatically created.
