### PR TITLE
Added Cider's .nrepl-port file.

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 .lein-repl-history
 .lein-plugins/
 .lein-failures
+.nrepl-port


### PR DESCRIPTION
[Cider](https://github.com/clojure-emacs/cider) is a Clojure IDE and REPL for Emacs which uses [nrepl](https://github.com/clojure/tools.nrepl) to communicate with a remote REPL. The `.nrepl-port` file contains the port of the current nrepl connection and it will exist when Cider is running.
