### PR TITLE
Add an exclusion for Visual Studio PublishScripts

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -138,10 +138,15 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
 
 # NuGet Packages
 *.nupkg
@@ -186,7 +191,7 @@ ClientBin/
 node_modules/
 orleans.codegen.cs
 
-# Since there are multiple workflows, uncomment next line to ignore bower_components 
+# Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
 #bower_components/
 


### PR DESCRIPTION
The `PublishScripts` directory created by selecting "Host in the cloud" on project creation may contain sensitive information. 

This update modifies the Visual Studio `.gitignore` template to exclude those files from source control. 

<img width="794" alt="Screenshot of new project form pointing out the 'Host in the cloud' option" src="https://cloud.githubusercontent.com/assets/279389/14055305/1dfbcc38-f29e-11e5-8d7f-e1422ae0886e.png">

cc @github/windows
