### PR TITLE
Remove Meteor.gitignore

### DIFF
--- a/Meteor.gitignore
+++ b/Meteor.gitignore
@@ -1,2 +1,0 @@
-.meteor/local
-.meteor/meteorite


### PR DESCRIPTION
There are only two entries in this .gitignore, and both are not needed.
- .meteor/local is already ignored by the standard Meteor .gitignore that is included with every project. This is redundant and should b left solely to the standard Meteor .gitignore in case this changes in the future.
- .meteor/meteorite should no longer be in any Meteor project. Meteorite was a package manager for Meteor, but it has been replaced by an official package manager built into the Meteor CLI. This directory should not exist, except on out of date Meteor projects which already have this ignore present.