### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+#Cloud9
+.c9/


### PR DESCRIPTION
Added line to remove configuration files from Cloud 9 web IDE.  (see https://c9.io)

This IDE has started putting config files in a .c9 folder.

I'm not sure if this is only in python files from repositories used in that IDE.
