### PR TITLE
Add trailing slash to .sass-cache

### DIFF
--- a/Sass.gitignore
+++ b/Sass.gitignore
@@ -1,2 +1,2 @@
-.sass-cache
+.sass-cache/
 *.css.map


### PR DESCRIPTION
Add trailing slash to `.sass-cache` to signify intent of matching directories.