### PR TITLE
Adding JetBrains Rider (.NET IDE from JetBrains) specific files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -237,3 +237,7 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# JetBrains Rider
+.idea/
+*.sln.iml


### PR DESCRIPTION
This ignores the `.idea` directory that is placed in the root of the solution, and a metadata file `.sln.iml` that is created.