### PR TITLE
Add several downloaded files that should not be incorporated and remove .SRCINFO

### DIFF
--- a/ArchLinuxPackages.gitignore
+++ b/ArchLinuxPackages.gitignore
@@ -1,5 +1,8 @@
 *.tar
 *.tar.*
+*.jar
+*.exe
+*.msi
 *.zip
 *.tgz
 *.log

--- a/ArchLinuxPackages.gitignore
+++ b/ArchLinuxPackages.gitignore
@@ -6,9 +6,5 @@
 *.log.*
 *.sig
 
-# AUR metadata
-.AURINFO
-.SRCINFO
-
 pkg/
 src/


### PR DESCRIPTION
As of version 4.0.0 the Arch User Repository is build out of one git repository per package. The .SRCINFO files need to be included in those.

Moreover, I added several extensions of files that are regularly downloaded by PKGBUILD scripts; these shouldn't be included in git repositories of package sources.