### PR TITLE
ignore /vendor/bundle on Ruby.gitignore

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -22,6 +22,7 @@ build/
 
 ## Environment normalisation:
 /.bundle/
+/vendor/bundle
 /lib/bundler/man/
 
 # for a library or gem, you might want to ignore these files since the code is


### PR DESCRIPTION
I think `/vendor/bundle` should be ignored like [Rails.gitignore](https://github.com/github/gitignore/blob/master/Rails.gitignore#L21).

Many Ruby developers may do `bundle install --path vendor/bundle` even without Rails.