### PR TITLE
Ignore timing.properties from takari-smart-builder

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -6,3 +6,4 @@ pom.xml.next
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
+.mvn/timing.properties


### PR DESCRIPTION
This extension is an alternative scheduler to build multi-module Maven projects.
It stores and updates timing for every build run in .mvn/timing.properties.

http://takari.io/book/30-team-maven.html#takari-smart-builder