### PR TITLE
add PyCharm.gitignore

### DIFF
--- a/PyCharm.gitignore
+++ b/PyCharm.gitignore
@@ -1,0 +1,4 @@
+# PyCharm
+# http://www.jetbrains.com/pycharm/webhelp/project.html
+.idea
+.iml


### PR DESCRIPTION
gitignore for JetBrains python IDE.
Application homepage: https://www.jetbrains.com/pycharm/
Added to provide previously unprovided support for the IDE.
see http://www.jetbrains.com/pycharm/webhelp/project.html for documentation of extensions