### PR TITLE
Ignore ncrunch project files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -111,6 +111,7 @@ _TeamCity*
 _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
+*.ncrunchproject
 
 # MightyMoose
 *.mm.*


### PR DESCRIPTION
NCrunch will add these to every project including submodules which is annoying. These seem specific to the user so we should ignore these by default.

/cc @shiftkey