### PR TITLE
Add .coverage. to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -37,6 +37,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
When using `coverage -p` to get coverage for test runs in several environments coverage creates files with filenames on the form .coverage.hostname.timestamp. This is often used when testing support for python 2 and 3 with tox.

See the last paragraph in [Combining data files](http://coverage.readthedocs.org/en/latest/cmd.html#combining-data-files) section in the coverage.py documentation for information about the filenaming.