### PR TITLE
Visual Studio Team Explorer needs simple pattern to ignore packages

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -150,6 +150,8 @@ publish/
 !**/packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
+# Visual Studio Team Explorer needs a simple pattern to recognize packages as ignored
+/packages
 
 # Windows Azure Build Output
 csx/


### PR DESCRIPTION
The current .gitignore for Visual Studio works fine from the command line but the Git support in Team Explorer does not recognize the same pattern as Git command line tools on Windows. 

A simpler pattern like "/packages" is required to ignore the folder.