### PR TITLE
update ignore for mac & Android Studio files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,3 +1,20 @@
+### Mac ###
+
+.DS_Store
+
+### Android Studio ###
+
+# Intellij project files
+*.iml
+*.ipr
+*.iws
+.idea/
+ 
+# Local IDEA workspace
+.idea/workspace.xml
+
+### Android ###
+
 # Built application files
 *.apk
 *.ap_


### PR DESCRIPTION
Added the android studio related files and the mac specific files (.DS_Store).

This file should be complete now for Android development on a mac using Android Studio instead of Eclipse ADT.
