### PR TITLE
add VENV or venv

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -52,3 +52,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Virtualenv folder
+venv/
+VENV/


### PR DESCRIPTION
python programers usually add a folder called venv or VENV and ignore them

http://docs.python-guide.org/en/latest/dev/virtualenvs/

so add it in .gitignore may be good
