### PR TITLE
Update VisualStudioCode.gitignore for V 0.8.0

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,2 +1,2 @@
-.settings
+.vscode
 


### PR DESCRIPTION
Version 0.8.0 (released on Sept. 10, 2015) of Visual Studio code has renamed their `.settings` folder to `.vscode`

See https://code.visualstudio.com/updates#vscode for details

**Application's Homepage** - https://code.visualstudio.com/
