### PR TITLE
Add extention compiled files python 2.x

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.pyc
+*.pyo
 
 # C extensions
 *.so


### PR DESCRIPTION
In python2 always is compiled files when a module is executed individually for testing.