### PR TITLE
gitignore file for D

### DIFF
--- a/D.gitignore
+++ b/D.gitignore
@@ -1,0 +1,20 @@
+# Compiled Object files
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.a
+*.lib
+
+# Executables
+*.exe
+
+# DUB
+.dub
+docs.json
+__dummy.html


### PR DESCRIPTION
[D Programming Language](http://dlang.org/)

Ignore the usual obj/library/executable files.
See https://github.com/D-Programming-Language/dub/blob/89c8dea75ae9cfde1ae6cfb7d9fe03dbccdbbdf8/source/dub/init.d#L168 for dub's default .gitignore.