### PR TITLE
Remove `build/` suppression

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -17,7 +17,6 @@
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/


### PR DESCRIPTION
The authoring of NuGet packages quite often include `build` folders, and when this is .gitignore'd it's very often the source of bugs in files that don't get checked in.

I've never seen a Visual Studio project that builds to a `build` folder (`bin` is the default name). As this is a Visual Studio template file, and we have real projects that include `build` folders that include source code, I recommend we remove suppression of this folder.