### PR TITLE
Added Crystal.gitignore

### DIFF
--- a/Crystal.gitignore
+++ b/Crystal.gitignore
@@ -1,0 +1,6 @@
+# Compiled files
+*.bc
+*.o
+
+# Compiler's cache
+.crystal


### PR DESCRIPTION
I added `gitignore` file for Crystal programming language.

It ignores compiled bitcode files, object files and a compiler's cache directory, which are generated automatically by a compiler.