### PR TITLE
Ignore PyCharm working files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea/


### PR DESCRIPTION
PyCharm is one of the most popular Python editors in use today, so I wanted to make sure we ignore it's working files, which keep track of things like which files you have open and window placement.