### PR TITLE
Add .Trash-* to ignore Linux partition or ext disk trash folders

### DIFF
--- a/Global/Linux.gitignore
+++ b/Global/Linux.gitignore
@@ -2,3 +2,6 @@
 
 # KDE directory preferences
 .directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*


### PR DESCRIPTION
- Add .Trash-* to Global/Linux.gitignore
- Ignores trash files which might appear on any external disk or partition.

Linux systems in many cases have a separate partition for /var /home, etc. This ignores the .Trash-* global folder which might appear.