### PR TITLE
Add .ipynb_checkpoints dir to python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# ipython/jupyter notebook
+.ipynb_checkpoints/


### PR DESCRIPTION
[ipython/jupyter notebooks](https://jupyter.org/) are often used when working with python projects. But they autosave incremental changes into a `.ipynb_checkpoints/` directory. This ignores these directories.