### PR TITLE
Ignore some Android Studio files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -15,6 +15,7 @@ gen/
 # Gradle files
 .gradle/
 build/
+*/build
 
 # Local configuration file (sdk path, etc)
 local.properties
@@ -30,3 +31,11 @@ proguard/
 
 # Android Studio captures folder
 captures/
+
+#Android Studio project files
+*.iml
+*/*.iml
+.idea/
+
+#Ignore DS_Store for mac users
+.DS_Store


### PR DESCRIPTION
The .iml files and .idea folder is auto generated and should be ignored in git
Adding the */build to be ignored because now the Android project structure add a build folder inside app folder to output auto generated things like apk and class files.
Adding DS_Store to be useful for mac users.