### PR TITLE
Tex: Ignore files generated by pdfcomment package

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -120,6 +120,10 @@ _minted*
 *.sympy
 sympy-plots-for-*.tex/
 
+# pdfcomment
+*.upa
+*.upb
+
 #pythontex
 *.pytxcode
 pythontex-files-*/


### PR DESCRIPTION
The pdfcomment package generates *.upa and *.upb files when compiling LaTeX files. These should be ignored as well.