### PR TITLE
Add /cover to Elixir.gitignore

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -1,4 +1,5 @@
 /_build
+/cover
 /deps
 erl_crash.dump
 *.ez


### PR DESCRIPTION
`/cover` is where `mix test --cover` adds its test coverage results.

I suggest ignoring this folder, as [`mix new` task does already](https://github.com/elixir-lang/elixir/blob/e12ca353a9c99a285bb1f0a670eda5d73077dc4b/lib/mix/lib/mix/tasks/new.ex#L219).