### PR TITLE
Ignore .fot .cb .cb2 for TeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -7,6 +7,9 @@
 *.out
 *.toc
 *.fmt
+*.fot
+*.cb
+*.cb2
 
 ## Intermediate documents:
 *.dvi


### PR DESCRIPTION
**Reasons for making this change:**

* File which ends by .fot stores information about footnotes and is automatically generated.
* File which ends by .cb or .cb2 are generated too and doesn't have any content on my system.

**Links to documentation supporting these rule changes:** 

Unfortunately I couldn't find any documentation about this behavior, but I think it couldn't be bad to ignore these files.
