### PR TITLE
Add HSP.gitignore

### DIFF
--- a/HSP.gitignore
+++ b/HSP.gitignore
@@ -1,0 +1,9 @@
+# Object files
+hsptmp*
+packfile
+obj
+*.ax
+
+# Binaries
+*.exe
+*.dpm


### PR DESCRIPTION
Hello!
I'm shouh and Japanese hobby programmer.
I want to add HSP.gitignore to this proj.
## HSP?

`HSP`--Hot Soup Processor-- is a Programming Language for Japanese Windows.
In Japan, `HSP` is mainly used for game programming and light scripting.
See also http://hsp.tv/
## Intention in this request

Unfortunately,
- `HSP` Documentation isn't available from the web.
  - You can read after finishing an installation.
- `HSP` Documentation is written in Japanese.
- `HSP` cannot be hilighted in the Github.com.

I want to know whether these Japanese Programming Language can be applyed to this project.

---

You know I'm poor at English.
Thank you for reading.
