### PR TITLE
Update Leiningen.gitignore

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -10,4 +10,4 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
-.lein-env
+/.lein-*


### PR DESCRIPTION
.lein-env generated by lein-environ for environ to be used in testing and dev environment.
In production environment variables should be used, there for .lein-env should not be in repository's history at all.
