### PR TITLE
Added Visual Studio 2015 .vs folder

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -60,5 +60,3 @@ Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
-
-

--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,3 +1,6 @@
+# Visual Studio 2015 user specific files
+.vs/
+
 # Compiled Object files
 *.slo
 *.lo
@@ -57,3 +60,5 @@ Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+
+


### PR DESCRIPTION
**Reasons for making this change:**

Visual Studio 2015 moved all the user files to the `.vs` folder, which shouldn't be tracked.

**Links to documentation supporting these rule changes:** 

https://visualstudio.uservoice.com/forums/121579-visual-studio/suggestions/6079923-store-project-related-information-in-vs-folder-to