### PR TITLE
Include lib64 for virtualenv

### DIFF
--- a/Global/VirtualEnv.gitignore
+++ b/Global/VirtualEnv.gitignore
@@ -4,6 +4,7 @@
 [Bb]in
 [Ii]nclude
 [Ll]ib
+[Ll]ib64
 [Ll]ocal
 [Ss]cripts
 pyvenv.cfg


### PR DESCRIPTION
On systems that require a lib64, virtualenv creates a symlink to the local lib ([see fix_lib64](https://github.com/pypa/virtualenv/blob/e657022e5a138a8827d212e8e2f6910416a63986/virtualenv.py#L1425)).

A fresh [virtualenv](https://virtualenv.pypa.io/en/latest/) with the current `.gitignore` template lists `lib64` as the only unchecked change.