### PR TITLE
ignore new scratch directory for metadata

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -17,3 +17,4 @@ nytprof.out
 /pm_to_blib
 *.o
 *.bs
+/_eumm/


### PR DESCRIPTION
This directory is created by ExtUtils::MakeMaker starting with version
7.05_05, via this commit:
https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/b6a9eba5b0501dbe2fa0568a15dc588b1a289128

It was added to the default MANIFEST.SKIP in ExtUtils::Manifest 1.70, here:
https://github.com/Perl-Toolchain-Gang/ExtUtils-Manifest/commit/e0f44577f84521ded664a41b46021eae95a1a1af