### PR TITLE
Fix capitalization of KiCad

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -1,4 +1,4 @@
-# For PCBs designed using KiCAD: http://www.kicad-pcb.org/
+# For PCBs designed using KiCad: http://www.kicad-pcb.org/
 
 # Temporary files
 *.000


### PR DESCRIPTION
According to their website, the correct capitalization is KiCad, not KiCAD.