### PR TITLE
Update Waf for URL and specificity

### DIFF
--- a/Waf.gitignore
+++ b/Waf.gitignore
@@ -1,4 +1,4 @@
-# for projects that use Waf for building: http://code.google.com/p/waf/
 .waf-*
 .waf3-*
 .lock-*
+# For projects that use the Waf build system: https://waf.io/

--- a/Waf.gitignore
+++ b/Waf.gitignore
@@ -1,4 +1,9 @@
-.waf-*
-.waf3-*
-.lock-*
 # For projects that use the Waf build system: https://waf.io/
+# Dot-hidden on Unix-like systems
+.waf-*-*/
+.waf3-*-*/
+# Hidden directory on Windows (no dot)
+waf-*-*/
+waf3-*-*/
+# Lockfile
+.lock-waf_*_build


### PR DESCRIPTION
**Reasons for making this change:**
- Waf's homepage has moved from Google Code to https://waf.io
- Add specificity to unpacked waflib pattern
- Add support for Windows

**Links to documentation supporting these rule changes:** 
- This is [how the lockfile is named](https://github.com/waf-project/waf/blob/waf-1.8.20/waflib/Options.py#L44) in the latest version
- This is [how the unpacked waflib directory is named](https://github.com/waf-project/waf/blob/waf-1.8.20/waf-light#L147) in the latest version, with the [leading dot used for non-Windows platforms](https://github.com/waf-project/waf/blob/waf-1.8.20/waf-light#L153)

Thanks!
