### PR TITLE
Adding Polymer.gitignore

### DIFF
--- a/Polymer.gitignore
+++ b/Polymer.gitignore
@@ -1,0 +1,2 @@
+#Installed components via bower
+bower_components/


### PR DESCRIPTION
[Installing Polymer
elements](https://www.polymer-project.org/1.0/docs/start/getting-the-cod
e.html#installing-polymer) with the help of
[bower](http://bower.io/#install-packages) installs them in
`bower_components` folder. Thus, with the help of this commit, an
element’s repo can be preinitialized with a `.gitignore` file which
already ignores the installation directory.
