### PR TITLE
update Visual studio gitignore for qt add-in

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -204,3 +204,10 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+#Qt Add-in for Visual Studio
+GeneratedFiles/
+*.moc
+moc_*.cpp
+qrc_*.cpp
+ui_*.h


### PR DESCRIPTION
this VisualStudio.gitignore have no ignore files for qt-vs-addin. such as moc_*.cpp qrc_*.cpp ui_*.h 