### PR TITLE
Update Jetbrains.gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -32,7 +32,7 @@
 ## Plugin-specific files:
 
 # IntelliJ
-out/
+/out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/


### PR DESCRIPTION
When users have a folder or package named `out/`, the current gitignore will ignore that folder too, making them update their local `.gitignore` to exclude these folders specifically.

Given that the `.gitignore` file is usually located at the same level as the intellij' `out/` build folder, I think it makes sense to only ignore the top level `/out/` build folder.