### PR TITLE
Add a .gitgnore for SourcePawn.

### DIFF
--- a/SourcePawn.gitignore
+++ b/SourcePawn.gitignore
@@ -1,0 +1,4 @@
+# SourcePawn
+*.dll # extensions
+*.so # extensions
+*.smx # plugins


### PR DESCRIPTION
SourcePawn is the scripting language used to compile .sp files, with the outcome of an .smx file, a plugin that SourceMod can run.

- [Introduction to SourcePawn 1.7](https://wiki.alliedmods.net/Introduction_to_SourcePawn_1.7)
- [SourceMod: Half-Life 2 Scripting](http://www.sourcemod.net/)
