### PR TITLE
Add ocamlbuild and oasis generated files to OCaml .gitignore

### DIFF
--- a/OCaml.gitignore
+++ b/OCaml.gitignore
@@ -7,3 +7,14 @@
 *.cmx
 *.cmxs
 *.cmxa
+
+# ocamlbuild working directory
+_build/
+
+# ocamlbuild targets
+*.byte
+*.native
+
+# oasis generated files
+setup.data
+setup.log


### PR DESCRIPTION
OCamlbuild (http://caml.inria.fr/pub/docs/manual-ocaml/ocamlbuild.html) and Oasis (http://oasis.forge.ocamlcore.org/) are very popular build automation tools for OCaml, often used together (roughly equivalent to make and autotools).
_build is where ocamlbuild keeps copies of the source files and compiled binaries, *.native and *.byte are compiled targets (native and bytecode respectively). setup.log and setup.data are oasis log and current build environment config.

ocaml.org oasis tutorial page recommends ignoring these files too: https://ocaml.org/learn/tutorials/setting_up_with_oasis.html#Otheroptionalsections