### PR TITLE
OpenCart system cache and logs location changes

### DIFF
--- a/OpenCart.gitignore
+++ b/OpenCart.gitignore
@@ -7,5 +7,6 @@ admin/config.php
 download/
 image/data/
 image/cache/
-system/cache/
-system/logs/
+system/library/cache/
+system/storage/cache/
+system/storage/logs/


### PR DESCRIPTION
I tried to locate when this changed in OpenCart (https://github.com/opencart/opencart/commits/master) but wasn't able to just looking at the commit messages. But, as of a fresh install of 2.1.0.1, these appear to be the new locations.
