### PR TITLE
Create Stata.gitignore

### DIFF
--- a/Stata.gitignore
+++ b/Stata.gitignore
@@ -1,0 +1,2 @@
+# Binary data formats
+*.dta


### PR DESCRIPTION
Stata is a statistical software package: http://www.stata.com . This gitignore exclude the binary data format: http://www.stata.com/manuals14/pfileformatsdta.pdf .
