### PR TITLE
Updated LICENSE year to 2015

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 GitHub, Inc.
+Copyright (c) 2015 GitHub, Inc.
 
 Permission is hereby granted,  free of charge,  to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
The MIT license file currently lists 2014; I'm updating to 2015.