### PR TITLE
Ignore pyenv's version marker

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# pyenv
+.python-version


### PR DESCRIPTION
[pyenv][pyenv] is a Python version manager for *nix shells. It allows the Python version and virtual environment to be set locally, per-directory, using a `.python-version` file. Because pyenv environment names are arbitrary and machine+user-specific (the name being in the `.python-version` file), they are usually noise.

[pyenv]: https://github.com/yyuu/pyenv