### PR TITLE
Add bower_components to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -25,3 +25,4 @@ build/Release
 # Dependency directory
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
+bower_components


### PR DESCRIPTION
Hi.
I'm using Node.js to development in back-end and front-end.

Bower is very popular package manager for front-end.
So, I think that it is good if add a dependency directory of Bower.

The `bower_components` directory is Bower's dependency directory.
In [Bower official repository](https://github.com/bower/bower/blob/master/.gitignore), it has been added in `.gitignore`.

Thank you.