### PR TITLE
Add rule to unignore the maven wrapper jar

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,3 +7,6 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+
+# Exclude maven wrapper
+!/.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
If a project uses the maven-wrapper library (https://github.com/takari/maven-wrapper) the .jar file of the maven-wrapper gets excluded if there is a catch-all `*.jar` rule in the .gitignore. 

I think the un-ignore rule for the maven-wrapper fits best into the normal maven `.gitignore`. 
However, I have noticed that the un-ignore rule is ignored if the catch-all `*.jar` rule is applied after the one I add. Is it possible to further customize the rule in a way, so the order in which the rules appear in the `.gitignore` is not important?
