### PR TITLE
Fix capitalization of IPython

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -59,7 +59,7 @@ docs/_build/
 # PyBuilder
 target/
 
-# Ipython Notebook
+# IPython Notebook
 .ipynb_checkpoints
 
 # pyenv


### PR DESCRIPTION
A (very) simple modification to the Python `.gitignore`, fixing the capitalization of the "P" in "IPython".