### PR TITLE
Global JDeveloper.gitignore

### DIFF
--- a/Global/JDeveloper.gitignore
+++ b/Global/JDeveloper.gitignore
@@ -1,6 +1,13 @@
+# default application storage directory used by the IDE Performance Cache feature
 .data/
+
+# used for ADF styles caching
 temp/
+
+# default output directories
 classes/
 deploy/
 javadoc/
+
+# lock file, a part of Oracle Credential Store Framework
 cwallet.sso.lck

--- a/Global/JDeveloper.gitignore
+++ b/Global/JDeveloper.gitignore
@@ -1,4 +1,6 @@
 .data/
 temp/
 classes/
+deploy/
+javadoc/
 cwallet.sso.lck


### PR DESCRIPTION
added comments and the following two entries:

deploy/
javadoc/

Both are default output directories for JDeveloper applications and projects.