### PR TITLE
Ignore ApplicationInsights.config for Microsoft Azure

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -160,6 +160,9 @@ csx/
 ecf/
 rcf/
 
+# Windows Azure ApplicationInsights config file
+ApplicationInsights.config
+
 # Windows Store app package directory
 AppPackages/
 BundleArtifacts/

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -152,15 +152,15 @@ publish/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
 
-# Windows Azure Build Output
+# Microsoft Azure Build Output
 csx/
 *.build.csdef
 
-# Windows Azure Emulator
+# Microsoft Azure Emulator
 ecf/
 rcf/
 
-# Windows Azure ApplicationInsights config file
+# Microsoft Azure ApplicationInsights config file
 ApplicationInsights.config
 
 # Windows Store app package directory


### PR DESCRIPTION
The feature Application Insights in Microsoft Azure is cool but the config file ApplicationInsights.config should not be in version control.

According to https://azure.microsoft.com/sv-se/blog/upcoming-name-change-for-windows-azure/ Windows Azure is also renamed to Microsoft Azure.