### PR TITLE
Update Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -23,7 +23,7 @@ moc_*.cpp
 qrc_*.cpp
 ui_*.h
 Makefile*
-*-build-*
+*build-*
 
 # QtCreator
 


### PR DESCRIPTION
Qt generates build files for me that are `build-Projname-WhateverWhatever` so this change continues to support *-build-* folders as well as others.