### PR TITLE
Add rule for MS PowerPoint temporary files

### DIFF
--- a/Global/MicrosoftOffice.gitignore
+++ b/Global/MicrosoftOffice.gitignore
@@ -8,3 +8,6 @@
 
 # Excel Backup File
 *.xlk
+
+# PowerPoint temporary
+~$*.ppt*


### PR DESCRIPTION
These files are created by PowerPoint when a file is opened. It's a temporary lock file.
The rule is similar to those for Word/Excel that are already present.

Unfortunately I could not find any official MS page which describe this file, but I've just verified that it is created on my pc using Office 2010.