### PR TITLE
Stop ignoring app/code/local/Mage

### DIFF
--- a/Magento.gitignore
+++ b/Magento.gitignore
@@ -89,7 +89,7 @@ LICENSE_AFL.txt
 LICENSE.html
 LICENSE.txt
 LICENSE_EE*
-mage
+/mage
 media/customer/
 media/dhl/
 media/downloadable/


### PR DESCRIPTION
with 'mage' on the gitignore file, a user can't add files customized from Mage.
Magento allows us to customize core files by coping then to app/code/local, but this line prevents git to find the file, adding a slash restrict the ignore to the root folder solving this problem, and ignoring only the mage file

http://www.magentocommerce.com/wiki/5_-_modules_and_development/0_-_module_development_in_magento/how_to_create_a_local_copy_of_app_code_core_mage