### PR TITLE
Create gitignore for Ceylon

### DIFF
--- a/Ceylon.gitignore
+++ b/Ceylon.gitignore
@@ -1,0 +1,1 @@
+/modules


### PR DESCRIPTION
Project home: http://ceylon-lang.org/

There is no clear official guidelines which files should be ignored.
The reason why I want to add `/modules/` to Ceylon.gitignore is that this is default location where ceylon tools store compilation output.
Reference http://ceylon-lang.org/documentation/1.2/reference/tool/config/#_local_repository
