### PR TITLE
Added OS X Specific .DS_Store ignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -27,6 +27,9 @@ xcuserdata
 *.hmap
 *.ipa
 
+## OS X specific
+*.DS_Store
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -27,6 +27,9 @@ xcuserdata
 *.hmap
 *.ipa
 
+## OS X specific
+*.DS_Store
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However


### PR DESCRIPTION
With the majority of ObjC and Swift being done on Mac OS X I have added an ignore for the OS X Specific .DS_Store file in order to make git add . commands easier and less prone to inclusion of this file.