### PR TITLE
Create KiCAD.gitignore

### DIFF
--- a/KiCAD.gitignore
+++ b/KiCAD.gitignore
@@ -1,0 +1,11 @@
+# For PCBs designed using KiCAD: http://www.kicad-pcb.org/
+
+# Temporary files
+*.000
+*.bak
+
+# Netlist files (exported from Eeschema)
+*.net
+
+# Autorouter files (exported from Pcbnew)
+.dsn


### PR DESCRIPTION
This adds a ```.gitignore``` for the [KiCAD](http://www.kicad-pcb.org/) EDA software.

Documentation on the file types is available [here](http://www.kicad-pcb.org/display/KICAD/File+Formats).

Essentially all files that are either temporary files or can be generated directly from a file already under version control (e.g. ```.net``` files are generated from ```.sch``` files) are ignored.