### PR TITLE
Restore original comment about node_modules

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -20,7 +20,6 @@ coverage
 build/Release
 
 # Dependency directory
-# Deployed apps should consider commenting this line out:
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
 


### PR DESCRIPTION
Not ignoring node_modules is not the opinion of "some people", it's a conditional circumstance. Even proponents of checking node_modules into Git agree that you shouldn't do it when you're writing a module to be included as a dependency on npmjs.org: the advantage of checking node_modules into Git is only for fully-packaged apps, which is why the original comment was what it was.
