### PR TITLE
Add ignore for npm debug log files

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+npm-debug.log*
 
 # Runtime data
 pids


### PR DESCRIPTION
Match `npm-debug.log.a00d99ec641001bcfa5b9eb7d2943c30` files created by running module inside a project (unittests, bower, grunt for instance)