### PR TITLE
Ignore HPC files generated by GHC

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -5,6 +5,7 @@ cabal-dev
 *.chi
 *.chs.h
 .virtualenv
+.hpc
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config


### PR DESCRIPTION
"GHC creates a subdirectory .hpc in the current directory, and puts HPC index (.mix) files in there..."

https://www.haskell.org/ghc/docs/7.4.2/html/users_guide/hpc.html
