### PR TITLE
Add Smalltalk gitignore

### DIFF
--- a/Smalltalk.gitignore
+++ b/Smalltalk.gitignore
@@ -1,0 +1,18 @@
+# changes file
+*.changes
+
+# system image
+*.image
+
+# Pharo Smalltalk Debug log file
+PharoDebug.log
+
+# Squeak Smalltalk Debug log file
+SqueakDebug.log
+
+# Monticello package cache
+/package-cache
+
+# Metacello-github cache
+/github-cache
+github-*.zip


### PR DESCRIPTION
Add Smalltalk gitignore

project:
- http://squeak.org/ Squeak Smalltalk 
- http://pharo.org/ Pharo Smalltalk

> Squeak Smalltalk 
> Squeak is an open-source Smalltalk programming system.

> Pharo Smalltalk
> Pharo emerged as a fork of Squeak Smalltalk. It focuses on modern software engineering and development techniques.

documentation: 
- [Squeak Smalltalk documentation](http://squeakbyexample.org/) Section [1.1](http://squeakbyexample.org//SBE.pdf#page=15) Getting started and Section [6.3] (http://squeakbyexample.org//SBE.pdf#page=139) Monticello

- [Pharo Smalltalk documentation](http://pharobyexample.org/versions/PBE1-2009-10-28.pdf) Section [1.1](http://pharobyexample.org/versions/PBE1-2009-10-28.pdf#page=15) Getting started and Section [6.3](pharobyexample.org/versions/PBE1-2009-10-28.pdf#page=133) Monticello