### PR TITLE
Added New Files created by Crashlytics Plugin

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -42,5 +42,5 @@ atlassian-ide-plugin.xml
 
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
-/crashlytics.properties
-/crashlytics-build.properties
+crashlytics.properties
+crashlytics-build.properties


### PR DESCRIPTION
@Crashlytics keeps on updating their gradle [plugin](https://www.crashlytics.com/downloads/gradle) to make life easier. After the recent [August](http://www.crashlytics.com/blog/crashlytics-august-update/) update they added some more flexibility for custom builds. This resulted in some ~~more~~ extra files being generated for the user.  
The `crashlytics.properties` file contains the secret and can [alternatively](https://plus.google.com/+AntonioBertucci/posts/S9krjvXfgfm) contain the apikey to rid your repo of the extra strings file. `crashlytics-build.properties` is updated constantly with info that is (seemingly) useful to someone but has no value in source control.  
These files can be found in multiple locations, hence the `**` to catch all instances of both files.
