### PR TITLE
ignore folder for non-nuget paket dependencies

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -235,6 +235,7 @@ _Pvt_Extensions
 
 # Paket dependency manager
 .paket/paket.exe
+paket-files/
 
 # FAKE - F# Make
 .fake/


### PR DESCRIPTION
**Reasons for making this change:**

Paket can download files from Git(Hub) and the web and puts them in `paket-files` folder

**Links to documentation supporting these rule changes:** 

http://fsprojects.github.io/Paket/http-dependencies.html
http://fsprojects.github.io/Paket/github-dependencies.html
http://fsprojects.github.io/Paket/git-dependencies.html


