### PR TITLE
Add VisualStudio GhostDoc plugin setting file

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -199,6 +199,9 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
 


### PR DESCRIPTION
I'm trying this again. This includes @starpeng's single commit from #994.

From #994:

> I :heart: GhostDoc, but the fact that it creates a `$(SolutionFile).GhostDoc.xml` file for each solution I open with Visual Studio is *super* annoying.
> In the 50+ repos (mostly .NET) I've contributed to, I've yet to see anyone actually committing this file to a repository. So for every repository, I have to make sure I don't *accidentally* include the file in a commit.
> This makes me *really* want to include it by default in `VisualStudio.gitignore`. If you really want to commit it, it's easy to comment out the one line :smile:

Having these files in `.gitignore` is a much better default, since few people use GhostDoc and/or want the file in their repository.