### PR TITLE
updated Visual Studio gitignore for Cocos2dx

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -3,7 +3,7 @@
 
 # User-specific files
 *.suo
-*.user
+#*.user
 *.userosscache
 *.sln.docstates
 


### PR DESCRIPTION
Using *.user ignores the Game.vsxproj.user file that is part of the project files in the win32 folder of a newly created project using Cocos2dx. The Game.vsxproj.user is needed to allow the project to be executed successfully in Visual Studio 2013 professional.