### PR TITLE
Ignore the pip self check marker file in a Virtualenv.

### DIFF
--- a/Global/VirtualEnv.gitignore
+++ b/Global/VirtualEnv.gitignore
@@ -6,3 +6,4 @@
 [Ll]ib
 [Ss]cripts
 pyvenv.cfg
+pip-selfcheck.json


### PR DESCRIPTION
The python package manager pip has started writing a state file, and in a virtualenv it gets put just inside the top level of the virtualenv folder (http://pydoc.net/Python/pip/6.0.6/pip.utils.outdated/) (look for pip-selfcheck.json). Here is [a very short discussion of that feature](https://github.com/pypa/pip/issues/2255). (https://github.com/pypa/virtualenv)