### PR TITLE
Exclude Latexian temp files for Tex documents

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -154,3 +154,6 @@ pythontex-files-*/
 # endfloat
 *.ttt
 *.fff
+
+# Latexian
+TSWLatexianTemp*


### PR DESCRIPTION
Latexian adds some additional temporary files, which are not required for building the project. Therefore they are better left out as well

The project itself is no longer maintained by TacoSW, however the application is still widely used. 