### PR TITLE
Added Elm gitignore

### DIFF
--- a/Elm.gitignore
+++ b/Elm.gitignore
@@ -1,0 +1,2 @@
+# Ignore downloaded packages and build artifacts
+/elm-stuff


### PR DESCRIPTION
The Elm programming language is on [elm-lang.org](http://elm-lang.org). 
This gitignore ignores build artefacts and downloaded dependencies. The directory name was decided on [here](https://groups.google.com/d/msg/elm-discuss/BNGXIjQpNAI/1c_98tAmr34J). 