### PR TITLE
Updated Grails.gitignore.

### DIFF
--- a/Grails.gitignore
+++ b/Grails.gitignore
@@ -1,4 +1,4 @@
-# .gitignore for Grails 1.2 and 1.3
+# .gitignore for Grails 2.*
 
 # web application files
 /web-app/WEB-INF/classes
@@ -14,6 +14,7 @@
 /stacktrace.log
 /test/reports
 /logs
+*.log
 
 # project release file
 /*.war
@@ -28,3 +29,14 @@
 
 # "temporary" build files
 /target
+
+# project specific settings
+/.settings
+/.classpath
+/.project
+
+# Windows thumbnail dbs
+*Thumbs.db
+
+# Mac folder files
+*.DS_Store


### PR DESCRIPTION
Updated Grails.gitignore for 2.*.
Added project specific files which get created when the project is converted to a Grails project.
Added additional OS specific file ignores.
