### PR TITLE
Expand list of root-of-volume dotfiles

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -8,9 +8,13 @@ Icon
 # Thumbnails
 ._*
 
-# Files that might appear on external disk
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
 .Spotlight-V100
+.TemporaryItems
 .Trashes
+.VolumeIcon.icns
 
 # Directories potentially created on remote AFP share
 .AppleDB


### PR DESCRIPTION
In addition to `.Spotlight-V100` and `.Trashes`, the following dotfiles
may appear at the root of all OSX volumes (not just external disks):

- `.DocumentRevisions-V100`: auto-save and versions storage
- `.fseventsd`: file system event storage
- `.Temporaryitems`: temp directory used by some applications instead of `/tmp` and `/var/tmp`
- `.VolumeIcon.icns`: storage of custom icon for volume, if set