### PR TITLE
Added .gitignore for PureScript

### DIFF
--- a/PureScript.gitignore
+++ b/PureScript.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+.psci_modules
+bower_components
+node_modules
+
+# Generated files
+.psci
+output


### PR DESCRIPTION
PureScript: http://purescript.org (this language is already part of https://github.com/github/linguist).

This .gitignore ignores dependencies installed using npm or bower as well as psci's generated files and the JavaScript that's generated from the PureScript code (output directory).

This also matches the default `bower.json` settings for a PureScript project:

```
"ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "output"
  ],
```
