### PR TITLE
[Rails] Added .swp, .DS_Store files and bin directory

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -1,15 +1,18 @@
 *.rbc
 capybara-*.html
 .rspec
+/bin
 /log
 /tmp
 /db/*.sqlite3
 /public/system
 /coverage/
 /spec/tmp
+*.swp
 **.orig
 rerun.txt
 pickle-email-*.html
+.DS_Store
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb


### PR DESCRIPTION
bin - artifacts directory with binaries, created by `bundle install --binstubs` command
Many rails developers are using mac and vim, so I added
.swp - temporary files, created by vim
.DS_Store - files, created by MacOS(when using `open *somedir*` for example)
