### PR TITLE
pre-emptively separate default ignore rules from user-defined ones

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -11,3 +11,5 @@
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
+
+# Custom ignore rules


### PR DESCRIPTION
Just an idea I got while using GitHub's Win & Mac clients. Adding ignore rules via the context menu of staged files simply appended them to the end. Since there is no pre-labelled separator, it was sometimes not clear whether I had added a certain ignore rule, or whether it came pre-defined. Adding this or a similar "footer" to the file would ensure that the pre-defined ignore rules above don't get confused with use-defined ones.