### PR TITLE
Add .qm files to Momentics.gitignore

### DIFF
--- a/Global/Momentics.gitignore
+++ b/Global/Momentics.gitignore
@@ -2,3 +2,4 @@
 x86/
 arm/
 arm-p/
+translations/*.qm


### PR DESCRIPTION
Translations for BlackBerry 10 Cascades/Native apps begin as source .ts files (which should be in a Git repo). During compilation, the IDE compiles these .ts files into binary .qm files (which should not be in a Git repo). Running a build clean gets rid of translations/*.qm (like it does for everything else in Momentics.gitignore), so adding this to the .gitignore keeps the source pristine.

Relevant: http://developer.blackberry.com/native/documentation/cascades/device_platform/internationalization/localization.html (section "Create Translation Files)
