### PR TITLE
Added doctrine 2 orm default cache and proxy locations

### DIFF
--- a/ZendFramework.gitignore
+++ b/ZendFramework.gitignore
@@ -15,6 +15,11 @@ data/sessions/
 data/tmp/
 temp/
 
+#Doctrine 2
+data/DoctrineORMModule/Proxy/
+data/DoctrineORMModule/cache/
+
+
 # Legacy ZF1
 demos/
 extras/documentation


### PR DESCRIPTION
Many of the ZF2 applications are integrated with Doctrine 2. The default location of Proxies and Caches are the ones specified in the PR. For more details checkout the configurations examples: https://github.com/doctrine/DoctrineORMModule/blob/master/docs/configuration.md