### PR TITLE
Added Haskell GHC profiling related files

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -10,3 +10,6 @@ cabal-dev
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
+*.prof
+*.aux
+*.hp


### PR DESCRIPTION
```
*.prof
*.aux
*.hp
```

Are generated when you are generating data, particularly for the generation of postscript graphs of the memory usage, with GHC's profiling support.
