### PR TITLE
Add 'opendb' file to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -76,6 +76,7 @@ _Chutzpah*
 ipch/
 *.aps
 *.ncb
+*.opendb
 *.opensdf
 *.sdf
 *.cachefile


### PR DESCRIPTION
Looks like Visual Studio has started creating a "[Solution].VC.opendb" file when you open a solution with C++ projects. This should be added to the gitignore for VS.