### PR TITLE
Remove a trailing whitepsace

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -52,7 +52,7 @@ Carthage/Build
 
 # fastlane
 #
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
 # https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md


### PR DESCRIPTION
**Reasons for making this change:**

It's good convention to avoid whitespace at end of line.

**Links to documentation supporting these rule changes:** 

http://programmers.stackexchange.com/q/121555
https://www.gnu.org/software/emacs/manual/html_node/emacs/Useless-Whitespace.html

