### PR TITLE
ignore IntelliJ IDEA workspace configuration file

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -31,3 +31,7 @@ proguard/
 
 # Android Studio captures folder
 captures/
+
+# IntelliJ IDEA workspace configuration file
+.idea/workspace.xml
+.idea/libraries/


### PR DESCRIPTION
`.idea/workspace.xml` and `.idea/libraries/`  are not necessary just like `local.properties`, if not exists android  studio will be create it.

android studio's default .gitignore file
```
.gradle
/local.properties
/.idea/workspace.xml
/.idea/libraries
.DS_Store
/build
/captures
````