### PR TITLE
Ignore files created by `\tikzexternalize`

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -120,6 +120,10 @@ _minted*
 *.sympy
 sympy-plots-for-*.tex/
 
+# TikZ & PGF
+*.dpth
+*.md5
+
 # todonotes
 *.tdo
 


### PR DESCRIPTION
When using TikZ & PGF with:
`\usepackage{tikz} \usetikzlibrary{external} \tikzexternalize`
It creates .dpth and .md5 files for the externalized tikzpictures.

See these pages in section *50 Externalization Library*:
p.617 - 50.4.1 Support for Labels and References In External Files
p.621 - `/tikz/external/up to date check`
In the PGF manual:
http://mirrors.ctan.org/graphics/pgf/base/doc/pgfmanual.pdf
