### PR TITLE
Add Phoenix Framework gitignore

### DIFF
--- a/PhoenixFramework.gitignore
+++ b/PhoenixFramework.gitignore
@@ -1,0 +1,23 @@
+# Mix artifacts
+/_build
+/deps
+/*.ez
+
+# Generate on crash by the VM
+erl_crash.dump
+
+# Static artifacts
+/node_modules
+
+# Since we are building assets from web/static,
+# we ignore priv/static. You may want to comment
+# this depending on your deployment strategy.
+/priv/static/
+
+# The config/prod.secret.exs file by default contains sensitive
+# data and you should not commit it into version control.
+#
+# Alternatively, you may comment the line below and commit the
+# secrets file as long as you replace its contents by environment
+# variables.
+/config/prod.secret.exs


### PR DESCRIPTION
This PR adds support for [Phoenix Framework](phoenixframework.org).
### Who?

"Phoenix is a framework for building HTML5 apps, API backends and distributed systems. Written in Elixir, you get beautiful syntax, productive tooling and a fast runtime." -- [Phoenix Framework](phoenixframework.org)
### What?

This was pulled directly from the [installer](https://github.com/phoenixframework/phoenix/blob/master/installer/templates/static/brunch/.gitignore).  These files are either build artifacts, crash dumps, or secrets.
### Why?

Phoenix is the de facto framework for Elixir and is growing by leaps and bounds.  It would be great to support both Elixir and Phoenix as .gitignore options on GitHub.

[Phoenix Framework on GitHub](https://github.com/phoenixframework/phoenix)
