### PR TITLE
Add TeX precompiled preamble and xypic

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -6,6 +6,7 @@
 *.fls
 *.out
 *.toc
+*.fmt
 
 ## Intermediate documents:
 *.dvi
@@ -142,6 +143,9 @@ pythontex-files-*/
 
 # xindy
 *.xdy
+
+# xypic precompiled matrices
+*.xyc
 
 # WinEdt
 *.bak


### PR DESCRIPTION
A precompiled header(`latex -ini`) compiled creates a `.fmt` file.
To speed up xypic's drawing, precompiled matrices are created with the `\CompileMatrices` entry in the preamble. This creates `*.xyc` files.