### PR TITLE
Create Elm.gitignore

### DIFF
--- a/Elm.gitignore
+++ b/Elm.gitignore
@@ -1,0 +1,5 @@
+# elm-package generated files
+elm-package.json
+elm-stuff/
+# elm-repl generated files
+repl-temp-*


### PR DESCRIPTION
.gitignore for Elm projects. 

Ignores installed packages (elm-package.json) and elm-stuff/, as these files will be generated once elm-package has been run for a .elm file. This is also beneficial where dependencies have changed, and an install package is no longer required.

elm-repl generated files have also been ignored. Most of the time, elm-repl manages to delete these files automatically, but there are scenarios where these files are not deleted on the closing of elm-repl