### PR TITLE
Add IDEs to Java.gitignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -3,10 +3,21 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-# Package Files #
+# Package Files 
 *.jar
 *.war
 *.ear
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+#Idea IntelliJ
+*.iml
+*.ipr
+*.iws
+
+#Eclipse
+*.classpath
+*.project
+/.settings
+/bin/


### PR DESCRIPTION
This ignores generated files from IntelliJ & Eclipse which every Java project doesn't want.