### PR TITLE
Create PVS.gitignore

### DIFF
--- a/PVS.gitignore
+++ b/PVS.gitignore
@@ -1,0 +1,15 @@
+# Ignore binary files
+pvsbin/
+bin/
+lib/
+*.bin
+.pvscontext
+# Ignore orphaned and old proofs
+orphaned-proofs.prf
+*.prf~
+# Ignore compiled Lisp files
+*fasl
+# Ignore PVS dump files
+*.dmp
+# Ignore PVS log files
+*.log


### PR DESCRIPTION
The Prototype Verification System (PVS) http://pvs.csl.sri.com is an interactive theorem prover developed by the non-for-profit organization SRI International (http://www.sri.com). PVS is open source (under the GPL license) and it's widely used by many academic, government, and commercial organizations. Documentation about PVS can be found at http://pvs.csl.sri.com/documentation.shtml. The reasons for ignored the proposed files are the following:
- Binary files: These files are re-created by the PVS type-checker and they are specific to the OS.
- Orphaned and old proofs: The PVS prover generate this files every time that a theory is proven.
- Compiled lisp files: PVS Lisp extensions are compiled every time the system is executed. The compiled file are specific to the compiler.
- Dump files: These files are usually large, but they can easily being recreated from PVS.
- Some PVS tools such as proveit and prooflite generate log files, for debugging purposes.  
