### PR TITLE
Added eZ Publish 4.x (a.k.a 'legacy') .gitignore file.

### DIFF
--- a/EzpublishLegacy.gitignore
+++ b/EzpublishLegacy.gitignore
@@ -1,0 +1,21 @@
+# General var folders, that are being
+# recreated every time you clear cache/
+# or regenerate autoloads.
+/var/autoload/
+/var/cache/
+/var/*/cache/
+/var/*_site/
+/var/log/
+/var/*/log/
+/var/storage/
+/var/test*
+
+# Temporary locations used for updates.
+/bin/linux/ezlupdate
+/bin/win32
+
+# These two exists only if you copy your
+# stack from newer, 5.x eZ Publish version
+# or if you use if from Symfony2 backend.
+/vendor
+/composer.lock


### PR DESCRIPTION
I'd like to add a .gitignore file for eZ Publish 4.x CMS. It's still quite popular, so I was shocked, that it's missing. 

Here are some important links about the project:
* [Home Page](http://ez.no)
* [Downloads page](http://share.ez.no/downloads/downloads)
* [Github page, where you can downloads always up-to-date legacy stack](https://github.com/ezsystems/ezpublish-legacy)
* [Documentation](https://doc.ez.no/eZ-Publish/)
* [Learning area](http://share.ez.no/learn)

I hope that that this .gitignore file will help GitHub users with new eZ Publish 4.x repository creation process.
