### PR TITLE
Ignore 'local' folder for virtualenv

### DIFF
--- a/Global/VirtualEnv.gitignore
+++ b/Global/VirtualEnv.gitignore
@@ -4,6 +4,7 @@
 [Bb]in
 [Ii]nclude
 [Ll]ib
+[Ll]ocal
 [Ss]cripts
 pyvenv.cfg
 pip-selfcheck.json


### PR DESCRIPTION
Whenever I use virtualenv, I get a folder called 'local' that I would like to ignore. 

For reference, I am using virtualenv version 1.11.4 for Python 2 on Linux Mint 17.

I added [Ll]ocal. I do not know when it would ever be capitalized, but I assume there is such as case based on the other entries in this file.