### PR TITLE
Bugfix - Typos in comments

### DIFF
--- a/Global/EiffelStudio.gitignore
+++ b/Global/EiffelStudio.gitignore
@@ -1,2 +1,2 @@
-# The compilation directoy
+# The compilation directory
 EIFGENs

--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -16,11 +16,11 @@ pickle-email-*.html
 config/initializers/secret_token.rb
 config/secrets.yml
 
-## Environment normalisation:
+## Environment normalization:
 /.bundle
 /vendor/bundle
 
-# these should all be checked in to normalise the environment:
+# these should all be checked in to normalize the environment:
 # Gemfile.lock, .ruby-version, .ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:

--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -21,7 +21,7 @@ build/
 /doc/
 /rdoc/
 
-## Environment normalisation:
+## Environment normalization:
 /.bundle/
 /vendor/bundle
 /lib/bundler/man/

--- a/Typo3.gitignore
+++ b/Typo3.gitignore
@@ -1,5 +1,5 @@
 ## TYPO3 v6.2
-# Ignore serveral upload and file directories.
+# Ignore several upload and file directories.
 /fileadmin/user_upload/
 /fileadmin/_temp_/
 /fileadmin/_processed_/


### PR DESCRIPTION
This PR fixes few typos found in comments.

> Please only modify one template per pull request. This helps keep pull requests and feedback focused on a specific project or technology.

Considering that this PR does not actually touch **any** ignore paths, I think it is OK for this to modify just few of these files.