### PR TITLE
adding the .orig files to the ignore list

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -174,6 +174,9 @@ Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 
+# SourceTree
+*.orig
+
 # SQL Server files
 *.mdf
 *.ldf


### PR DESCRIPTION
This is to keep noise from using source tree to a minimum.