### PR TITLE
Add spool folder to Symfony

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -4,6 +4,9 @@
 !app/cache/.gitkeep
 !app/logs/.gitkeep
 
+# Email spool folder
+/app/spool/*
+
 # Cache and logs (Symfony3)
 /var/cache/*
 /var/logs/*


### PR DESCRIPTION
**Reasons for making this change:**

As stated in Symfony documentation, all " log and cache files and dumped assets (which are created automatically by your project), should not be committed in Git.". Spool folder only contains files created by running the application, since they are files to be sent.

**Links to documentation supporting these rule changes:** 

http://symfony.com/doc/current/cookbook/workflow/new_project_git.html