### PR TITLE
Add *.VC.opendb for UnrealEngine

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -34,6 +34,7 @@
 *.suo
 *.opensdf
 *.sdf
+*.VC.opendb
 
 # Precompiled Assets
 SourceArt/**/*.png


### PR DESCRIPTION
Add "*.VC.opendb" to the .gitignore for the UnrealEngine for Visual Studio 2015 Update 1 users. This reflects the changes in the VisualStudio.gitignore made in [Pull Reqiest 1](https://github.com/github/gitignore/pull/1778) and [Pull Reqiest 1](https://github.com/github/gitignore/pull/1783) but is more specifically targeted at solving the [Issue] (http://stackoverflow.com/questions/34319008/git-issue-with-visual-studio-2015-update-1).