### PR TITLE
Update to NetBeans .gitignore nbproject folder

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -1,4 +1,5 @@
-nbproject/private/
+### NetBeans ###
+nbproject/*
 build/
 nbbuild/
 dist/


### PR DESCRIPTION
When I commit a NetBeans 8.0.2 HTML5Application nbproject/private/ does not ignore files project.properties and project.xml.
My edit nbproject/* is cleaner and ignores the nbproject folder and all folders and files within - including project.properties and project.xml