### PR TITLE
Add Eclipse JDT .classpath file, and the Eclipse core .project file

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -11,6 +11,9 @@ local.properties
 .settings/
 .loadpath
 
+# Eclipse Core
+.project
+
 # External tool builders
 .externalToolBuilders/
 
@@ -19,6 +22,9 @@ local.properties
 
 # CDT-specific
 .cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
 
 # PDT-specific
 .buildpath


### PR DESCRIPTION
The current template is missing the .project file which is used by Eclipse core to track which plugins and other settings are configured for the project. It is also missing the .classpath file which is used by the Eclipse Java Development Tools plugin to manage the classpath of builds in the IDE.

There is rarely a good reason to check these files in as .project can have conflicts with other developer's plugin settings, and .classpath is usually managed by a Maven or Gradle IDE plugin.

Supporting information: http://stackoverflow.com/a/14080532