### PR TITLE
Add Tern plugin to Eclipse.gitignore

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -32,5 +32,8 @@ local.properties
 # sbteclipse plugin
 .target
 
+# Tern plugin
+.tern-project
+
 # TeXlipse plugin
 .texlipse


### PR DESCRIPTION
The Tern plugin generate a '.tern-project' file in the project directory. (https://github.com/angelozerr/tern.java/wiki/Tern-Eclipse-IDE)