### PR TITLE
Issue with .gitignore not ignoring node_modules

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -25,7 +25,7 @@ build/Release
 
 # Dependency directory
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
-node_modules
+node_modules/
 
 # Optional npm cache directory
 .npm


### PR DESCRIPTION
This fixes the bug that is documented here:
https://github.com/vmaudgalya/redux-timer/commit/30ba26fda235e516fa31b82d33b39455bd177965


The bug is as follows:
Initially, when I created the repository "redux-timer" I initialized the repo with the default .gitignore for Nodejs projects. However, after pushing, .gitignore did not ignore node_modules/ folder and its contents, and thus I ended up pushing node_modules, and ended up having to remove it later. This PR should fix this issue.

