### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -6,7 +6,6 @@ packages
 
 # Or the files created by dart2js.
 *.dart.js
-*.dart.precompiled.js
 *.js_
 *.js.deps
 *.js.map


### PR DESCRIPTION
Dart2js (Dart's JavaScript compiler) no longer creates `foo.dart.precompiled.js` files when compiling.
