### PR TITLE
Add a global redis ignore file.

### DIFF
--- a/Global/Redis.gitignore
+++ b/Global/Redis.gitignore
@@ -1,0 +1,3 @@
+# Ignore redis binary dump (dump.rdb) files
+
+*.rdb


### PR DESCRIPTION
Ignores all .rdb files, (default: dump.rdb).

These files contain a binary representation of the in-memory
redis data that is generated using cli tools or on a redis
failure.

They can be used to restore a redis db, and may contain
sensitive data so should not be saved in version control.