### PR TITLE
Add gitignore for Kotlin

### DIFF
--- a/Kotlin.gitignore
+++ b/Kotlin.gitignore
@@ -1,0 +1,1 @@
+Java.gitignore


### PR DESCRIPTION
[Kotlin](https://kotlinlang.org/) is a JVM-based language developed by the [Jetbrains](https://www.jetbrains.com/) folks that claims 100% interop with Java. The first stable version, [1.0.0, came out in February 2016](http://blog.jetbrains.com/kotlin/2016/02/kotlin-1-0-released-pragmatic-language-for-jvm-and-android/).

I'm not aware of any Kotlin-specific generated files during the build, so because Kotlin has Java interop, generates class files similar to Java, and generally uses the same file formats, I symlinked Kotlin.gitignore to Java.gitignore.
