### PR TITLE
Add *.glsdefs to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -76,6 +76,7 @@ acs-*.bib
 *.glg
 *.glo
 *.gls
+*.glsdefs
 
 # gnuplottex
 *-gnuplottex-*


### PR DESCRIPTION
.glsdefs is generated alongside .gls files when using makeglossaries