### PR TITLE
ArchLinuxPackages: Ignore AUR metadata (.AURINFO)

### DIFF
--- a/ArchLinuxPackages.gitignore
+++ b/ArchLinuxPackages.gitignore
@@ -5,5 +5,9 @@
 *.log
 *.log.*
 *.sig
+
+# AUR metadata
+.AURINFO
+
 pkg/
 src/


### PR DESCRIPTION
.AURINFO is new piece of metadata that is generated when creating a source tar ball to submit to the AUR.

https://wiki.archlinux.org/index.php/AUR_Metadata
