### PR TITLE
ignore file for Blender 3D (blender.org) scripts and models

### DIFF
--- a/Blender.gitignore
+++ b/Blender.gitignore
@@ -1,0 +1,2 @@
+*.blend1
+__pycache__/


### PR DESCRIPTION
Rudimentary ignore definition for Blender 3D (blender.org) scripting and modeling.
