### PR TITLE
Added a .gitignore template for Lua based projects.

### DIFF
--- a/Lua.gitignore
+++ b/Lua.gitignore
@@ -1,0 +1,41 @@
+# Compiled Lua sources
+luac.out
+
+# luarocks build files
+*.src.rock
+*.zip
+*.tar.gz
+
+# Object files
+*.o
+*.os
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+*.def
+*.exp
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+


### PR DESCRIPTION
Added common ignore globs for Lua, an extensible, high-performace, lightweight multi-paradigm language designed for embedded scripting.

    http://www.lua.org/about.html (More info at https://en.wikipedia.org/wiki/Lua_(programming_language)

The de-facto package manager for Lua is LuaRocks.

     http://luarocks.org/

- LuaRocks creates a number of files as part of the build process.  These are ignored (*.src.rock, *.tar.gz, *.zip)
- Lua modules are conventionally written in C as shared libraries.  Common build artifacts for C projects copied from C.gitignore