### PR TITLE
Ignore some Windows Store package related files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -166,9 +166,11 @@ rcf/
 # Microsoft Azure ApplicationInsights config file
 ApplicationInsights.config
 
-# Windows Store app package directory
+# Windows Store app package directories and files
 AppPackages/
 BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
 
 # Visual Studio cache files
 # files ending in .cache can be ignored

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -187,7 +187,6 @@ ClientBin/
 *.pfx
 *.publishsettings
 node_modules/
-bower_components/
 orleans.codegen.cs
 
 # RIA/Silverlight projects

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -185,7 +185,9 @@ ClientBin/
 *.pfx
 *.publishsettings
 node_modules/
+bower_components/
 orleans.codegen.cs
+_pkginfo.txt
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -189,7 +189,6 @@ ClientBin/
 node_modules/
 bower_components/
 orleans.codegen.cs
-_pkginfo.txt
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
Ignores _pkginfo.txt and Package.StoreAssociation.xml. Those files can always be regenerated by the IDE.