### PR TITLE
Add user-specific settings to Momentics.gitignore

### DIFF
--- a/Global/Momentics.gitignore
+++ b/Global/Momentics.gitignore
@@ -3,3 +3,6 @@ x86/
 arm/
 arm-p/
 translations/*.qm
+
+# IDE settings
+.settings/


### PR DESCRIPTION
The .settings folder contains all of the user-specific preferences for Momentics (like it does for Eclipse, since they're the same underneath). Should be local only.
