### PR TITLE
R.gitignore - exclude vignettes products

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -6,3 +6,7 @@
 
 # RStudio files
 .Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf


### PR DESCRIPTION
R vignettes are kind of tutorials. They often contains binary image content and there is not point to version vignette result, only the vignette scripts versioning makes sense.
