### PR TITLE
Ignore npm-debug.log

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
+
+# Debug log from npm
+npm-debug.log


### PR DESCRIPTION
Makes it so that the debug log from npm gets ignored. The file is typically generated when npm fails in some way.