### PR TITLE
Ignore BundleArtifacts folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -162,6 +162,7 @@ rcf/
 
 # Windows Store app package directory
 AppPackages/
+BundleArtifacts/
 
 # Visual Studio cache files
 # files ending in .cache can be ignored


### PR DESCRIPTION
Visual Studio creates folder named as `BundleArtifacts` during generation of app package for Windows Store. This folder can be ignored.