### PR TITLE
Add *.Rproj for RStudio users

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -6,3 +6,6 @@
 
 # R data files from past sessions
 .Rdata
+
+# RStudio files
+*.Rproj


### PR DESCRIPTION
RStudio - the only real R IDE, and an incredibly commonly used environment for R, particularly since it has git support - uses .Rproj files in projects, that follow the pattern projectname.Rproj. Adding *.Rproj to capture these and exclude them.
