### PR TITLE
Update to include iMPACT and Core Generator files

### DIFF
--- a/Global/XilinxISE.gitignore
+++ b/Global/XilinxISE.gitignore
@@ -42,6 +42,16 @@
 *_usage.xml
 *_xst.xrpt
 
+# iMPACT generated files
+_impactbatch.log
+impact.xsl
+impact_impact.xwbt
+ise_impact.cmd
+webtalk_impact.xml
+
+# Core Generator generated files
+xaw2verilog.log
+
 # project-wide generated files
 *.gise
 par_usage_statistics.html


### PR DESCRIPTION
I know the Xilinx ISE has been deprecated, but I still work on old Virtexs and these files really should be included in the ignores.

iMPACT is the JTAG programming utility for the ISE and Core Generator is the proprietary core generation tool.