### PR TITLE
Ignore iml file anywhere

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,6 +1,6 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
 
-/*.iml
+*.iml
 
 ## Directory-based project format:
 .idea/


### PR DESCRIPTION
Intellij's iml file can be anywhere on the path.
This is true for multi-module maven project where each module has its own $projectName.iml file in its own directory.
