### PR TITLE
Added .stack-work/ directory to Haskell .gitignore.

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -13,3 +13,4 @@ cabal.sandbox.config
 *.prof
 *.aux
 *.hp
+.stack-work/


### PR DESCRIPTION
`.stack-work/` is a work directory used by the `stack` build tool.

The `stack` build tool has recently been gaining a lot of traction in
the Haskell community.  It is very similar to the `cabal` build tool,
which also has entries in this Haskell `.gitignore` file.