### PR TITLE
Incorrect Dir Path

### DIFF
--- a/Composer.gitignore
+++ b/Composer.gitignore
@@ -1,5 +1,5 @@
 composer.phar
-vendor/
+/vendor/
 
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file


### PR DESCRIPTION
When generating the ignore rules for Composer, an incorrect format is used. The vendor directory added is written `vendor/`, which causes other `vendors` directories to be ignored. The correct format to use is `/vendor/`, which would only ignore the root `vendor` directory.