### PR TITLE
Updates based on discussions with Dart team

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,3 +1,5 @@
+# See https://www.dartlang.org/tools/private-files.html
+
 # Files and directories created by pub
 .buildlog
 .packages
@@ -7,14 +9,19 @@ build/
 **/packages/
 
 # Files created by dart2js
-*.js
-*.precompiled.js
+# (Most Dart developers will use pub build to compile Dart, use/modify these 
+#  rules if you intend to use dart2js directly
+#  Convention is to use extension '.dart.js' for Dart compiled to Javascript to
+#  differentiate from explicit Javascript files)
+*.dart.js
+*.js.part
 *.js.deps
 *.js.map
 *.info.json
 
 # Directory created by dartdoc
-doc/
+doc/api
 
-# Don't commit pubspec lock file (Library packages only! Remove pattern if developing an application package)
+# Don't commit pubspec lock file 
+# (Library packages only! Remove pattern if developing an application package)
 pubspec.lock


### PR DESCRIPTION
1. Updates based on discussions with Dart team
See https://github.com/dart-lang/www.dartlang.org/issues/1496

* Removed *.precompiled.js - not generated by dart2js any more
* *.js_ → *.part.js

Also:

2. Added guidance comments

3. doc/ → doc/api as manually written documents may be in doc/

4. Added reference to appropriate Dart web site page