### PR TITLE
Update Jekyll.gitignore

### DIFF
--- a/Jekyll.gitignore
+++ b/Jekyll.gitignore
@@ -1,1 +1,2 @@
 _site/
+.sass-cache/


### PR DESCRIPTION
.sass-cache directory is ignored by default (ref: jekyll/jekyll@9df020f7e971bfdbe9d858cb2105d9b1baf760bc)
