### PR TITLE
Remove phpunit from symfony file

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -26,10 +26,6 @@
 /web/bundles/
 /web/uploads/
 
-# PHPUnit
-/app/phpunit.xml
-/phpunit.xml
-
 # Build data
 /build/
 


### PR DESCRIPTION
PHPUnit configuration files are essential to run continuous integration tests on platforms like travis.