### PR TITLE
WordPress: Only ignore files in root to support other plugins

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,7 +1,4 @@
 *.log
-.htaccess
-sitemap.xml
-sitemap.xml.gz
 wp-config.php
 wp-content/advanced-cache.php
 wp-content/backup-db/
@@ -13,6 +10,9 @@ wp-content/uploads/
 wp-content/wp-cache-config.php
 wp-content/plugins/hello.php
 
-/readme.html
+/.htaccess
 /license.txt
+/readme.html
+/sitemap.xml
+/sitemap.xml.gz
 


### PR DESCRIPTION
Most files are ignores without defining the directory.
This caused trouble with several plugins.
To fix that some files should only be ignored in the root directory.

- .htaccess is only ignored in the root directory
  due to some plugins or devs that need and create the htaccess
  for security issues in subfolders
- sitemap.xml and sitemap.xml.gz is only ignored in the root directory
  due to plugins that have an equal name and are therefor ignored
- Those files are ordered alphabetically