### PR TITLE
added JDeveloper.gitignore

### DIFF
--- a/Global/JDeveloper.gitignore
+++ b/Global/JDeveloper.gitignore
@@ -1,0 +1,4 @@
+.data/
+temp/
+classes/
+cwallet.sso.lck


### PR DESCRIPTION
The .gitignore file for [Oracle JDeveloper](http://www.oracle.com/technetwork/developer-tools/jdev/overview/index.html).

.data/

The directory used by the [IDE Performance Cache](http://andrejusb.blogspot.com/2011/11/jdeveloper-11g-r2-ide-application.html) feature of Oracle JDeveloper, usually under the root directory of the application.

![ide-performance-cache](https://cloud.githubusercontent.com/assets/3736028/4786415/13e4e248-5d94-11e4-925f-a94c81c0efcd.png)

![ide-performance-cache-data](https://cloud.githubusercontent.com/assets/3736028/4786416/41872364-5d94-11e4-9ab8-9d8f5ba190dd.png)

temp/

The directory used for ADF styles caching, usually under the WEB-INF/ directory in the web content directory of the view project. It gets created once you open a page in the Design mode.

![adf-styles-cache](https://cloud.githubusercontent.com/assets/3736028/4786417/50451744-5d94-11e4-8821-675dfae7b8e3.png)

classes/

The default Output Directory for fusion web application projects.

cwallet.sso.lck

The lock file for cwallet.sso which is a part of [Credential Store Framework](http://docs.oracle.com/middleware/1213/idm/app-security/devcsf.htm).
