### PR TITLE
Django (Python Web Framework) Added

### DIFF
--- a/Django.gitignore
+++ b/Django.gitignore
@@ -1,0 +1,40 @@
+# Python bytecode:
+*.py[co]
+
+# Packaging files:
+*.egg*
+
+# Sphinx docs:
+build
+
+# SQLite3 database files:
+*.db
+
+# Logs:
+*.log
+
+# Eclipse
+.project
+.pydevproject
+.settings
+
+# Linux Editors
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+.elc
+auto-save-list
+tramp
+.\#*
+*.swp
+*.swo
+
+# Mac
+.DS_Store
+._*
+
+# Windows
+Thumbs.db
+Desktop.ini
+


### PR DESCRIPTION
Django is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.

Hi there, I just added proper rules to gitignore required for Django, the references are:

Website - https://www.djangoproject.com/
Documentation - https://docs.djangoproject.com
Github Repository - https://github.com/django/django

This gitignore for django is used in the most famous Django Book **Two Scoops of Django** -
https://github.com/twoscoops/django-twoscoops-project
