### PR TITLE
Python: don't track virtualenv files.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -77,5 +77,9 @@ celerybeat-schedule
 # dotenv
 .env
 
+# virtualenv
+venv/
+ENV/
+
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Don't track files created by virtualenv.
Typical location are "venv" or "ENV" directories (relatively to project's home). These files depend on environment preferred by particular user. They shouldn't be committed to repository, because 1) it's meaningless and 2) could overwrite or conflict with settings of  another user of the same repository.

http://docs.python-guide.org/en/latest/dev/virtualenvs/
https://virtualenv.pypa.io/en/latest/userguide.html