### PR TITLE
add gitignore for TSD/typings tool

### DIFF
--- a/Typings.gitignore
+++ b/Typings.gitignore
@@ -1,0 +1,2 @@
+## Ignore downloaded typings
+typings


### PR DESCRIPTION
## Provide a link to the application or project’s homepage

The [tsd](http://definitelytyped.org/tsd/) tool (now [deprecated](https://github.com/DefinitelyTyped/tsd/issues/269) and succeeded by the [typings](https://github.com/typings/typings) tool) allows [TypeScript](http://www.typescriptlang.org/) users to download type definitions from an online repository. 
## Provide links to documentation

The type definitions required by a project are specified in a tsd.json file and get downloaded by default to a typings folder. The relevant section of the documentation describing the default folder to which type definition files are installed is [here](https://github.com/typings/typings#install) for Typings, and [here](https://github.com/DefinitelyTyped/tsd#tsdjson) for TSD.
## Explain why you’re making a change

Type definitions should be downloaded by the user from the appropriate repository rather than being committed.
