### PR TITLE
Ignore *.auxlock files created by TikZ in TeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -123,6 +123,7 @@ sympy-plots-for-*.tex/
 # TikZ & PGF
 *.dpth
 *.md5
+*.auxlock
 
 # todonotes
 *.tdo


### PR DESCRIPTION
TikZ uses `*.auxlock` files to check if the main `*.aux` file is available.
This is only used when using the `external` tikz library.
TikZ uses this in case one of the TikZ pictures to externalize contains references.

Described in section: 50.8.1 References In External Pictures (p.627)
http://mirror.utexas.edu/ctan/graphics/pgf/base/doc/pgfmanual.pdf