### PR TITLE
Add ignore for puppet modules

### DIFF
--- a/Puppet.gitignore
+++ b/Puppet.gitignore
@@ -1,0 +1,13 @@
+# Built packages
+pkg/*
+
+# Should run on multiple platforms so don't check in
+Gemfile.lock
+
+# Tests
+spec/fixtures/*
+coverage/*
+
+# Third-party
+vendor/*
+.bundle/*


### PR DESCRIPTION
Homepage: https://forge.puppetlabs.com

No official documentation, however this PR explains the items in official puppetlabs modules' gitignore files, such as [NTP](https://github.com/puppetlabs/puppetlabs-ntp/blob/master/.gitignore) or [Apache](https://github.com/puppetlabs/puppetlabs-apache/blob/master/.gitignore).

These changes apply to everyone writing puppet modules, at least as a starting point.
