### PR TITLE
'Podfile.lock' in Objective-C gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -34,6 +34,7 @@ xcuserdata
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 #Pods/
+#Podfile.lock
 
 # Carthage
 #


### PR DESCRIPTION
* If you want to use [Cocoapods](http://cocoapods.org), add `Podfile.lock` in Objective-C gitignore file
   * *But It's comment now*