### PR TITLE
VSCode 0.8.0 config folder change

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,2 +1,2 @@
-.settings
+.vscode
 


### PR DESCRIPTION
Starting with 0.8.0, VS Code will store its settings in a .vscode folder and no longer in the generic .settings folder.