### PR TITLE
Added nore ignores. Removed.env example file

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -1,7 +1,5 @@
 vendor/
 node_modules/
-.rocketeer/
-.phpintel/
 
 # Laravel 4 specific
 bootstrap/compiled.php
@@ -13,3 +11,6 @@ storage/
 .env.*.php
 .env.php
 .env
+
+# Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
+.rocketeer/

--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -1,5 +1,7 @@
 vendor/
 node_modules/
+.rocketeer/
+.phpintel/
 
 # Laravel 4 specific
 bootstrap/compiled.php
@@ -11,4 +13,3 @@ storage/
 .env.*.php
 .env.php
 .env
-.env.example


### PR DESCRIPTION
**Reasons for making this change:**

`.env.example` should not be ignored, because it contains exmplaes of actual parameters and on deploy, needs to be copied to `.env` file with appropriate parameter values.

**Links to documentation supporting these rule changes:** 

Didn't find a documentation, but I think this is common practice, to use such files.
https://mattstauffer.co/blog/laravel-5.0-environment-detection-and-environment-variables#introducing-php-dotenv