### PR TITLE
remove *.nupkg rule.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -132,7 +132,7 @@ publish/
 *.publishproj
 
 # NuGet Packages
-*.nupkg
+# *.nupkg
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.


### PR DESCRIPTION
because nuget packages are in the "packages" directory, so it can be ignored normally by rule "*_/packages/_", so the "_.nupkg" rule is not necessary.
But some repositories keep some nuget packages of release version, if the "_.nupkg" rule exists, the packages will be ignored.
