### PR TITLE
Remove *.xcscheme from Global/Xcode.gitignore,Objective-C.gitignore and…

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -21,4 +21,3 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 *.xcuserstate
-*.xcscheme

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -22,7 +22,6 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
-*.xcscheme
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -22,7 +22,6 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
-*.xcscheme
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
… Swift.gitignore

Xcode schemes should be held under source control when shared. When not shared they are stored in xcuserdata, so are already ignored. Therefore ignoring *.xcscheme is incorrect, as far as I'm aware.