### PR TITLE
add backup file (.bak)

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -201,6 +201,7 @@ Generated_Code/
 # because we have git ;-)
 _UpgradeReport_Files/
 Backup*/
+*.bak
 UpgradeLog*.XML
 UpgradeLog*.htm
 


### PR DESCRIPTION
sometimes, an editor will generate a backup file (.bak) after edit a file, it should be ignored
