### PR TITLE
Update OpenCart.gitignore

### DIFF
--- a/OpenCart.gitignore
+++ b/OpenCart.gitignore
@@ -9,3 +9,5 @@ image/data/
 image/cache/
 system/cache/
 system/logs/
+
+system/storage/


### PR DESCRIPTION
Ignore storage folder (contains logs, cache, uploads, etc.)

This change will make .gitignore compatible with all OpenCart versions.