### PR TITLE
Fix Prestashop unwanted gitignored directory

### DIFF
--- a/Prestashop.gitignore
+++ b/Prestashop.gitignore
@@ -8,6 +8,7 @@ config/settings.*.php
 
 admin-dev/autoupgrade/
 cache/
+!classes/cache/
 config/xml/*.xml
 log/
 *sitemap.xml


### PR DESCRIPTION
The line `cache/` causing problem for gitignore important class directory and files `classes/cache/*`.