### PR TITLE
Ignoring vignettes/*.R

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -20,6 +20,7 @@
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
+vignettes/*.R
 
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth


### PR DESCRIPTION
'.R' files are also produced sometimes when building vignettes. These don't need to be committed.