### PR TITLE
Add Carthage build folder and explaination

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -24,3 +24,10 @@ DerivedData
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
 # Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build


### PR DESCRIPTION
[Carthage](https://github.com/Carthage/Carthage) is "A simple, decentralized dependency manager for Cocoa", an alternative to [CocoaPods](https://github.com/CocoaPods/CocoaPods). 

These changes support the following recommendations:
- [Carthage/Build does not need to be checked in.](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#carthagebuild)
- [Carthage/Checkouts can optionally be checked in.](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#carthagecheckouts)

Since there's already some content in this gitignore for CocoaPods, Carthage info would be useful.
