### PR TITLE
Unity3D - Cache files, solution settings files and meta file update

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -19,4 +19,3 @@
 
 # Unity3D Generated File On Crash Reports
 sysinfo.txt
-

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -7,7 +7,6 @@
 *.csproj
 *.unityproj
 *.sln
-*.sln.DotSettings
 *.suo
 *.tmp
 *.user
@@ -20,8 +19,4 @@
 
 # Unity3D Generated File On Crash Reports
 sysinfo.txt
-
-# General operating system files
-*.DS_STORE
-*.db
 

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -7,7 +7,9 @@
 *.csproj
 *.unityproj
 *.sln
+*.sln.DotSettings
 *.suo
+*.tmp
 *.user
 *.userprefs
 *.pidb
@@ -23,5 +25,3 @@ sysinfo.txt
 *.DS_STORE
 *.db
 
-# Some additional ones
-*.tmp

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -13,5 +13,15 @@
 *.pidb
 *.booproj
 
+# Unity3D generated meta files
+*.pidb.meta
+
 # Unity3D Generated File On Crash Reports
 sysinfo.txt
+
+# General operating system files
+*.DS_STORE
+*.db
+
+# Some additional ones
+*.tmp


### PR DESCRIPTION
Hi! 

I've added the most annoying files that are coming from Mac and Windows: .DS_STORE file and the .db file extension.

Unity3D: http://unity3d.com/
UnityVS former contributer: http://syntaxtree.com/
UnityVS current contributer: http://unityvs.com/ (also syntax tree but ms branded)

Also added three files that occur in Unity3D projects: .tmp, .sln.DotSettings and the .pidb.meta all coming from the IDE VS2013.


Regards
Matthias