### PR TITLE
ignore node_modules everywhere as default

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -24,7 +24,7 @@ coverage
 build/Release
 
 # Dependency directories
-node_modules
+/node_modules
 jspm_packages
 
 # Optional npm cache directory

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -3,6 +3,10 @@ logs
 *.log
 npm-debug.log*
 
+# .DS_Store
+*/.DS_Store # 1 level deep
+.DS_Store
+
 # Runtime data
 pids
 *.pid
@@ -23,12 +27,12 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
-# Dependency directories
-/node_modules
-jspm_packages
+# Dependency directory
+*/node_modules
 
 # Optional npm cache directory
 .npm
 
 # Optional REPL history
 .node_repl_history
+

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -27,8 +27,9 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
-# Dependency directory
+# Dependency directories
 */node_modules
+jspm_packages
 
 # Optional npm cache directory
 .npm


### PR DESCRIPTION
**Reasons for making this change:**

Since practice is to pull node_modules relative to the box, the default config should be for global node_modules ignore to include subdirectories.

**Links to documentation supporting these rule changes:** 

Documents relating to the original intent of node_modules, and variance of Javascript compilation across different environments.
