### PR TITLE
Remove cabal.config from Haskell gitignore

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -11,7 +11,6 @@ cabal-dev
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config
-cabal.config
 *.prof
 *.aux
 *.hp


### PR DESCRIPTION
Cabal is a package manager for Haskell (similar to npm for node, pip for python, etc).  You are able to provide a `cabal.config` file in the base of your package to change cabal settings.

The Stackage.org project provides a `cabal.config` which locks in a specific package set.  This file should be shared between developers so that everyone is developing using the same versions of packages.  In order to use it like this, the `cabal.config` file should not be ignored.

Here is a page describing how to use the `cabal.config` provided by Stackage:

http://www.stackage.org/lts

@snoyberg and @chrisdone are running Stackage (as well as being well-known Haskell developers), so it may be a good idea to get their opinion on this.

Here is the cabal documentation.  It doesn't say anything about ignoring the `cabal.config` file:
https://www.haskell.org/cabal/users-guide/installing-packages.html