### PR TITLE
Added a gitignore for Anjuta IDE http://anjuta.org/

### DIFF
--- a/Global/Anjuta.gitignore
+++ b/Global/Anjuta.gitignore
@@ -1,2 +1,3 @@
-# Local configuration folder
+# Local configuration folder and symbol database
 /.anjuta/
+/.anjuta_sym_db.db


### PR DESCRIPTION
Anjuta is an IDE designed for the GNOME project which homepage is http://anjuta.org/

The page describing the `.anjuta` folder is https://developer.gnome.org/anjuta-manual/stable/project-import.html.en Essentially, it says:

>  Anjuta's own settings are stored in a file with the .anjuta extension and a hidden directory created in the project directory.

This gitignore file will ignore the per-user settings folder. A project specific settings are stored in a file named by the project name and ending with `.anjuta`.
