### PR TITLE
KiCAD: ignore more temp files and generated data

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -18,6 +18,3 @@ _autosave-*
 # Exported BOM files
 *.xml
 *.csv
-
-# Other system files
-.DS_Store

--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -5,9 +5,19 @@
 *.bak
 *.bck
 *.kicad_pcb-bak
+*~
+_autosave-*
+*.tmp
 
 # Netlist files (exported from Eeschema)
 *.net
 
 # Autorouter files (exported from Pcbnew)
 .dsn
+
+# Exported BOM files
+*.xml
+*.csv
+
+# Other system files
+.DS_Store


### PR DESCRIPTION
- New temporary file patterns : `*~`, `_autosave-*`, `*.tmp`, `.DS_Store`

- New *Bill Of Materials* file extensions : `.xml`, directly generated from the schematics files (`.sch`, not in gitignore). Then official scripts like *bom2csv.xsl* generate the actual BOM as `.csv`.
Doc: http://docs.kicad-pcb.org/en/eeschema.html#creating-customized-netlists-and-bom-files