### PR TITLE
Ignore auxiliary files from \usepackage{cprotect}

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -32,8 +32,6 @@
 *.pdfsync
 
 ## Auxiliary and intermediate files from other packages:
-
-
 # algorithms
 *.alg
 *.loa
@@ -48,6 +46,9 @@ acs-*.bib
 *.nav
 *.snm
 *.vrb
+
+# cprotect
+*.cpt
 
 #(e)ledmac/(e)ledpar
 *.end


### PR DESCRIPTION
[cprotect](https://www.ctan.org/tex-archive/macros/latex/contrib/cprotect?lang=en) tracks its contents in an auxiliary file, this is safe to ignore.