### PR TITLE
Add sourcemaps to the Sass ignore

### DIFF
--- a/Sass.gitignore
+++ b/Sass.gitignore
@@ -1,1 +1,2 @@
 .sass-cache
+*.css.map


### PR DESCRIPTION
When merging branches there are usually conflicts with the CSS sourcemaps. It's not an issue to just recompile the CSS to generate a new sourcemap but having the file ignored helps to save an unnecessary step.
