### PR TITLE
Add Bitrix .gitignore

### DIFF
--- a/Bitrix.gitignore
+++ b/Bitrix.gitignore
@@ -1,0 +1,11 @@
+# exclude core
+bitrix/*
+
+# include templates folder (you can add your template name to ignore system templates)
+!bitrix/templates
+
+# include custom components  
+!bitrix/components/
+bitrix/components/bitrix/
+
+


### PR DESCRIPTION
Bitrix is commercial PHP & MySQL based CMS, most popular in Russian Federation.
CMS rating on russian site: http://www.ratingruneta.ru/cms/
I don't think it's very popular in other countries but its .gitignore could be here for completeness and someone finds it useful.

Site:
English: http://www.bitrixsoft.com/
Russian: https://www.1c-bitrix.ru/

Ignoring: core files (there are too many files which you should not edit) and include custom folders for your code.

Since version 14 you can use /local folder for your code and ignore all /bitrix folder.
Info (only russian): http://dev.1c-bitrix.ru/community/blogs/vad/local-folder.php
