### PR TITLE
Remove entries for Intellij IDEA

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -11,7 +11,6 @@ bin/
 tmp/
 test-result
 server.pid
-*.iml
 *.eml
 /dist/
 .cache


### PR DESCRIPTION
The *.iml file is IDE specific.  It is generated by Intellij IDEA to store project related metadata.  It is not a Play Framework specific artifact and should not be included in the PlayFramework.gitignore.

See: https://github.com/github/gitignore/pull/1581

I would also vote for the removal of .eclipse and *.eml files on similar grounds but will do so in a separate pull request.