### PR TITLE
add .projectile file to emacs .gitignore

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -36,3 +36,6 @@ flycheck_*.el
 
 # server auth directory
 /server/
+
+# projectiles files
+.projectile


### PR DESCRIPTION
Hello !

Added .projectile used by emacs package projectile. This file is useful to projectile to ignores files and speed up search and grep in a project.

Etienne Bazin