### PR TITLE
Add buildNumber.properties

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -5,3 +5,4 @@ pom.xml.versionsBackup
 pom.xml.next
 release.properties
 dependency-reduced-pom.xml
+buildNumber.properties


### PR DESCRIPTION
The popular build plugin org.codehaus.mojo:buildnumber-maven-plugin stores the build number it manages in a file named buildNumber.properties.