### PR TITLE
add *.xctimeline for playground

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -22,6 +22,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+*.xctimeline
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
Without it, `git pull` may fail for playgrounds if it is already in use.