### PR TITLE
Qt: ignore CMakeLists.txt.user

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -32,3 +32,7 @@ Makefile*
 #QtCtreator Qml
 *.qmlproject.user
 *.qmlproject.user.*
+
+#QtCtreator CMake
+CMakeLists.txt.user
+


### PR DESCRIPTION
Qt.ignore already has QtCreator specific lines and Qt's cache files (named *.user).
Therefore, ignore CMakeLists.txt.user created by QtCreator seems innocuous  (same as .pro.user but for cmake based proyects).

