### PR TITLE
Exclude keystore files (Android/Android Studio .gitignore)

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -34,3 +34,6 @@ captures/
 
 # Intellij
 *.iml
+
+#Keystore files
+*.jks


### PR DESCRIPTION
**Reasons for making this change:**

Apart from requiring credentials to function correctly, keystores are sensitive data and are often stored inside the project's directory. Keystores are used to digitally sign software made with Java.