### PR TITLE
Fix ignore rule for Dart packages symlinks

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -6,7 +6,7 @@
 .project
 .pub/
 build/
-**/packages/
+packages
 
 # Files created by dart2js
 # (Most Dart developers will use pub build to compile Dart, use/modify these 


### PR DESCRIPTION
This fixes the ignore rule for Dart (https://www.dartlang.org/) packages directories. Dart uses a tool called `pub` for dependency management. All dependencies are stored in the repository root in a directory called `packages`. According to https://www.dartlang.org/tools/private-files.html the packages directory which holds the dependencies should be ignored (of course this also makes a lot of sense). Dart makes a symlink to this packages directory in all directories in your repositories. Since Git treats symlinks as files, the trailing slash on this line should be removed so not only the root packages directory but also all symlinks to this directory are ignored. 
