### PR TITLE
comment out CakePHP version headers

### DIFF
--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -1,11 +1,11 @@
-CakePHP 3
+# CakePHP 3
 
 /vendor/*
 /config/app.php
 /tmp/*
 /logs/*
 
-CakePHP 2
+# CakePHP 2
 
 /app/tmp/*
 /app/Config/core.php


### PR DESCRIPTION
I've commented out the headers on the different CakePHP versions, "CakePHP 3" and "CakePHP 2". They should be commented out as they are only for explaining to the user of this gitignore which version the various ignore rules belong to.