### PR TITLE
adding bower_components

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -159,6 +159,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 node_modules/
+bower_components/
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
For ASP.NET vNext we are going to be adding support for bower/node. `node_modules` folder is already excluded, I've added an entry for  `bower_components`.
