### PR TITLE
Ignore .virthualenv not .virtualenv

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -6,7 +6,7 @@ cabal-dev
 *.chs.h
 *.dyn_o
 *.dyn_hi
-.virtualenv
+.virthualenv
 .hpc
 .hsenv
 .cabal-sandbox/

--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -6,7 +6,6 @@ cabal-dev
 *.chs.h
 *.dyn_o
 *.dyn_hi
-.virthualenv
 .hpc
 .hsenv
 .cabal-sandbox/


### PR DESCRIPTION
This change was introduced in 3bb4e51184066f5cf60daa029c31e7f52398353b, where it was marked as changed due to a typo. However, that is the correct name of this particular virtual environment. See https://hackage.haskell.org/package/virthualenv