### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,18 +1,18 @@
-# Don’t commit the following directories created by pub.
+# Files and directories created by pub
 .buildlog
+.packages
+.project
 .pub/
 build/
-packages
-.packages
+**/packages/
 
-# Or the files created by dart2js.
-*.dart.js
-*.js_
+# Files created by dart2js
+*.js
 *.js.deps
 *.js.map
 
-# Or the files created by dartdoc.
+# Directory created by dartdoc
 doc/
 
-# Don't commit pubspec lock file. (Library packages only! Remove pattern if developing an application package.)
+# Don't commit pubspec lock file (Library packages only! Remove pattern if developing an application package)
 pubspec.lock

--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -10,6 +10,7 @@ build/
 *.js
 *.js.deps
 *.js.map
+*.info.json
 
 # Directory created by dartdoc
 doc/

--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -8,6 +8,7 @@ build/
 
 # Files created by dart2js
 *.js
+*.precompiled.js
 *.js.deps
 *.js.map
 *.info.json


### PR DESCRIPTION
1. Modify patterns to explicitly match directories

2. Modified patterns to match files and directories created by tools in Dart SDK 1.12:

    1. `pub` patterns:

        * Added patterns matching files listed in https://www.dartlang.org/tools/private-files.html

    2. `dart2js` patterns:

        * Added `*.js`, `*.precompiled.js` removed `*.js_`, `*.dart.js` to match files created by dart2js - see https://stackoverflow.com/questions/20314796/which-files-are-generated-when-executing-dart2js-and-why
        * Added `*.info.json` - see https://www.dartlang.org/tools/dart2js/