### PR TITLE
Android: Remove redundant pattern for matching build directories

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -15,7 +15,6 @@ gen/
 # Gradle files
 .gradle/
 build/
-/*/build/
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
build/ already matches all directories named 'build' in the repository,
regardless of level. Gradle can have more than two levels of project nesting.
However, /*/build/ matches only the 'build' directories of 2nd-level projects.
Thus, the first pattern is more appropriate than the second.