### PR TITLE
Ignore buckup doctrine entities

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -41,3 +41,6 @@
 
 # Composer PHAR
 /composer.phar
+
+# Temporary files
+*/Entity/*~

--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -42,5 +42,5 @@
 # Composer PHAR
 /composer.phar
 
-# Temporary files
+# Backup entities generated with doctrine:generate:entities command
 */Entity/*~


### PR DESCRIPTION
Command 'doctrine:generate:entities with option 'backup' generates backup entities. These files should not be shared amongs contributors.s

