### PR TITLE
Update fastlane links

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -45,7 +45,7 @@ Carthage/Build
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
-# https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md
+# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
 
 fastlane/report.xml
 fastlane/screenshots

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -55,7 +55,7 @@ Carthage/Build
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
-# https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md
+# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
 
 fastlane/report.xml
 fastlane/Preview.html


### PR DESCRIPTION
**Reasons for making this change:**

The old link is broken since Fastlane moved all their sources into one repo.

Fastlane now has a mono repo, the documentation moved into the folder fastlane/docs