### PR TITLE
Ignore REPL history file

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # Optional npm cache directory
 .npm
+
+# Optional REPL history
+.node_repl_history


### PR DESCRIPTION
Like in #1732, Docker images can consider project directoy as $HOME