### PR TITLE
add .eggs/ directory to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -13,6 +13,7 @@ develop-eggs/
 dist/
 downloads/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/


### PR DESCRIPTION
Python2.7 creates those files, when installing with `setup.py`.