### PR TITLE
Create OpenCV.gitignore

### DIFF
--- a/OpenCV.gitignore
+++ b/OpenCV.gitignore
@@ -1,0 +1,7 @@
+#OpenCV for Mac and Linux
+#build and release folders
+*/CMakeFiles
+*/CMakeCache.txt
+*/Makefile
+*/cmake_install.cmake
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

This is help for OpenCV Library.

**Links to documentation supporting these rule changes:** 

http://docs.opencv.org/2.4/doc/tutorials/introduction/linux_install/linux_install.html

**Comments:**

OpenCV.gitignore is helpful for Mac and Linux users.