### PR TITLE
Update CakePHP.gitignore for Composer

### DIFF
--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -5,3 +5,5 @@ app/tmp/*
 app/[Cc]onfig/core.php
 app/[Cc]onfig/database.php
 !empty
+# Uncomment if installing Cake core using Composer
+# [Vv]endor/*


### PR DESCRIPTION
Add the Composer vendor folder to the list, commented out by default. For more information see http://book.cakephp.org/2.0/en/installation/advanced-installation.html.