### PR TITLE
Add an explanation to reduce PHP framework clutter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,11 @@ high quality, we request that contributions adhere to the following guidelines.
 In general, the more you can do to help us understand the change you’re making,
 the more likely we’ll be to accept your contribution quickly.
 
+If a template is mostly a list of files installed by a particular version of
+some software (e.g. a PHP framework) then it's brittle and probably no more
+helpful than a simple `ls`. If it's not possible to curate a small set of
+useful rules, then the template might not be a good fit for this collection.
+
 Please also understand that we can’t list every tool that ever existed.
 Our aim is to curate a collection of the *most common and helpful* templates,
 not to make sure we cover every project possible. If we choose not to

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ high quality, we request that contributions adhere to the following guidelines.
 In general, the more you can do to help us understand the change you’re making,
 the more likely we’ll be to accept your contribution quickly.
 
+If a template is mostly a list of files installed by a particular version of
+some software (e.g. a PHP framework) then it's brittle and probably no more
+helpful than a simple `ls`. If it's not possible to curate a small set of
+useful rules, then the template might not be a good fit for this collection.
+
 Please also understand that we can’t list every tool that ever existed.
 Our aim is to curate a collection of the *most common and helpful* templates,
 not to make sure we cover every project possible. If we choose not to


### PR DESCRIPTION
Several of the templates consist solely of long lists of files which are installed by default by PHP frameworks. These template really aren't all that helpful because they are brittle in that the list of files is specific to a particular version of the software. Having a template for each version seems overkill, and in most cases you would be better off using `ls` or similar to automatically produce such a gitignore, if that's what you need.

See also #985 for my previous explanation of this problem. If we agree that this is a problem, then I propose to delete the templates which currently follow this pattern. If there is a way to curate a small, useful set of rules about these projects, then people can re-introduce them in new PRs, but the current list of rules seem unsalvageably messy in most cases.
- [Magento](https://github.com/github/gitignore/blob/eaeed89430318d8b04bc4734bd07190aaaeb29bd/Magento.gitignore)
- [Joomla](https://github.com/github/gitignore/blob/2b1fe3e280dbb0a53f5c5906ac0f3f6fd0e44dab/Joomla.gitignore)
- Drupal
- LemonStand
- SugarCRM
- Symfony
- ZendFramework
