### PR TITLE
Add RubyMine specific file to Ruby.gitignore

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -15,6 +15,9 @@
 .repl_history
 build/
 
+# Specific to RubyMine:
+/.idea
+
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/


### PR DESCRIPTION
[RubyMine](https://www.jetbrains.com/ruby/) is a Ruby and Rails IDE, used very commonly in companies, which automatically makes this file, that you'd want to ignore :smile: 