### PR TITLE
Adding a few more files/file extensions/directories for Synopsys VCS.

### DIFF
--- a/Global/SynopsysVCS.gitignore
+++ b/Global/SynopsysVCS.gitignore
@@ -1,23 +1,57 @@
-# Waveforms
-*.vpd
+########## Waveforms #######################################
+# Value Change Dumping (VCD) - IEEE Standard
 *.vcd
+# VCDlus Dumping (VPD) - Synopsys proprietary format
+*.vpd
+# Extended VCD (EVCD) - Dump only port information
 *.evcd
+# Fast Signal DataBase (FSDB)
+*.fsdb
 
-# Binary files
+
+########## Simulation executable file ######################
+# Default name of the simulation executable.  A different
+# name can be specified with this switch (the associated
+# daidir database name is also taken from here)
+#   -o <path>/<filename>
 simv
 
-# Directories used for compilation
-csrc/
-simv.daidir/
 
-# Log files
+########## Intermediate files used for simulation ##########
+# Generated for Verilog top configs
+simv.daidir/
+# Generated for VHDL top configs
+simv.db.dir/
+# Infrastructure necessary to co-simulate SystemC models
+# with Verilog/VHDL models.  An alternate directory may
+# be specified with this switch:
+#   -Mdir=<directory_path>
+csrc/
+
+
+########### Log files ######################################
+# The switch below allows to specify the file that will be
+# used to write all messages from simulation
+#   -l <filename>
 *.log
 
-# DVE, UCLI related files
-DVEfiles/
-ucli*
-*.key
 
-# Coverage related files
+########## Coverage-related files ##########################
+# Generation of coverage result reports is done with urg
+# and the database location is specified with this switch:
+#   urg -dir <coverage_directory>.vdb
 simv.vdb/
 urgReport/
+
+
+########## DVE, UCLI related files #########################
+# DVE produces some logs that are created in this directory.
+DVEfiles/
+ucli.key
+
+
+########## C Language interface ############################
+# When the design is elaborated for DirectC, VCS will create
+# a file in the current directory with declarations for 
+# C/C++ functions.
+vc_hdrs.h

--- a/Global/SynopsysVCS.gitignore
+++ b/Global/SynopsysVCS.gitignore
@@ -1,57 +1,36 @@
-########## Waveforms #######################################
-# Value Change Dumping (VCD) - IEEE Standard
+# Waveform formats
 *.vcd
-# VCDlus Dumping (VPD) - Synopsys proprietary format
 *.vpd
-# Extended VCD (EVCD) - Dump only port information
 *.evcd
-# Fast Signal DataBase (FSDB)
 *.fsdb
 
-
-########## Simulation executable file ######################
-# Default name of the simulation executable.  A different
-# name can be specified with this switch (the associated
-# daidir database name is also taken from here)
-#   -o <path>/<filename>
+# Default name of the simulation executable.  A different name can be 
+# specified with this switch (the associated daidir database name is 
+# also taken from here):  -o <path>/<filename>
 simv
 
-
-########## Intermediate files used for simulation ##########
-# Generated for Verilog top configs
+# Generated for Verilog and VHDL top configs
 simv.daidir/
-# Generated for VHDL top configs
 simv.db.dir/
-# Infrastructure necessary to co-simulate SystemC models
-# with Verilog/VHDL models.  An alternate directory may
-# be specified with this switch:
-#   -Mdir=<directory_path>
+
+# Infrastructure necessary to co-simulate SystemC models with 
+# Verilog/VHDL models.  An alternate directory may be specified with this
+# switch:  -Mdir=<directory_path>
 csrc/
 
-
-########### Log files ######################################
-# The switch below allows to specify the file that will be
-# used to write all messages from simulation
-#   -l <filename>
+# Log file - the following switch allows to specify the file that will be
+# used to write all messages from simulation:  -l <filename>
 *.log
 
-
-########## Coverage-related files ##########################
-# Generation of coverage result reports is done with urg
-# and the database location is specified with this switch:
-#   urg -dir <coverage_directory>.vdb
+# Coverage results (generated with urg) and database location.  The 
+# following switch can also be used:  urg -dir <coverage_directory>.vdb
 simv.vdb/
 urgReport/
 
-
-########## DVE, UCLI related files #########################
-# DVE produces some logs that are created in this directory.
+# DVE and UCLI related files.
 DVEfiles/
 ucli.key
 
-
-########## C Language interface ############################
-# When the design is elaborated for DirectC, VCS will create
-# a file in the current directory with declarations for 
-# C/C++ functions.
+# When the design is elaborated for DirectC, the following file is created
+# with declarations for C/C++ functions.
 vc_hdrs.h


### PR DESCRIPTION
@arcresu : This is just a follow-up to pull request [1282](https://github.com/github/gitignore/pull/1282).  I talked to a Field Engineer over at Synopsys, and he pointed out some files that I had originally missed.  Those have been added in this patch.  I have also added a few comments about each one of the files, file extensions and directories that will be ignored just for documentation purposes.