### PR TITLE
added: rules for ignoring precompiled headers for C/C++

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -4,6 +4,10 @@
 *.o
 *.obj
 
+# Precompiled Headers
+*.gch
+*.pch
+
 # Compiled Dynamic libraries
 *.so
 *.dylib

--- a/C.gitignore
+++ b/C.gitignore
@@ -4,6 +4,10 @@
 *.obj
 *.elf
 
+# Precompiled Headers
+*.gch
+*.pch
+
 # Libraries
 *.lib
 *.a


### PR DESCRIPTION
What's precompiled headers: http://en.wikipedia.org/wiki/Precompiled_header

`*.gch` for GCC, see https://gcc.gnu.org/onlinedocs/gcc/Precompiled-Headers.html
`*.pch` for MSVC, see http://msdn.microsoft.com/en-us/library/szfdksca.aspx
