### PR TITLE
Add dist/ folder to Emacs gitignores

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -30,6 +30,7 @@ tramp
 
 # cask packages
 .cask/
+dist/
 
 # Flycheck
 flycheck_*.el


### PR DESCRIPTION
Hello there!

**Reasons for making this change:**

`cask package` command by default produces this `dist/` folder with a ready-to-install package.el package, which is generally not something that should exist in a source code repo.

**Links to documentation supporting these rule changes:** 

http://cask.readthedocs.org/en/latest/guide/usage.html#cask-package

regards,
rexim
