### PR TITLE
Removed unnecessary CRLF newline

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -3,7 +3,7 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
There is an CR LF which should'nt be there
![osx_line_endings](https://cloud.githubusercontent.com/assets/8547365/9431051/cda90eae-4a09-11e5-9f80-29abc20d7d63.png)

2 times newline is for separation of Frameworks like in:
https://www.gitignore.io/api/vim,osx