### PR TITLE
Windows Azure Emulator

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -155,6 +155,10 @@ publish/
 csx/
 *.build.csdef
 
+# Windows Azure Emulator
+efc/
+rfc/
+
 # Windows Store app package directory
 AppPackages/
 


### PR DESCRIPTION
Ignoring directory "efc" and "rfc" created by the Windows Azure Emulator

Directory before starting emulator the first time:

Directory: C:\temp\AzureCloudService1\AzureCloudService1

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----         9/1/2015   9:16 AM                bin
d-----         9/1/2015   9:16 AM                WorkerRole1Content
-a----         9/1/2015   9:16 AM           3014 AzureCloudService1.ccproj
-a----         9/1/2015   9:16 AM            144 AzureCloudService1.ccproj.user
-a----         9/1/2015   9:16 AM            505 ServiceConfiguration.Cloud.cscfg
-a----         9/1/2015   9:16 AM            505 ServiceConfiguration.Local.cscfg
-a----         9/1/2015   9:16 AM            428 ServiceDefinition.csdef


And after starting the Emulator:

Directory: C:\temp\AzureCloudService1\AzureCloudService1

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----         9/1/2015   9:16 AM                bin
d-----         9/1/2015   9:19 AM                csx
d-----         9/1/2015   9:19 AM                ecf
d-----         9/1/2015   9:19 AM                obj
d-----         9/1/2015   9:19 AM                rcf
d-----         9/1/2015   9:16 AM                WorkerRole1Content
-a----         9/1/2015   9:16 AM           3014 AzureCloudService1.ccproj
-a----         9/1/2015   9:16 AM            144 AzureCloudService1.ccproj.user
-a----         9/1/2015   9:16 AM            505 ServiceConfiguration.Cloud.cscfg
-a----         9/1/2015   9:16 AM            505 ServiceConfiguration.Local.cscfg
-a----         9/1/2015   9:16 AM            428 ServiceDefinition.csdef