### PR TITLE
JavaWithMaven

### DIFF
--- a/JavaWithMaven.gitignore
+++ b/JavaWithMaven.gitignore
@@ -1,4 +1,5 @@
 # Maven stuff
+
 target/
 pom.xml.tag
 pom.xml.releaseBackup
@@ -8,7 +9,8 @@ release.properties
 
 *.class
 
-# Java stuff 
+# Java stuff
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 


### PR DESCRIPTION
I've unified the Java and Maven .gitignore file, because Java and Maven is often used together, so developers can use this .gitignore without modifications.
