### PR TITLE
User-specific files for MonoDevelop/Xamarin Studio.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -7,6 +7,9 @@
 *.userosscache
 *.sln.docstates
 
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
Template for Visual Studio suits almost perfectly for MonoDevelop/Xamarin Studio .NET projects aswell. One thing that the template doesn't cover is MonoDevelop/Xamarin Studio user preferences file.