### PR TITLE
Ignore FAKE - F# Make cache folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -218,3 +218,6 @@ _Pvt_Extensions
 
 # Paket dependency manager
 .paket/paket.exe
+
+# FAKE - F# Make
+.fake/


### PR DESCRIPTION
Recent versions of FAKE uses a cache folder containing a compiled version of all scripts named .fake that should never be commited to git.