### PR TITLE
Reports created by Ranorex test executions should not be tracked.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -215,3 +215,15 @@ FakesAssemblies/
 **/*.Server/GeneratedArtifacts
 **/*.Server/ModelManifest.xml
 _Pvt_Extensions
+
+# Execution reports created Ranorex
+*.nlog*
+*.rxlog*
+*.rxlog
+*_trace*
+*/*.rxuser
+*.rxuser
+*.rximg
+Report
+Reports
+*/Reports/*


### PR DESCRIPTION
Ranroex is a large plugin to Visual Studio for GUI test automation, so the usual VS ignores (.bin, .obj, etc.) should ignored with some additional ignores which are specific to a Ranorex Solution.