### PR TITLE
Ignore default Emacs server auth dir

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -30,3 +30,6 @@ tramp
 
 # cask packages
 .cask/
+
+# server auth directory
+/server/


### PR DESCRIPTION
The server-auth-dir is where Emacs stores authentication files for Emacs
servers (running over TCP). These are (usually) ephemeral in nature, and
should be ignored.

You can read more about [server-auth-dir](http://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/server.el?id=9b2375008348da99b5ec414cd3ca8c4669a12576#n132) in the Emacs source code, where it is self-documenting.