### PR TITLE
Ipython Notebook checkpoints

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+#Ipython Notebook
+.ipynb_checkpoints


### PR DESCRIPTION
Checkpoints are automatically committed when adding Ipython notebooks to Github. This versioning is redundant given that git already performs code versioning to previous checkpoints. Hence, most projects prefer to include these files in the gitignore. 