### PR TITLE
add rules for new CakePHP 3

### DIFF
--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -7,10 +7,7 @@ CakePHP 3
 
 CakePHP 2
 
-tmp/*
-[Cc]onfig/core.php
-[Cc]onfig/database.php
-app/tmp/*
-app/[Cc]onfig/core.php
-app/[Cc]onfig/database.php
-!empty
+/app/tmp/*
+/app/Config/core.php
+/app/Config/database.php
+/vendors/*

--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -1,3 +1,12 @@
+CakePHP 3
+
+/vendor/*
+/config/app.php
+/tmp/*
+/logs/*
+
+CakePHP 2
+
 tmp/*
 [Cc]onfig/core.php
 [Cc]onfig/database.php


### PR DESCRIPTION
This is a demand for [CakePHP framework](http://cakephp.org)
The skeleton of a CakePHP 3 application can be found in [CakePHP docs](http://book.cakephp.org/3.0/en/installation.html#production)

The .gitignore file can be found directly in the project:
- CakePHP 3 : https://github.com/cakephp/app/blob/master/.gitignore

As discussed on github [here](https://github.com/cakephp/docs/issues/2027#issuecomment-63729955), we would like to add the .gitignore rules for the new CakePHP 3 version.

Thanks