### PR TITLE
Ignore Settings.StyleCop

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -154,6 +154,7 @@ AppPackages/
 *.[Cc]ache
 ClientBin/
 [Ss]tyle[Cc]op.*
+*.[Ss]tyle[Cc]op
 ~$*
 *~
 *.dbmdl


### PR DESCRIPTION
When [Resharper.StyleCop](https://github.com/kubiix/ReSharper.StyleCop/) is installed and StyleCop settings are changed, it generates a `Settings.StyleCop` file in the solution folder which should be ignored.