### PR TITLE
TestingTools gitignore file added

### DIFF
--- a/TestingTools.gitignore
+++ b/TestingTools.gitignore
@@ -1,0 +1,15 @@
+#
+# This .gitignore file aims to avoid all those files and folders generated
+# by testing tools such as 'SonarQube', 'PyCov' and so on
+#
+
+# SonarQube
+.sonar
+sonar-project.properties
+
+# Sphinx
+doc/build
+doc/make.bat
+
+# PyCov
+.coverage


### PR DESCRIPTION
This .gitignore file aims to avoid those autogenerated files and folders from testing tools such as SonarQube, Sphinx, PyCov... It's not a complete file, but if everyone add some of those files that they have to ignore manually, the file will be useful for a wider range of developers.

For me it works fine as I use mostly these tools in my projects, but of course there must a lot more.
