### PR TITLE
Add Swift Package Manager to Swift.gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -27,6 +27,12 @@ xcuserdata
 *.hmap
 *.ipa
 
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+.build/
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However


### PR DESCRIPTION
This adds lines relevant to the [Swift Package Manager](https://github.com/apple/swift-package-manager) to `Swift.gitignore` - the directories `Packages` and `.build`. This is the new, official package manager for Swift code.

Matches the style used for Carthage - build directory disabled by default, checkouts directory (`Packages`) optionally disabled. This matches what the [official examples do](https://github.com/apple/example-package-dealer/blob/master/.gitignore), although actually *running* `swift build` will leave a dirty working tree, since they haven't checked in `Packages` already.