### PR TITLE
Typo in comment

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -31,5 +31,5 @@ config/secrets.yml
 *.bowerrc
 bower.json
 
-#Ignore pow enironment settings
+# Ignore pow environment settings
 .powenv


### PR DESCRIPTION
I know this is petty, but imagine thousand upon thousand of corrective commits saved by fixing the typo right into the heart of the file.