### PR TITLE
Initial gitignore file for Cadence Virtuoso

### DIFF
--- a/Global/Virtuoso.gitignore
+++ b/Global/Virtuoso.gitignore
@@ -1,0 +1,18 @@
+# Gitignore for Cadence Virtuoso
+################################################################
+
+# Log files
+*.log
+panic*.log.*
+
+# OpenAccess database lock files
+*.cdslck*
+
+# Run directories for layout vs. schematic and design rule check
+lvsRunDir/*
+drcRunDir/*
+
+# Abstract generation tool
+abstract.log*
+abstract.record*
+


### PR DESCRIPTION
 [Cadence Virtuoso](http://www.cadence.com/products/cic/Pages/default.aspx)

Cadence Virtuoso is a commercial EDA tool used for full custom IC (ASIC) design, providing capabilities like schematic capture, layout and simulation. This gitignore file blacklists database 
lock files, the contents of run directories for layout versus schematic and design rule checks as
 well as log files for a selection of tools of the suite.

[Cadence](https://en.wikipedia.org/wiki/Cadence_Design_Systems) is a major player and the software is used widely in chip industry as well as by students & researchers in universities. I propose the addition of this gitignore file due to an other equally widespread EDA tool (ModelSim, used for digital simulation) already included. 
