### PR TITLE
Added AppCode files to Objective-C gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -28,3 +28,6 @@ DerivedData
 #AppCode
 .idea/
 *.iml
+
+#OSX Specific
+.DS_Store


### PR DESCRIPTION
A lot of us are using AppCode (https://www.jetbrains.com/objc/) to develop Objective-C applications. We should add the AppCode specific project files to the Objective-C gitignore file.
