### PR TITLE
[Tex] Change *.mtc0 to *.mtc[0-9] *.mtc[1-9][0-9]

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -93,7 +93,8 @@ acs-*.bib
 # minitoc
 *.maf
 *.mtc
-*.mtc0
+*.mtc[0-9]
+*.mtc[1-9][0-9]
 
 # minted
 _minted*


### PR DESCRIPTION
When using minitoc package, LateX often generates multiple .mtc files such as `*.mtc0`, `*.mtc1`, ..., `*.mtc13`, ... This patch allows one to ignore all *.mtc files from index 0 to index 99 (ignoring ` *.mtc[0-9] ` and ` *.mtc[1-9][0-9] `).