### PR TITLE
Ignore all auxiliary LaTeX files.

### DIFF
--- a/LaTeX.gitignore
+++ b/LaTeX.gitignore
@@ -1,0 +1,16 @@
+*.aux
+*.bbl
+*.blg
+*.dtx
+*.ins
+*.fd
+*.dvi
+*.pdf
+*.log
+*.toc
+*.lof
+*.lot
+*.idx
+*.ind
+*.ilg
+*.out


### PR DESCRIPTION
These files are generated by the LaTeX compiler and serve as a cache between compilations. They should not be version controlled.

More information about these file types: http://en.wikibooks.org/wiki/LaTeX/Basics#Ancillary_files
The LaTeX homepage: http://www.latex-project.org/