### PR TITLE
Copied Vim .gitignore from Global to main folder

### DIFF
--- a/Vim.gitignore
+++ b/Vim.gitignore
@@ -1,0 +1,6 @@
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~


### PR DESCRIPTION
As a Vim user,
I want the option of choosing a Vim .gitignore
so that when I create a new repo that does not fit any of the other types,
or when I create a new VimL repo, I have a good starter .gitignore.

Basically, Vim has a language; it's not just an environment.

I copied the file that was in `Global/` to the main area.
