### PR TITLE
Added Castalia *.stat files

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -52,3 +52,6 @@
 # Delphi history and backups
 __history/
 *.~*
+
+# Castalia statistics file
+*.stat


### PR DESCRIPTION
Castalia is a free plugin for Delphi since XE7 and it's distributed by Embarcadero with Delphi XE7. It uses *.stat files to save statistics of the IDE usage for each project (compile time, debug time etc.)

It is safe to delete it, and it is useless to move *.stat files between developers (each developer has its own IDE statistics).