### PR TITLE
Add Apache Cordova gitignore

### DIFF
--- a/ApacheCordova.gitignore
+++ b/ApacheCordova.gitignore
@@ -1,0 +1,5 @@
+# Generated build files
+bld/
+
+# Generated binaries etc
+bin/


### PR DESCRIPTION
Project URL: http://cordova.apache.org
Documentation: http://cordova.apache.org/docs/en/4.0.0/
Reason: Cordova being used more often, partly due to it being integrated into the latest version of Visual Studio
