### PR TITLE
Create m2e.gitignore

### DIFF
--- a/m2e.gitignore
+++ b/m2e.gitignore
@@ -1,0 +1,2 @@
+.classpath
+.project


### PR DESCRIPTION
This makes sense when using Maven and eclipse (with m2e plugin).

I'm not sure if it makes sense to put it in `maven.gitignore` (since I could use maven but not use eclipse at all), and it doesn't make sense as `eclipse.gitignore`, because not everyone uses maven.

Either way, when using eclipse and maven, it doesn't make sense to not ignore those files.

There is no official documentation regarding this subject, but it is a common practice.

Please see #1211 for details.