### PR TITLE
Add Code Recommenders directory

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -45,3 +45,6 @@ local.properties
 
 # STS (Spring Tool Suite)
 .springBeans
+
+# Code Recommenders
+.recommenders/


### PR DESCRIPTION
Code Recommenders introduced in Eclipse Luna (4.5) creates a .recommenders directory at the root of the workspace, like .metadata