### PR TITLE
Update Android.gitignore to include Android Studio nav temp files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -25,3 +25,6 @@ proguard/
 
 # Log Files
 *.log
+
+# Android Studio Navigation editor temp files
+.navigation/


### PR DESCRIPTION
Gitignore the temp files directory generated by Android Studio's navigation editor tool.

To generate this directory open a project in Android Studio, then navigate to `tools -> android -> navigation editor`. This directory contains screenshots of the various activities and menues in the project which are used to build a navigation tree.