### PR TITLE
Added solution & project ncrunch files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -106,6 +106,8 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+*.ncrunchsolution
+*.ncrunchproject
 
 # MightyMoose
 *.mm.*


### PR DESCRIPTION
Both *.ncrunchsolution & *.ncrunchproject are not required to be source controlled.