### PR TITLE
Stop tracking of VS vshost files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -21,6 +21,8 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+*.vshost.exe.manifest
+*.vshost.exe.config
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
Visual Studio generates vshost files automatically, these are not to be tracked.
