### PR TITLE
Create CodeKit.gitignore

### DIFF
--- a/Global/CodeKit.gitignore
+++ b/Global/CodeKit.gitignore
@@ -1,0 +1,3 @@
+# General CodeKit files to ignore
+config.codekit
+/min


### PR DESCRIPTION
A .gitignore file specific to CodeKit, a Mac OS-only complier/server/manager app.

For every project started in, or added into, CodeKit a config.codekit file is automatically generated and placed in the root directory. This file has no purpose or need outside of CodeKit.

CodeKit also automatically minifies scripts, adds a min directory, and places minified files in it. This is fine locally, but I try not to push up anything I don't have to.

I don't do a lot of pull requests, so please let me know if there's anything else you need from me; I don't want to come off as pushy :stuck_out_tongue_winking_eye: 
