### PR TITLE
Add HaxeFlixel to Global

### DIFF
--- a/Global/HaxeFlixel.gitignore
+++ b/Global/HaxeFlixel.gitignore
@@ -1,0 +1,4 @@
+# HaxeFlixel - A port of Flixel to Haxe using OpenFL. http://haxeflixel.com/
+
+# Ignore the output folder where binaries are created
+output/


### PR DESCRIPTION
HaxeFlixel is a port of the popular Flash Library Flixel to the language Haxe. It enables developers to build their games natively to Linux, Windows, OSX, Android, iOS, Neko, Ouya, Flash and BlackBerry.

Homepage: http://haxeflixel.com/