### PR TITLE
Added .gitignore template for the Racket langauge (www.racket-lang.org)

### DIFF
--- a/Racket.gitignore
+++ b/Racket.gitignore
@@ -1,0 +1,10 @@
+# DrRacket autosave files
+*~
+\#*
+.\#*
+
+# OS X specific directory information
+.DS_Store
+
+# Compiled racket bytecode
+compiled


### PR DESCRIPTION
The added template is equivalent to the one created by the Racket language's command line utilities (see http://docs.racket-lang.org/pkg/cmdline.html#%28part._raco-pkg-new%29) 

It ignores DrRacket (an editor) autosave files, compiled Racket byte-code, and the OS X .DS_Store directory.
