### PR TITLE
removing aditional white space

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -23,4 +23,4 @@ DerivedData
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
-# Pods/
+#Pods/


### PR DESCRIPTION
removing this aditional white space avoid a mistake for beginners developers ignore the pod directory, because is confusing to note when they remove the '#' character and git still is tracking the pod dir.