### PR TITLE
Added backup files for WinEdt

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -117,3 +117,7 @@ sympy-plots-for-*.tex/
 
 # xindy
 *.xdy
+
+# WinEdt
+*.bak
+*.sav


### PR DESCRIPTION
WinEdt (a popular TEX editor for windows) uses files "*.bak" for backup and "*.sav" for autosave.