### PR TITLE
Adding Fastlane ignore files

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -41,3 +41,10 @@ xcuserdata
 # Carthage/Checkouts
 
 Carthage/Build
+
+# Fastlane
+#
+# Add the following lines if you want to avoid checking in Fastlane generated files.
+#
+# fastlane/report.xml
+# fastlane/screenshots


### PR DESCRIPTION
Fastlane https://fastlane.tools/ is a very useful tool that lets you define and run your deployment pipelines for different environments. It helps to unify apps release process and automate the whole process. fastlane connects all fastlane tools and third party tools, like CocoaPods and xctool.

These two ignore lines are the ones that avoid generated files to be checked in to the repo and also used in the fastlane main example: https://github.com/KrauseFx/fastlane-example/blob/master/.gitignore