### PR TITLE
Add CUDA.gitignore

### DIFF
--- a/CUDA.gitignore
+++ b/CUDA.gitignore
@@ -1,0 +1,6 @@
+*.i
+*.ii
+*.gpu
+*.ptx
+*.cubin
+*.fatbin


### PR DESCRIPTION
This gitignore file adds ignoring capability for intermediate files in CUDA projects. As it can be seen in [CUDA documentation](http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html) section [4.2](http://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#full-cuda-compilation-trajectory), depending on NVCC compiler flags, intermediate files with extensions provided in the gitignore file may be created. This .gitignore file aims to ignore these intermediate files.