### PR TITLE
Add npm and bower package folders for ASP.NET 5

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -194,3 +194,8 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+#ASP.NET vNext
+bower_components
+**/wwwroot/lib/*
+node_modules


### PR DESCRIPTION
ASP.NET 5 (aka "vNext") supports bower and npm packages.  The contents of these packages should probably not be checked in to git.