### PR TITLE
Fix typo for Azure Emulator log directory

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -156,7 +156,7 @@ csx/
 *.build.csdef
 
 # Windows Azure Emulator
-efc/
+ecf/
 rfc/
 
 # Windows Store app package directory

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -157,7 +157,7 @@ csx/
 
 # Windows Azure Emulator
 ecf/
-rfc/
+rcf/
 
 # Windows Store app package directory
 AppPackages/


### PR DESCRIPTION
The Azure emulator actually generates an ecf/ directory.