### PR TITLE
Add ignores for autoscan files

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -2,6 +2,10 @@
 
 Makefile.in
 
+/autoscan.log
+/autoscan-*.log
+/configure.scan
+
 # http://www.gnu.org/software/autoconf
 
 /autom4te.cache

--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -2,16 +2,16 @@
 
 Makefile.in
 
-/autoscan.log
-/autoscan-*.log
-/configure.scan
-
 # http://www.gnu.org/software/autoconf
 
 /autom4te.cache
+/autoscan.log
+/autoscan-*.log
 /aclocal.m4
 /compile
+/config.h.in
 /configure
+/configure.scan
 /depcomp
 /install-sh
 /missing


### PR DESCRIPTION
Files generated by [autoscan](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/autoscan-Invocation.html) should be ignored too: they're a `configure.ac` template (`configure.scan`) and logs.
This is done by numerous projects, e.g. https://github.com/google/ios-webkit-debug-proxy/pull/113/files