### PR TITLE
update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -52,3 +52,10 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# SonarQube
+.sonar
+sonar-project.properties
+
+# PyCov
+.coverage


### PR DESCRIPTION
I have been testing Python apps lately, as a consequence I realized that Python.gitignore does not provide anything for that, and you have to add it manually. I have added some lines that will ignore files from SonarQube and PyCov.
