### PR TITLE
Add gitignore file for bazel generated files

### DIFF
--- a/Bazel.gitignore
+++ b/Bazel.gitignore
@@ -1,0 +1,5 @@
+bazel-bin
+bazel-genfiles
+bazel-out
+bazel-testlogs
+


### PR DESCRIPTION
[Bazel](http://bazel.io) is Google's new build system for compiled
languages. At present there is no documentation on what files are
generated that need to be ignored but these are the ones that I've
noticed. A link to the documentation can be found
[here](http://bazel.io/docs/build-encyclopedia.html). Bazel is a really
awesome tool and it thankfully does not generate my extra files. It is
also incredibly easy to get started with so I imagine that it will
become pretty popular in the near future.
