### PR TITLE
Ignore auto directory from AUCTeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -39,6 +39,9 @@
 # amsthm
 *.thm
 
+#AUCTeX
+auto/
+
 # beamer
 *.nav
 *.snm


### PR DESCRIPTION
[AUCTeX](http://www.gnu.org/software/auctex/) is a common Emacs package for editing `.tex` files.

One option that is common and is recommended in the [Quick Start](http://www.gnu.org/software/auctex/manual/auctex.html#Quick-Start) is to set

```
(setq TeX-auto-save t)
(setq TeX-parse-self t)
```

because this:

> get[s] support for many of the LaTeX packages you will use in your documents

This [leads to](http://www.gnu.org/software/auctex/manual/auctex/Multifile.html)

> AUCTeX keep[ing] track of macros, environments, labels, and style files that are used in a given document [by] having an ‘`auto`’ subdirectory placed in the directory where your document is located. Each time you save a file, AUCTeX will write information about the file into the ‘`auto`’ directory. When you load a file, AUCTeX will read the information in the ‘`auto`’ directory about the file you loaded

So, basically, this `auto/` directory just contains some `.el` files that contain autocompletion information for macros that might be used in the `.tex` file. There's no need to track this stuff with `git`.
