### PR TITLE
Added *.sqlite3-journal to Rails.gitignore

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -4,6 +4,7 @@ capybara-*.html
 /log
 /tmp
 /db/*.sqlite3
+/db/*.sqlite3-journal
 /public/system
 /coverage/
 /spec/tmp


### PR DESCRIPTION
I added `/db/*.sqlite3-journal` to `Rails.gitignore`.

For example, when tests are interrupted, this file exists.
And refer to the following, which is the gitignore template in rails.
https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/gitignore
