### PR TITLE
Update CocoaPods guide URL

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -21,6 +21,6 @@ DerivedData
 #
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
-# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 #Pods/


### PR DESCRIPTION
This updates the link provided to the CocoaPods documentation regarding whether the Pods directory should be ignored or not.