### PR TITLE
Fuse hidden

### DIFF
--- a/Global/Linux.gitignore
+++ b/Global/Linux.gitignore
@@ -1,5 +1,8 @@
 *~
 
+# temporary files which can be created if a process still has a deleted file handle open
+.fuse_hidden*
+
 # KDE directory preferences
 .directory
 

--- a/Global/Linux.gitignore
+++ b/Global/Linux.gitignore
@@ -1,6 +1,6 @@
 *~
 
-# temporary files which can be created if a process still has a deleted file handle open
+# temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*
 
 # KDE directory preferences


### PR DESCRIPTION
`.fuse_hidden<random-number>` files can be created by FUSE filesystems if a process has a file handle (link count >1 on the file) on a file which is already deleted. `.fuse_hidden<random-number>` files are simply copies of the deleted files. They are fully temporary and can safely removed. Normally they are cleaned up automatically, at the latest after system reboot.

These files are only part of the filesystem management and so never interesting to commit them.
They can appear in every FUSE filesystem in any folder, so every guy can need this Pull Request in his `.gitignore`. In my case the files appear very often in a Windows NTFS-3G mounted filesystem under Ubuntu Linux.

I found no official documentation (no one seems to find one accoring to the comments), but many references (sorted a bit by relevance):
https://www.novell.com/support/kb/doc.php?id=7009301
http://askubuntu.com/a/493206/238229
http://serverfault.com/a/478619/229608
https://github.com/osxfuse/osxfuse/issues/3#issuecomment-2335680
http://stackoverflow.com/a/29561923/3644818
http://unix.stackexchange.com/a/48357
http://superuser.com/a/799866/341696
https://blog.hartwork.org/?p=1095
http://www.unix.com/unix-for-dummies-questions-and-answers/234021-rsync-can-i-delete-nfs-fuse-files.html