### PR TITLE
Add history file that is generated by R.app for Mac OS

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -1,5 +1,6 @@
 # History files
 .Rhistory
+.Rapp.history
 
 # Example code in package build process
 *-Ex.R


### PR DESCRIPTION
In section 2.4.10 of the [R for Mac OS X FAQ](http://cran.r-project.org/bin/macosx/RMacOSX-FAQ.html), it is noted that `R.app` uses an `.Rapp.history` file for saving the history of an R session rather than an `.Rhistory` file.
