### PR TITLE
Ignore ncrunch project and solution files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -111,6 +111,8 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+*.ncrunchproject
+*.ncrunchsolution
 
 # MightyMoose
 *.mm.*


### PR DESCRIPTION
This ignores [NCrunch](http://www.ncrunch.net/) solution and project files. These files are auto-generated, and IMO should not be part of solution. Without these files, solution will still load, but NCrunch will be disabled.