### PR TITLE
Ruby: ignore more build artifacts specific to RubyMotion

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -14,10 +14,17 @@
 .dat*
 .repl_history
 build/
-vendor/Pods/
 *.bridgesupport
 build-iPhoneOS/
 build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
 
 ## Documentation cache and generated files:
 /.yardoc/

--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -14,6 +14,10 @@
 .dat*
 .repl_history
 build/
+vendor/Pods/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
 
 ## Documentation cache and generated files:
 /.yardoc/


### PR DESCRIPTION
**Reasons for making this change:**

RubyMotion build artifacts