### PR TITLE
Add scrapy stuff to .gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -51,6 +51,9 @@ coverage.xml
 # Django stuff:
 *.log
 
+# Scrapy stuff:
+.scrapy
+
 # Sphinx documentation
 docs/_build/
 


### PR DESCRIPTION
The `.scrapy` is used for caches, should just be ignored.