### PR TITLE
Create IGORPro.gitignore

### DIFF
--- a/IGORPro.gitignore
+++ b/IGORPro.gitignore
@@ -1,0 +1,5 @@
+# Avoid including Experiment files: they can be created and edited locally to test the ipf files
+*.pxp
+*.pxt
+*.uxp
+*.uxt


### PR DESCRIPTION
.gitignore template file for repositories of Wavemetrics IGOR Pro functions (.ipf files).