### PR TITLE
Update Typo3.gitignore for CMS v6.2

### DIFF
--- a/Typo3.gitignore
+++ b/Typo3.gitignore
@@ -1,18 +1,20 @@
-## TYPO3 v4
+## TYPO3 v6.2
 # Ignore serveral upload and file directories.
 /fileadmin/user_upload/
 /fileadmin/_temp_/
+/fileadmin/_processed_/
 /uploads/
 # Ignore cache
 /typo3conf/temp_CACHED*
 /typo3conf/temp_fieldInfo.php
-# Ignore local config which overrides typo3 config.
-# You should include your local stuff with `@include('localconf_local.php');` at the end of localconf.php.
-# See http://stackoverflow.com/questions/11905360/how-best-to-manage-typo3-installations-using-git for details.
-/typo3conf/localconf_local.php
+/typo3conf/deprecation_*.log
+/typo3conf/AdditionalConfiguration.php
 # Ignore system folders, you should have them symlinked.
-# If not comment out the following two entries.
+# If not comment out the following entries.
 /typo3
-/t3lib
+/typo3_src
+/typo3_src-*
+/.htaccess
+/index.php
 # Ignore temp directory.
 /typo3temp/


### PR DESCRIPTION
Typo3 now has an official way of overriding Configuration (`AdditionalConfiguration.php`).
Did not find any documentation, but thats the way its implemented: http://git.io/vL4lU http://git.io/vL44t

[`/t3lib` has moved](http://wiki.typo3.org/Upgrade#Upgrading_to_6.2_Long_Term_Support) into the `/typo3` Directory.

There were ignores missing for the [symlinked setup](http://docs.typo3.org/typo3cms/InstallationGuide/singlehtml/#quick-installation).

This file now only works for 6.2, no longer for 4.5 and probably not jet for 7.x.
Which is probably a sane choice since 6.2 ist the only currently supported LTS release.
Old versions (pre 6.2) should really not be used and it should be possible to migrate 4.5
without much trouble now ( [LTS smooth migration](http://typo3.org/extensions/repository/view/smoothmigration)).
Support for 4.5 could be kept if wanted (just tell me and i'll change the commit, its only about ignoring `/t3lib`). 
Ignoring `/typo3conf/localconf_local.php` by default never was a good idea (IMO). 
Before `AdditionalConfiguration.php` the easiest way was to create an empty extension and use `ext_localconf.php` - but this is only one way to do it...
