### PR TITLE
Remove ApplicationInsights.config from VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -163,9 +163,6 @@ csx/
 ecf/
 rcf/
 
-# Microsoft Azure ApplicationInsights config file
-ApplicationInsights.config
-
 # Windows Store app package directories and files
 AppPackages/
 BundleArtifacts/


### PR DESCRIPTION
**Reasons for making this change:**

Commit a25589c92187674f68dcfafe8433e0c1e6069159 introduced an ignore line for ApplicationInsights.config. This change breaks builds on certain systems, namely VSTS.

The current ASP.NET 4 template adds ApplicationInsights.config to the project's .csproj file. When VSTS attempts to build the project, it will fail if it cannot find ApplicationInsights.config.

ApplicationInsights.config is a required application file and should not be ignored.

**Links to documentation supporting these rule changes:** 

https://azure.microsoft.com/en-us/documentation/articles/app-insights-start-monitoring-app-health-usage/#ide