### PR TITLE
added excludes for vendored directories (since GO 1.5)

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# GO15VENDOREXPERIMENT flag specifics
+vendor/**
+!vendor/manifest


### PR DESCRIPTION
The standard github .gitignore file for GO does not exclude vendored directories. Since Go 1.5, the Go compiler with look for dependencies under the `/vendor/**` path first and default back to the `$GOPATH/**`. Most vendoring tools for go do not expect you to have the directories under `/vendor` checked in but will `go get` them into the vendor directory. That's why I recommend excluding the `/vendor/**` directories. The `/vendor/manifest` file is needed by many  dependency management tools in Go to keep a record of the vendored dependencies and rebuild them if necessary - so it should not be excluded.