### PR TITLE
Add VC.db for Visual C++ new Database Engine

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -80,6 +80,7 @@ ipch/
 *.opensdf
 *.sdf
 *.cachefile
+*.VC.db
 
 # Visual Studio profiler
 *.psess


### PR DESCRIPTION
**Reasons for making this change:**

Visual C++ 2015 Update 1 Introduced new database engine(*.VC.db) replacing *.sdf files. It was not default in Update 1, but it will be enabled by default in Update 2.


**Links to documentation supporting these rule changes:** 

"New, Improved, and Faster Database Engine" from https://blogs.msdn.microsoft.com/vcblog/2015/11/11/new-improved-and-faster-database-engine/
"with Update 2, new Visual Studio installations use this new engine by default" from https://www.visualstudio.com/en-us/news/vs2015-update2-vs.aspx
