### PR TITLE
Ignore Default RSpec State File

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -5,6 +5,7 @@
 /InstalledFiles
 /pkg/
 /spec/reports/
+/spec/examples.txt
 /test/tmp/
 /test/version_tmp/
 /tmp/


### PR DESCRIPTION
RSpec 3.3 adds `--only-failures` run support, which requires the presence of an `examples.txt` or similar file that is recommended to be left out of version control. This file is added as one of the sane defaults RSpec ships with, so it makes sense to ignore this file by default.

Context: http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/