### PR TITLE
Ignore NCrunch temporary files.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -106,6 +106,7 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+nCrunchTemp_*
 
 # MightyMoose
 *.mm.*


### PR DESCRIPTION
While [NCrunch](http://www.ncrunch.net/) is running it creates little temporary files in the pattern `nCrunchTemp_*`. These are automatically cleaned up, but a badly timed `git status` or `git add -A` can catch them momentarily.

Unfortunately I can't find any official documentation that discusses these files, but here are a few examples of public GitHub repos were people have added an ignore rule like this:

- https://github.com/TinyBlueRobots/NancyFs/blob/master/.gitignore#L63
- https://github.com/cloudfoundry-incubator/if_warden/blob/master/.gitignore#L68
- https://github.com/peterkeating/nancy-boilerplate/blob/master/.gitignore#L46

and some mention of the files on NCrunch forums:

- http://forum.ncrunch.net/yaf_postst1304_Don-t-start-builds.aspx
- http://forum.ncrunch.net/yaf_postst1093_NCrunch-cannot-build-project-that-VS-can.aspx

