### PR TITLE
Do not ignore gradle wrapper's jar file

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -7,6 +7,7 @@
 *.jar
 *.war
 *.ear
+!gradle/wrapper/gradle-wrapper.jar
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*


### PR DESCRIPTION
It's required for bootstrapping.
