### PR TITLE
Update JetBrains.gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,4 +1,4 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 
 *.iml
 


### PR DESCRIPTION
Added a forgotten IDE to the .gitignore documentation.

Why?
For completeness and correctness

What?
[Webstorm](https://www.jetbrains.com/webstorm).