### PR TITLE
Ignore ./wheelhouse directories

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -20,6 +20,7 @@ lib64/
 parts/
 sdist/
 var/
+wheelhouse/
 *.egg-info/
 .installed.cfg
 *.egg


### PR DESCRIPTION
Python's new [wheel distribution format](https://www.python.org/dev/peps/pep-0427/) has [`wheel` tooling](https://pypi.python.org/pypi/wheel) which is not yet fully accounted for in Python's gitignore. Whilst `python setup.py bdist_wheel` will build into the dist/ directory, `pip wheel` builds into the wheelhouse/ directory, which this patch adds to the ignore list. The wheelhouse directory -- as with the dist directory -- ends up with a lot of binary files in it.
