### PR TITLE
gitignore for JENKINS_HOME Jenkins settings

### DIFF
--- a/JENKINS_HOME.gitignore
+++ b/JENKINS_HOME.gitignore
@@ -1,0 +1,19 @@
+#Learn more about Jenkins and JENKINS_HOME directory for which this file is intended.
+#  http://jenkins-ci.org/
+#  https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins
+
+#ignore all JENKINS_HOME except jobs directory, root xml config, and .gitignore file
+/*
+!/jobs
+!/.gitignore
+!/*.xml
+
+#ignore all files in jobs subdirectories except for folders
+#note: git doesn't track folders, only file content
+jobs/**
+!jobs/**/
+
+#exclude only config.xml files in repository subdirectories
+!config.xml
+
+#as a result only settings and job config.xml files in JENKINS_HOME will be tracked by git

--- a/JENKINS_HOME.gitignore
+++ b/JENKINS_HOME.gitignore
@@ -13,7 +13,13 @@
 jobs/**
 !jobs/**/
 
+#uncomment the following line to save next build numbers with config
+#!jobs/**/nextBuildNumber
+
 #exclude only config.xml files in repository subdirectories
 !config.xml
+
+#don't track workspaces (when users build on the master)
+jobs/**/*workspace
 
 #as a result only settings and job config.xml files in JENKINS_HOME will be tracked by git


### PR DESCRIPTION
This allows an admin to use git to keep a backup of Jenkins settings without tracking binary artifacts.  Useful for preserving settings during plugin upgrades.

Note: `secret.key` is purposefully not tracked by git.  This should be backed up separately because configs may contain secrets which were encrypted using the `secret.key`.

See also:
- http://jenkins-ci.org/
- https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins
