### PR TITLE
Never ignore the wrapper jar

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -3,3 +3,6 @@ build/
 
 # Ignore Gradle GUI config
 gradle-app.setting
+
+#Never ignore the wrapper jar (jars are ignored by Java.gitignore)
+!gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
Jars are ignored by [Java.gitignore](https://github.com/github/gitignore/blob/master/Java.gitignore#L7), but wrapper jar [should be committed to VCS](http://www.gradle.org/docs/current/userguide/gradle_wrapper.html).