### PR TITLE
Adding endfloat.sty auxiliary files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -141,3 +141,7 @@ pythontex-files-*/
 # WinEdt
 *.bak
 *.sav
+
+# endfloat
+*.ttt
+*.fff


### PR DESCRIPTION
endfloat.sty produces these two auxiliary files.
From Section 3.2 of its documentation:
> Loading it will have LATEX produce two extra files with .ttt and .fff extensions (for tables and figures, respectively).