### PR TITLE
Add "*.out" to Go.gitignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+*.out

--- a/Go.gitignore
+++ b/Go.gitignore
@@ -23,4 +23,5 @@ _testmain.go
 *.test
 *.prof
 
+# Output of the go coverage tool, specifically when used with LiteIDE
 *.out


### PR DESCRIPTION
The IDE LiteIDE creates a file named "cover.out" when using the go coverage tool for your tests.