### PR TITLE
VisualStudio.gitignore: no good reason to ignore sql folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -148,7 +148,6 @@ csx/
 AppPackages/
 
 # Others
-sql/
 *.Cache
 ClientBin/
 [Ss]tyle[Cc]op.*


### PR DESCRIPTION
Remove ignoring of folders called `sql`. No particularly good reason exists to ignore all folders named `sql`. 
