### PR TITLE
add *.vs/ to ignore VS files in VS15 CTP5

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -22,9 +22,6 @@ bld/
 [Bb]in/
 [Oo]bj/
 
-# Roslyn cache directories
-*.ide/
-
 # Visual Studo 2015 cache/options directory
 .vs/
 

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -25,6 +25,9 @@ bld/
 # Roslyn cache directories
 *.ide/
 
+# Visual Studo 2015 cache/options directory
+.vs/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
As of Visual Studio 2015 CTP5 the Roslyn cache and suo files are stored in a .vs/ directory.