### PR TITLE
add ignore achemso bib file (acs-*.bib) to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -36,6 +36,9 @@
 *.alg
 *.loa
 
+# achemso
+acs-*.bib
+
 # amsthm
 *.thm
 


### PR DESCRIPTION
Ignore acs-*.bib, an aux file generated by \documentclass{achemso} or by \usepackage{achemso}

http://ctan.org/pkg/achemso

achemso is a LaTeX package by Joseph Wright that anyone composing an article for the a Journal of the American Chemical Society would use, either for publications or for generating industry-standard bibliographic references.
