### PR TITLE
Ignore gradle scripts generated by Intellij

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -12,3 +12,7 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+# Ignore gradle scripts
+gradlew
+gradlew.bat


### PR DESCRIPTION
IntelliJ IDEA if you select gradle wrapper in project creation time it creates two scripts (linux and windows) called gradlew and gradlew.bat, and I think it's not good idea to upload those files.

