### PR TITLE
No need to push .spyderproject file in a python project

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -73,3 +73,6 @@ target/
 
 # dotenv
 .env
+
+# Spyder project settings
+.spyderproject


### PR DESCRIPTION
**Reasons for making this change:**

I dont' think it is usefull to push IDE configurations in a project.

**Links to documentation supporting these rule changes:** 

https://pythonhosted.org/spyder/index.html#


