### PR TITLE
Add Visual Studio Code project settings folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -234,3 +234,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# Visual Studio Code
+.vscode/


### PR DESCRIPTION
Ignores individual [Visual Studio Code](https://code.visualstudio.com/) project settings like task configuration and debug configuration.

Why: you might want not to share your personal VS Code project settings.

Description of Settings for VS Code: https://code.visualstudio.com/Docs/customization/userandworkspace

