### PR TITLE
adding dynamically linked haskell libraries

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -4,6 +4,8 @@ cabal-dev
 *.hi
 *.chi
 *.chs.h
+*.dyn_o
+*.dyn_hi
 .virtualenv
 .hpc
 .hsenv


### PR DESCRIPTION
Adding gitignore for Haskell files generated by dynamically linking against Haskell libraries. These are commonly seen when compiling Template Haskell code.
