### PR TITLE
add *.xcscheme to Global/Xcode.gitignore,Objective-C.gitignore and Sw…

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -21,3 +21,4 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 *.xcuserstate
+*.xcscheme

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -22,6 +22,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+*.xcscheme
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -22,6 +22,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+*.xcscheme
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
In this change, I added *.xcscheme to Global/Xcode.gitignore,Objective-C.gitignore and Swift.gitignore. When we use Xcode to develop iOS App, we must ignore *.xcscheme file. Because if we use Git to control version, *.xcscheme will lead to continuous modification automatically. But it's not necessary. At present, this change is used in this repo. [https://github.com/chenyufeng1991/CollectionView](https://github.com/chenyufeng1991/CollectionView).