### PR TITLE
Added Eclipse Recommenders to Eclipse gitignore

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -10,6 +10,7 @@ tmp/
 local.properties
 .settings/
 .loadpath
+.recommenders
 
 # Eclipse Core
 .project


### PR DESCRIPTION
**Project:** Eclipse Code Recommenders: http://www.eclipse.org/recommenders/
**Documentation:** http://www.eclipse.org/recommenders/manual/
**Why:** Eclipse Code Recommenders creates a new folder called ".recommenders" for its Code Recommenders feature. Because these are not actual code files, they can be safely ignored.