### PR TITLE
Ignore `.RData` files

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -2,6 +2,9 @@
 .Rhistory
 .Rapp.history
 
+# Session Data files
+.RData
+
 # Example code in package build process
 *-Ex.R
 


### PR DESCRIPTION
N.B. this ignores only the exact file `.RData` generated by default from `save.image()` and `quit()`.  It is _not_ what is referred to in https://github.com/github/gitignore/commit/1f8466164330277fc8c9126ded3cc207ff3baf91 and http://cran.r-project.org/doc/manuals/r-release/R-exts.html#Data-in-packages, which refers only to files with an `*.RData` _extension_.