### PR TITLE
Update ForceDotCom.gitignore

### DIFF
--- a/ForceDotCom.gitignore
+++ b/ForceDotCom.gitignore
@@ -1,4 +1,11 @@
 .project
 .settings
+.metadata
 salesforce.schema
 Referenced Packages
+*.sublime-project
+*.sublime-settings
+*.sublime-workspace
+apex-scripts/log
+build.properties
+config


### PR DESCRIPTION
In order to support latest Salesforce.com development tools the following paths were added

.metadata - This folder contains metadata information which is related to Force.com IDE which working as a plugin for Eclipse Platform 

During a past few years Mavensmate (http://mavensmate.com/) is going to be a primary IDE for Force.com developers. This IDE works on top of Sublime Text editor, thus the following files and folders must be excluded from git repository:
*.sublime-project
*.sublime-settings
*.sublime-workspace
config - Mavensmate configuration
apex-scripts/log - logs of execution Apex code from Mavensmate

build.properties - properties for Apache Ant which is used as a base for Salesforce.com Ant Migration Tool. This tool provides a build automation functionality. Especially for Force.com projects this file contains credentials and keys which should not be added into git repository.