### PR TITLE
Time to clean out the .Trash

### DIFF
--- a/Global/Linux.gitignore
+++ b/Global/Linux.gitignore
@@ -2,3 +2,6 @@
 
 # KDE directory preferences
 .directory
+
+# Directories created on removable media
+.[Tt]rash*


### PR DESCRIPTION
Some people may store their repositories on removable media devices, after something is deleted there Linux creates .Trash-UID (user ID) directory, so it has to be included in .gitignore and ignored by Git.
