### PR TITLE
add Keil.gitignore

### DIFF
--- a/Keil.gitignore
+++ b/Keil.gitignore
@@ -1,0 +1,16 @@
+JLinkLog.txt
+*.uvgui.*
+*.bak
+*.dep
+*.log
+*.plg
+*.o
+*.d
+*.crf
+*.tra
+*.axf
+*.hex
+*.lnp
+*.sct
+*.__i
+*.htm


### PR DESCRIPTION
The Keil.gitignore is fit for being used on Keil Project which files need to be ignored.
