### PR TITLE
Update Umbraco.gitignore

### DIFF
--- a/Umbraco.gitignore
+++ b/Umbraco.gitignore
@@ -14,4 +14,4 @@ Cached/
 # Don't ignore Umbraco packages (VisualStudio.gitignore mistakes this for a NuGet packages folder)
 # Make sure to include details from VisualStudio.gitignore BEFORE this
 !**/App_Data/[Pp]ackages/
-!**/[Uu]mbraco/developer/[Pp]ackages
+!**/[Uu]mbraco/[Dd]eveloper/[Pp]ackages


### PR DESCRIPTION
!**/[Uu]mbraco/developer/[Pp]ackages doesn't always work, because sometimes the /umbraco/developer directory name starts with a capital "D".
