### PR TITLE
Add Android Studio generated files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -30,3 +30,7 @@ proguard/
 
 # Android Studio captures folder
 captures/
+
+# Android Studio generated files
+.idea/
+*.iml


### PR DESCRIPTION
Everything in .idea/ and all .iml files should not be included in git. They
are generated by Android Studio when opening a Gradle project.  They will
be different for each person's Android Studio, so if they are in git, it'll
be an endless source of git conflicts.