### PR TITLE
Add a standard file for jekyll project

### DIFF
--- a/Jekyll.gitignore
+++ b/Jekyll.gitignore
@@ -1,3 +1,44 @@
+# Ignore docs files
+.ruby-version
+
+# Numerous always-ignore extensions
+*.diff
+*.err
+*.orig
+*.log
+*.rej
+*.swo
+*.swp
+*.zip
+*.vi
+*~
+
+# OS or Editor folders
+.DS_Store
+._*
+Thumbs.db
+.cache
+.project
+.settings
+.tmproj
+*.esproj
+nbproject
+*.sublime-project
+*.sublime-workspace
+.idea
+
+# Komodo
+*.komodoproject
+.komodotools
+
+# grunt-html-validation
+validation-status.json
+validation-report.json
+
+# Folders to ignore
+node_modules
+bower_components
 _site/
 .sass-cache/
 .jekyll-metadata
+_gh_page


### PR DESCRIPTION
A useful .gitignore file for your standard project jekyll.