### PR TITLE
Remove redundancy in Global/Vim.gitignore

### DIFF
--- a/Global/Vim.gitignore
+++ b/Global/Vim.gitignore
@@ -1,8 +1,6 @@
 # swap
 [._]*.s[a-w][a-z]
 [._]s[a-w][a-z]
-# persistent undo 
-*.un~
 # session
 Session.vim
 # temporary


### PR DESCRIPTION
Anything matched by `*.un~` will also be matched by the last rule, `*~`.