### PR TITLE
Add Google App Engine generated folder

### DIFF
--- a/AppEngine.gitignore
+++ b/AppEngine.gitignore
@@ -1,0 +1,2 @@
+# Google App Engine generated folder
+appengine-generated/


### PR DESCRIPTION
Ignore the appengine-generated folder created when running the development server.

https://cloud.google.com/appengine/docs/java/tools/devserver