### PR TITLE
Revert "adding entry for ignoring <solutionname>.sln.ide folder which contains visual studio 2015 solution specific cache data"

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -7,9 +7,6 @@
 *.userosscache
 *.sln.docstates
 
-# User-specific folders
-*.sln.ide/
-
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
This reverts commit b07a0904e3c0714353f997b1dc6122b367dab648

There's an entry for `*.ide/` and I cannot see what the point of `*.sln.ide/` is.

https://github.com/github/gitignore/blob/master/VisualStudio.gitignore#L26.
