### PR TITLE
Ignoring build folder inside app module in Android projects

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -15,6 +15,7 @@ gen/
 # Gradle files
 .gradle/
 build/
+*/build/
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
The `*/build` folder should be ignored because the android structure generate files and outputs inside this folder.