### PR TITLE
adding artifacts and project.lock.json for asp.net 5

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -38,6 +38,10 @@ TestResult.xml
 [Rr]eleasePS/
 dlldata.c
 
+# ASP.NET 5
+project.lock.json
+artifacts/
+
 *_i.c
 *_p.c
 *_i.h


### PR DESCRIPTION
I've added the following to ```VisualStudio.gitignore``` to support ASP.NET 5

```
# ASP.NET 5
project.lock.json
artifacts/
```

```project.lock.json``` is created by default whenever a restore operation is executed. It should be ignored by default.

The ```artifacts``` folder will contain build output, and likely should never be checked in.

_Note: I'm on the team that works on Visual Studio for ASP.NET_