### PR TITLE
Avoid ignoring Gradle wrapper jar file

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -3,3 +3,6 @@ build/
 
 # Ignore Gradle GUI config
 gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar


### PR DESCRIPTION
This is added because .jar files are usually ignored (see Java.gitignore).
Nevertheless, the gradle-wrapper.jar should be committed to VCS.

See http://www.gradle.org/docs/current/userguide/gradle_wrapper.html for an explaination of Gradle wrapper and related files.
In particular, the Gradle doc says: `All of these files should be submitted to your version control system`.

This is most useful when Gradle is used in a Java project, which happens most of the times IMHO. In any case, this exclusion shouldn't cause any issue in non-Java project.