### PR TITLE
Revert "Ignoring build folder inside app module in Android projects"

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -15,7 +15,6 @@ gen/
 # Gradle files
 .gradle/
 build/
-*/build/
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
This reverts commit f4cf36c5e1e275cb40b981f84be0cd723cd0c152.

`build/` two lines above already matches all nested directories as well. No need for this redundant line. The same problem was already fixed by @baudm in 9c8c32fea57a9539241900c93cce2d65b62aa418 earlier this year.

From his commit message:

> build/ already matches all directories named 'build' in the repository, regardless of level. Gradle can have more than two levels of project nesting. However, /*/build/ matches only the 'build' directories of 2nd-level projects. Thus, the first pattern is more appropriate than the second.