### PR TITLE
added VB & F# version of orleans.codegen.cs

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -171,7 +171,7 @@ ClientBin/
 *.publishsettings
 node_modules/
 bower_components/
-orleans.codegen.cs
+orleans.codegen.(cs|vb|fs)
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
Added VB & F# version of orleans.codegen.cs
See: https://github.com/dotnet/orleans/blob/master/.gitignore#L4-L7