### PR TITLE
[ObjC][Swift] Ignore Xcode SCM blueprint files

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -21,6 +21,7 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 *.xcuserstate
+*.xcscmblueprint
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -21,6 +21,7 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 *.xcuserstate
+*.xcscmblueprint
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
These files are automatically generated by Xcode and maintain
information regarding source control. Xcode is typically used
in Objective-C and Swift projects, so add these to the ignored files for
these platforms.