### PR TITLE
gitignore file for a basic elm lang project

### DIFF
--- a/Elm.gitignore
+++ b/Elm.gitignore
@@ -1,0 +1,2 @@
+elm-stuff/*
+!elm-stuff/exact-dependencies.json


### PR DESCRIPTION
`elm-stuff` is a directory created by `elm-make` in the process of compiling .elm source files. It contains dependencies and artifacts created in the process and should not be checked-in, with the exception of `elm-stuff/exact-dependencies.json`, which the user might want to keep.

ref https://github.com/elm-lang/elm-make

> If you are creating an app or product, you want to keep your dependency ranges very specific. When you build, a file is generated called elm-stuff/exact-dependencies.json which lists all of the packages needed for your project and the exact versions you happen to be using right now. You may want to check this in to version control if you want the same exact thing every time.