### PR TITLE
Added jet

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -54,3 +54,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# JetBrains PyCharm, WebStorm, etcc..
+.idea/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -56,4 +56,4 @@ docs/_build/
 target/
 
 # JetBrains PyCharm, WebStorm, etcc..
-.idea/
+.idea/workspace.xml


### PR DESCRIPTION
Added jetbrains pycharm's .idea/workspace.xml folder to gitignore, it is strictly system dependant making it useless to git track
PyCharm is a popular enough ide so this should be a welcome change to anyone using it and being tired of manually ignoring this file in each project.

Official site: https://www.jetbrains.com/pycharm/
Docs: https://www.jetbrains.com/idea/help/project.html