### PR TITLE
Create Crystal.gitignore

### DIFF
--- a/Crystal.gitignore
+++ b/Crystal.gitignore
@@ -1,0 +1,10 @@
+/.deps/
+/libs/
+/.crystal/
+/doc/
+
+
+# Libraries don't need dependency lock
+# Dependencies will be locked in application that uses them
+# Uncomment the line below if you are creating a library.
+#/.deps.lock


### PR DESCRIPTION
Taken from the Crystal compiler's project init feature. Gitignore created by @flaviut.
### What is it?

[Crystal](http://crystal-lang.org/) is a language derived from Ruby, compiled for the LLVM. Because it's only syntactically similar to Ruby there are some differences which should be taken into account.
### What is being ignored?

Files created by the compiler in a normal session are being ignored here. `.deps` is where the compiler pulls in dependencies declared in a project's `Projectfile`. `libs` is similar is that it is external code downloaded later. `.crystal` is contains the LLVM bytecode created by the compiler at compilation. `doc` is well documentation. And `.deps.lock` is comparable to a `Gemfile.lock`.
### Why?

Crystal is a fairly new language which has been recently gathering a following. Thought it would be nice for new Crystal projects on GitHub projects to be created with a proper gitignore.
