### PR TITLE
Racket ignore files

### DIFF
--- a/Racket.gitignore
+++ b/Racket.gitignore
@@ -1,0 +1,4 @@
+*~
+*.bak
+
+compiled/


### PR DESCRIPTION
`.bak` as temp files in root and `compiled` as default build folder
