### PR TITLE
Add DNX project.lock.json to ignore file

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -194,3 +194,6 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+# DNX-based projects have a project.lock.json file. It is not recommended that this be checked in by default
+project.lock.json

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -195,5 +195,5 @@ FakesAssemblies/
 # Visual Studio 6 workspace options file
 *.opt
 
-# DNX-based projects have a project.lock.json file. It is not recommended that this be checked in by default
+# DNX-based projects have a project.lock.json file. This should not be checked-in during development
 project.lock.json


### PR DESCRIPTION
I'm 95% sure this is correct, but adding @davidfowl and @lodejard to confirm.

Users may want to check the lock file in on release branches but to do so they need to a) "lock" it using a specific command (`dnu lock` or something) and b) can override the ignore file for the specific add operation.