### PR TITLE
added dotenv to python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -68,3 +68,5 @@ target/
 # pyenv
 .python-version
 
+# dotenv
+.env


### PR DESCRIPTION
**Reasons for making this change:**

`.env` is a common choice to store local environment variables based on `Heroku/foreman` workflow.

**Links to documentation supporting these rule changes:** 

https://github.com/theskumar/python-dotenv

