### PR TITLE
Ignore vendor directory

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -2,3 +2,4 @@
 .env.*.php
 .env.php
 .env
+/vendor


### PR DESCRIPTION
The `vendor` directory is where the app dependencies are stored, after running `composer install` or `composer update`. It shouldn't be added to version control, since it is enough to have the `composer.json` file to resolve dependencies