### PR TITLE
In TeX.gitignore: added *.rel for RefTeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -92,6 +92,9 @@
 # nomencl
 *.nlo
 
+# RefTeX
+*.rel
+
 # sagetex
 *.sagetex.sage
 *.sagetex.py


### PR DESCRIPTION
The RefTeX package (part of AUCTeX) generates a *.rel auxiliary file for references/labels/citations.
