### PR TITLE
Stop ignoring StyleCop.json

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -172,7 +172,6 @@ BundleArtifacts/
 
 # Others
 ClientBin/
-[Ss]tyle[Cc]op.*
 ~$*
 *~
 *.dbmdl


### PR DESCRIPTION
StyleCop.Analyzers is the modern re-invention of StyleCop, and uses a StyleCop.json file that the default .gitignore file made very difficult to check in, and easy to think was checked in but isn't.
See https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/32057fff82adf7cfb92aa50aef69a6b030eedf31/documentation/Configuration.md#source-control for the documented case.

Looking through history, this line was last touched to make it case insensitive, and before that the line was in the original VisualStudio.gitignore file, without justification for why it should ignore all file extensions. From my experience with stylecop, the only file I remember it creating was stylecop.cache. I would change `[Ss]tyle[Cc]op.*` to `[Ss]tyle[Cc]op.cache` but there is already a line for suppressing all *.cache files (which wasn't there when the stylecop line was originally added). So I believe this line is now obsolete, and as I explain above, actually problematic.

CC: @sharwell