### PR TITLE
root sitemap.xml

### DIFF
--- a/Magento.gitignore
+++ b/Magento.gitignore
@@ -104,6 +104,7 @@ shell/abstract.php
 shell/compiler.php
 shell/indexer.php
 shell/log.php
+sitemap.xml
 skin/adminhtml/default/default/
 skin/adminhtml/default/enterprise
 skin/frontend/base/


### PR DESCRIPTION
The Magento production is configured to automatically generate the sitemap.xml, as is the url is taken as a base, it is important to be ignored.