### PR TITLE
Update TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -26,6 +26,7 @@
 
 ## Build tool auxiliary files:
 *.fdb_latexmk
+*.synctex
 *.synctex.gz
 *.synctex.gz(busy)
 *.pdfsync


### PR DESCRIPTION
*.synctex is generated when the --synctex=-1 option is used. (the minus sign turns off compression)