### PR TITLE
TeX.ignore: added *.rel for RefTeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -175,3 +175,6 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~*
+
+# Emacs: AUCTeX / RefTeX
+*.rel


### PR DESCRIPTION
**Reasons for making this change:**

This is re-opening #1294 . It seems that since the time of that pull request, this .gitignore file has begun accepting editor-specific patterns.

**Links to documentation supporting these rule changes:** 

Examples of editor-specific patterns for TeX projects include eab300ef2354ceaae31410642171bea86f4d4983 and b2f2bf499c01c873158cd21b18681e4154dfa9c2 .
