### PR TITLE
Adding the Android Studio captures folder

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -27,3 +27,6 @@ proguard/
 
 # Android Studio Navigation editor temp files
 .navigation/
+
+# Android Studio captures folder
+captures/


### PR DESCRIPTION
The captures folder is used by Android studio to keep heap dumps and other captures files. These are usually not shared as part of the source file.