### PR TITLE
Including .DS_Store to have directly a complete .gitignore.

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -21,3 +21,6 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 *.xcuserstate
+
+## OS X specific
+.DS_Store

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -41,3 +41,6 @@ xcuserdata
 # Carthage/Checkouts
 
 Carthage/Build
+
+## OS X specific
+.DS_Store

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -41,3 +41,6 @@ xcuserdata
 # Carthage/Checkouts
 
 Carthage/Build
+
+## OS X specific
+.DS_Store


### PR DESCRIPTION
Please include the .DS_Store directly into the languages/IDE .gitignore files to have directly a usable .gitignore in one file. For example, every time I create a project I download the .gitignore for Swift for example and every time I need to edit it to add the .DS_Store ignored.

Thanks.