### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -53,3 +53,8 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyDev (Eclipse based)
+.metadata/
+.project
+.pydevproject


### PR DESCRIPTION
Add meta data folder and project files of PyDev IDE (http://pydev.org/) to the gitignore file. Checking in project configuration files from your IDE is generally not a good idea.

The IDE is based on Eclipse, so it creates the standard Eclipse .metadata folder and .project project file. Additionally PyDev writes Python specific project settings to .pydevproject.