### PR TITLE
Ignore playground files

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -27,6 +27,9 @@ xcuserdata
 *.hmap
 *.ipa
 
+## Playgrounds
+timeline.xctimeline
+
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -29,6 +29,7 @@ xcuserdata
 
 ## Playgrounds
 timeline.xctimeline
+playground.xcworkspace
 
 # Swift Package Manager
 #


### PR DESCRIPTION
##### [Ignore timeline.xctimeline playground file](https://github.com/adrfer/gitignore/commit/679c67738234abd77567df5c07257bfab314f106)

The `timeline.xctimeline`, which is part of a playground bundle and is automatically generated by the runtime when a Swift file is executed and the timeline is open, contains only timestamps of execution.

##### [Ignore playground.xcworkspace playground file](https://github.com/adrfer/gitignore/commit/33da976da9a6ff4394797ef807651a79114c0065)

The `playground.xcworkspace`, which is also part of a playground bundle, contains only details of how one last left its windows — which inspectors were open, how panes were setup, etc.