### PR TITLE
Create PSoC.gitignore

### DIFF
--- a/PSoC.gitignore
+++ b/PSoC.gitignore
@@ -1,0 +1,28 @@
+# Ignore the build output directories. 
+
+CortexM3/
+CortexM0/
+Export/
+Generated_Source/
+codegentemp/
+
+# Exclude project files with username extensions implicitly
+
+*.cyprj*
+!*.cyprj
+
+# Ignore the workspace configuration files
+# PSoC Creator 3 uses .cywrk, not .cywsp
+
+*.cywrk*
+*.cywsp*
+
+# Ignore the intermediate output files
+
+*.cycdx
+*.cyfit
+*.rpt
+*.svd
+*timing.html
+
+


### PR DESCRIPTION
This change adds a gitignore file for Cypress PSoC Creator projects, [see here](http://www.cypress.com/psoccreator/) for more information on PSoC Creator.  [Suggestions from Cypress](http://www.cypress.com/?id=4&rID=76644) were used to create the .gitignore file (it didn't exist before).
