### PR TITLE
work around intellij gradle wrapper refreshing bug

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -9,3 +9,6 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties


### PR DESCRIPTION
Work around https://youtrack.jetbrains.com/issue/IDEA-116898 by offering to gitignore the gradle wrapper once it's safely in version control.