### PR TITLE
Add ".env" to Laravel.gitignore

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -1,3 +1,4 @@
 /bootstrap/compiled.php
 .env.*.php
 .env.php
+.env


### PR DESCRIPTION
Laravel 5 uses vlucas/phpdotenv for env configuration.
http://laravel.com/docs/5.0/configuration#environment-configuration

Laravel 4 used env.php files. 
The new configuration files do not have ".php" extensions

Pull req  #1380 addressed this, but included other things.

Fixes #1380.