### PR TITLE
Add .recommenders

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -1,6 +1,7 @@
 *.pydevproject
 .metadata
 .gradle
+.recommenders
 bin/
 tmp/
 *.tmp


### PR DESCRIPTION
As another user reported it [here](http://stackoverflow.com/questions/27650929/git-wont-stop-tracking-eclipse-java-recommenders) and from personal testing in Eclipse luna whenever you use the content assist feature for the first time in a project a folder named .recommenders is created.