### PR TITLE
Add Dropbox.gitignore

### DIFF
--- a/Global/Dropbox.gitignore
+++ b/Global/Dropbox.gitignore
@@ -1,0 +1,4 @@
+# Dropbox settings and caches
+.dropbox
+.dropbox.attr
+.dropbox.cache


### PR DESCRIPTION
Folders that are synced with Dropbox can contain user-specific files and caches. Dropbox.gitignore adds some Dropbox gitignore files based on the following Dropbox Support articles:
https://www.dropbox.com/help/328
https://www.dropbox.com/help/145