### PR TITLE
Adding .cask directory to Global/Emacs.gitignore

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -27,3 +27,6 @@ tramp
 
 # AUCTeX auto folder
 /auto/
+
+# cask packages
+.cask/


### PR DESCRIPTION
adding line to remove cask package direcotory from cask (see: https://github.com/cask/cask)

cask is a dependency / package management tool for Emacs lisp packages.
