### PR TITLE
Use https for all Help URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ high quality, we request that contributions adhere to the following guidelines.
 - **Provide a link to the application or project’s homepage**. Unless it’s
   extremely popular, there’s a chance the maintainers don’t know about or use
   the language, framework, editor, app, or project your change applies to.
-  
+
 - **Provide links to documentation** supporting the change you’re making.
   Current, canonical documentation mentioning the files being ignored is best.
   If documentation isn’t available to support your change, do the best you can
   to explain what the files being ignored are for.
-  
+
 - **Explain why you’re making a change**. Even if it seems self-evident, please
   take a sentence or two to tell us why your change or addition should happen.
   It’s especially helpful to articulate why this change applies to *everyone*
   who works with the applicable technology, rather than just you or your team.
-  
+
 - **Please consider the scope of your change**. If your change specific to a
   certain language or framework, then make sure the change is made to the
   template for that language or framework, rather than to the template for an
@@ -70,9 +70,9 @@ Here’s how we suggest you go about proposing a change to this project:
 Using the web-based interface to make changes is fine too, and will help you
 by automatically forking the project and prompting to send a pull request too.
 
-[fork]: http://help.github.com/forking/
+[fork]: https://help.github.com/forking/
 [branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository
-[pr]: http://help.github.com/pull-requests/
+[pr]: https://help.github.com/pull-requests/
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Here’s how we suggest you go about proposing a change to this project:
 Using the web-based interface to make changes is fine too, and will help you
 by automatically forking the project and prompting to send a pull request too.
 
-[fork]: https://help.github.com/forking/
+[fork]: https://help.github.com/articles/fork-a-repo/
 [branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository
-[pr]: https://help.github.com/pull-requests/
+[pr]: https://help.github.com/articles/using-pull-requests/
 
 ## License
 


### PR DESCRIPTION
Use https for all Help URLs and avoid unnecessary redirects from old Help URLs.