### PR TITLE
Dartdoc output directory, pubspec.lock comment disambiguation

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,4 +1,4 @@
-# Don’t commit the following directories created by pub.
+﻿# Don’t commit the following directories created by pub.
 .buildlog
 .pub/
 build/
@@ -11,5 +11,8 @@ packages
 *.js.deps
 *.js.map
 
-# Include when developing application packages.
+# Or the files created by dartdoc.
+doc/
+
+# Don't commit pubspec lock file. (Library packages only! Remove pattern if developing an application package.)
 pubspec.lock

--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,4 +1,4 @@
-﻿# Don’t commit the following directories created by pub.
+# Don’t commit the following directories created by pub.
 .buildlog
 .pub/
 build/


### PR DESCRIPTION
1. Added directory for output of dartdoc tool.
2. Made style of comment for the pubspec.lock pattern consistent with others and disambiguated it.