### PR TITLE
delete some extra rules for Qt-VS-add-in

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -204,3 +204,10 @@ FakesAssemblies/
 
 # Visual Studio 6 workspace options file
 *.opt
+
+#Qt Add-in for Visual Studio
+GeneratedFiles/
+*.moc
+moc_*.cpp
+qrc_*.cpp
+ui_*.h

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -207,7 +207,4 @@ FakesAssemblies/
 
 #Qt Add-in for Visual Studio
 GeneratedFiles/
-*.moc
-moc_*.cpp
-qrc_*.cpp
-ui_*.h
+


### PR DESCRIPTION
`GeneratedFiles/` - This is a folder generated by [Qt VS add-in](http://doc.qt.io/vs-addin/).
- moc,qrc,ui files are all under this folder
