### PR TITLE
Ignore output from R CMD build and R CMD check

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -5,6 +5,12 @@
 # Example code in package build process
 *-Ex.R
 
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
 # RStudio files
 .Rproj.user/
 


### PR DESCRIPTION
Both rules are restricted to the top level only, so `*.tar.gz` files in data directories for instance will _not_ be ignored.