### PR TITLE
Explain .lock-wscript and move it

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -16,6 +16,9 @@ coverage
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
+# node-waf configuration
+.lock-wscript
+
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
@@ -23,6 +26,3 @@ build/Release
 # Commenting this out is preferred by some people, see
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
-
-# Users Environment Variables
-.lock-wscript


### PR DESCRIPTION
This changes the comment to better explain what .lock-wscript is for (it's for the [obsolete](http://blog.nodejs.org/2012/06/25/node-v0-8-0/) node-waf build system, not "Users Environment Variables"), and moves it next to the other ignore pattern(s) for binary module compilation artifacts.
