### PR TITLE
Ignore some auxiliary files from knitr

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -69,6 +69,11 @@
 # hyperref
 *.brf
 
+# knitr
+*-concordance.tex
+*.tikz
+*-tikzDictionary
+
 # listings
 *.lol
 


### PR DESCRIPTION
[`knitr`](http://yihui.name/knitr/) is an R package that can be used to compile a `.Rnw` file containing both LaTeX and R source code to a `.tex` file, which can then be further compiled to a `.pdf` file with your favorite TeX engine. When the R source code generates images (e.g., a graph), it will create some auxiliary files, including `.tikz` file(s) and a `BASEFILENAME-tikzDictionary` file (at least if the `dev` chunk option is set to `'tikz'`). Additionally, if `opts_knit$get('concordance')` is `TRUE`, then an auxiliary `BASEFILENAME-concordance.tex` file is generated. None of these things need to be tracked with version control.