### PR TITLE
Added coverage annotation files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -41,6 +41,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+,cover
 
 # Translations
 *.mo

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -41,7 +41,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-,cover
+*,cover
 
 # Translations
 *.mo


### PR DESCRIPTION
Coverage creates annotation files by appending ",cover" (with a comma, not a period) to the filename. These should be ignored.