### PR TITLE
Mercury.gitignore: Add Mercury.modules

### DIFF
--- a/Mercury.gitignore
+++ b/Mercury.gitignore
@@ -1,4 +1,5 @@
 Mercury/
+Mercury.modules
 *.mh
 *.err
 *.init


### PR DESCRIPTION
The Mercury.modules file can be auto-generated by the Mercury compiler,
as such it appears only in Makefiles, and should therefore be ignored.