### PR TITLE
Revert "Ignore npm-debug.log"

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -25,6 +25,3 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
-
-# Debug log from npm
-npm-debug.log


### PR DESCRIPTION
Reverts github/gitignore#1343 for redundancy with the existing `*.log`.