### PR TITLE
Update waf for python3 builds

### DIFF
--- a/Waf.gitignore
+++ b/Waf.gitignore
@@ -1,3 +1,4 @@
 # for projects that use Waf for building: http://code.google.com/p/waf/
 .waf-*
+.waf3-*
 .lock-*


### PR DESCRIPTION
Waf uses .waf3-* if the interpreter is python3.

For distributions whose default is now python3, this avoids them accidentally committing the waf directory.