### PR TITLE
remove harmful line from PlayFramework.gitignore

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -5,7 +5,6 @@ bin/
 /lib/
 /logs/
 /modules
-/project/project
 /project/target
 /target
 tmp/


### PR DESCRIPTION
'project/project' is valid directory for 'project' project-related files. For example, if one configure his sbt build to use scala files directly from 'project/', dependencies like 'project/project/plugins.sbt' will be ignored because of this line.
See http://www.scala-sbt.org/0.13/tutorial/Organizing-Build.html#sbt+is+recursive.