### PR TITLE
update comment on ignoring repositories.config

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -137,7 +137,7 @@ publish/
 **/packages/*
 # except build/, which is used as an MSBuild target.
 !**/packages/build/
-# If using the old MSBuild-Integrated Package Restore, uncomment this:
+# Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
 
 # Windows Azure Build Output


### PR DESCRIPTION
Wait for https://github.com/NuGet/NuGetDocs/pull/275 to merge before merging.

As mentioned in https://github.com/NuGet/NuGetDocs/pull/262#issuecomment-56222507 "it's actually okay to omit the `repositories.config` from source control, as NuGet will re-generate it when you open the solution again." It appears newer versions of NuGet do not require this file.

/cc @arcresu as you made previous change in https://github.com/github/gitignore/commit/ced2a153472c60d905522041d27874c6a36d60a7 & discussed at https://github.com/github/gitignore/pull/1131#issuecomment-48265224.
