### PR TITLE
Only ignore the node_modules directory in project root.

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -24,4 +24,4 @@ build/Release
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
-node_modules
+/node_modules


### PR DESCRIPTION
.gitignore - node

Ignoring /node_modules, which is populated upon installing an npm module is good. Ignoring lib/node_modules is bad. Having a lib/node_modules directory in your project is optimal if you have submodules in your project you want to reference.

"Furthermore, to make the module lookup process even more optimal, rather than putting packages directly in /usr/lib/node, we could put them in /usr/lib/node_modules/<name>/<version>. Then node will not bother looking for missing dependencies in /usr/node_modules or /node_modules.

In order to make modules available to the node REPL, it might be useful to also add the /usr/lib/node_modules folder to the $NODE_PATH environment variable. Since the module lookups using node_modules folders are all relative, and based on the real path of the files making the calls to require(), the packages themselves can be anywhere."

Ref: http://nodejs.org/api/modules.html#modules_addenda_package_manager_tips