### PR TITLE
Update Python.gitignore to include .bak files created by 2to3

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# 2to3
+*.bak


### PR DESCRIPTION
The standard Python distribution's 2to3 tool migrates code from Python 2 to Python 3.
The tool will create files with the extension '.bak' when run with -w argument, which appears to be fairly standard usage.

For example:

`2to3 -w test.py`

will produce:

`test.py.bak`