### PR TITLE
Created Splunk.gitignore file

### DIFF
--- a/Splunk.gitignore
+++ b/Splunk.gitignore
@@ -1,0 +1,3 @@
+# Splunk local meta file
+local.meta
+

--- a/Splunk.gitignore
+++ b/Splunk.gitignore
@@ -1,3 +1,5 @@
 # Splunk local meta file
 local.meta
 
+# Splunk local folder
+local


### PR DESCRIPTION
When developing a Splunk App the local.meta file is not required for the distribution of the Splunk App. The local.meta file contains information about the current " *.meta files contain ownership information, access controls, and export settings for Splunk objects like saved searches, event types, and views. Each app has its own default.meta file."

http://docs.splunk.com/Documentation/Splunk/6.2.3/admin/Defaultmetaconf
