### PR TITLE
Create TortoiseGit.gitignore

### DIFF
--- a/Global/TortoiseGit.gitignore
+++ b/Global/TortoiseGit.gitignore
@@ -1,0 +1,2 @@
+# Project-level settings
+/.tgitconfig


### PR DESCRIPTION
**Link to the application homepage:**
http://tortoisegit.org/

**Link to documentation:**
http://tortoisegit.org/docs/tortoisegit/tgit-dug-settings.html#tgit-dug-settings-hierachical
Here the documentation talks about the `/.tgitconfig` file which is proposed to be ignored. That file is stored by the application if some settings are saved at Project level.

**Why you’re making a change:**
Because I think that the `.tgitconfig` file contains some personal settings which shouldn't be committed to a repo. It's something similar to the `.git/config` file.
