### PR TITLE
Update Umbraco.gitignore

### DIFF
--- a/Umbraco.gitignore
+++ b/Umbraco.gitignore
@@ -6,6 +6,7 @@
 **/App_Data/Logs/
 **/App_Data/[Pp]review/
 **/App_Data/TEMP/
+**/App_Data/cache/
 Cached/
 
 # Ignore Umbraco content cache file


### PR DESCRIPTION
ImageProcessorModule added to Umbraco 7 creates a image cache folder in App_Data

See:
https://our.umbraco.org/projects/collaboration/imageprocessor/
http://imageprocessor.org/imageprocessor-web/configuration/