### PR TITLE
Revert 2bd7d8ec88bc9fad5aca91951826b16118227554

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -22,7 +22,3 @@ _testmain.go
 *.exe
 *.test
 *.prof
-
-# GO15VENDOREXPERIMENT flag specifics
-vendor/**
-!vendor/manifest


### PR DESCRIPTION
Reverts github/gitignore#1689

@shiftkey This is bad. Can we revert this please? It is a common go idiom to commit your dependencies. Only [gb](https://github.com/constabulary/gb) uses a manifest file. The most popular is [godeps](https://github.com/tools/godep) right now and they suggest that you commit the dependencies. I think since this controversial. I would suggest that remove this. I know that we commit our dependencies and would like to continue to do so by default. Go 1.5 does not state anywhere that you should not commit them. 