### PR TITLE
Add AppCode's project settings for Swift and Objective-c

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -49,3 +49,7 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/screenshots
+
+# AppCode
+# Add this line if you want to ignore AppCode's project settings
+# .idea/

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -59,3 +59,7 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/screenshots
+
+# AppCode
+# Add this line if you want to ignore AppCode's project settings
+# .idea/


### PR DESCRIPTION
**Reasons for making this change:**

AppCode's growing popularity make this change needed.

**Links to documentation supporting these rule changes:** 

See details about AppCode here: https://www.jetbrains.com/objc/

If this is a new template: 

no
