### PR TITLE
Add KiCad ignore for .bck and .kicad_pcb-bak

### DIFF
--- a/KiCAD.gitignore
+++ b/KiCAD.gitignore
@@ -3,6 +3,8 @@
 # Temporary files
 *.000
 *.bak
+*.bck
+*.kicad_pcb-bak
 
 # Netlist files (exported from Eeschema)
 *.net


### PR DESCRIPTION
These are two other filetypes that KiCad creates before overwriting something.