### PR TITLE
Create CodeBlocks.gitignore

### DIFF
--- a/Global/CodeBlocks.gitignore
+++ b/Global/CodeBlocks.gitignore
@@ -1,0 +1,3 @@
+# Code::Blocks
+*.depend
+*.layout


### PR DESCRIPTION
Documentation at http://wiki.codeblocks.org/index.php?title=File_formats_description lists lists *.depend and *.layout as useful only to Code::Block itself.
