### PR TITLE
Visual Studio Code 0.8.0 has renamed .settings

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,2 +1,2 @@
 .settings
-
+.vscode

--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,2 +1,4 @@
+# VSCode vers. < 0.8.0
 .settings
+# VSCode vers. >= 0.8.0
 .vscode


### PR DESCRIPTION
As of VSCode 0.8.0 ```.settings``` is now ```.vscode```