### PR TITLE
Sonar .gitignore file

### DIFF
--- a/Sonar.gitignore
+++ b/Sonar.gitignore
@@ -1,0 +1,2 @@
+#Sonar generated dir
+/.sonar/


### PR DESCRIPTION
When running "Get Issues from Sonar runner" from NetBeans (using the radar sonar plugin) a {project_dir}/.sonar directory is created.
This directory is also created when running the maven sonar:sonar goal in preview mode analysis.
