### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -3,6 +3,7 @@
 .pub/
 build/
 packages
+.packages
 
 # Or the files created by dart2js.
 *.dart.js


### PR DESCRIPTION
As of Dart 1.12, the pub package manager will start generating a .packages file that will eventually replace the packages/ directory.