### PR TITLE
Ignore everything in dist/ except dist/resources/.

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -1,4 +1,5 @@
-dist
+dist/*
+!dist/resources/
 cabal-dev
 *.o
 *.hi


### PR DESCRIPTION
See http://www.haskell.org/haskellwiki/Structure_of_a_Haskell_project.

The page above proposes storing non-source stuff used by the program in dist/resources.  This change ignores everything in dist/ (presumably generated by cabal) except the contents of dist/resources.
