### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -12,9 +12,12 @@
 bin/
 gen/
 
-# Gradle files
+# Gradle and Android Studio files
 .gradle/
 build/
+*.iml
+.idea
+.navigation/
 
 # Local configuration file (sdk path, etc)
 local.properties
@@ -24,6 +27,3 @@ proguard/
 
 # Log Files
 *.log
-
-# Android Studio Navigation editor temp files
-.navigation/


### PR DESCRIPTION
Exclude `.idea/` dir and `*.iml` files from Android Studio.

Several sources indicating this is the right thing:
  * https://code.google.com/p/android/issues/detail?id=156708#c6
  * https://stackoverflow.com/questions/18415541/android-studio-import-project-with-gradle-changes-iml-files
  * https://github.com/owncloud/android/blob/master/.gitignore

---

The link to googlecode is an answer from a Google employee on Android:

> For Gradle-based Android projects, Studio uses build.gradle files as its source of truth and generates the iml files based on the project structure defined in build.gradle files. How they get regenerated is in IDEA's functionality.
>
>It is strongly recommended to not include iml in source control.