### PR TITLE
Add .generated.swift to Swift gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -26,6 +26,7 @@ xcuserdata
 ## Obj-C/Swift specific
 *.hmap
 *.ipa
+*.generated.swift
 
 # CocoaPods
 #


### PR DESCRIPTION
`.generated.swift` files are pre built swift files that often cause unnecessary merge conflicts.