### PR TITLE
Create C#.gitignore

### DIFF
--- a/C#.gitignore
+++ b/C#.gitignore
@@ -1,0 +1,36 @@
+#Specific file paths to Ignore
+
+#Visual Studio Files
+[Oo]bj
+[Bb]in
+[Dd]ebug
+[Bb]uild/
+*.user
+*.suo
+*.exe
+*.pdb
+*.aps
+*_i.c
+*_p.c
+*.ncb
+*.tlb
+*.tlh
+*.[Cc]ache
+*.bak
+*.ncb
+*.ilk
+*.log
+*.lib
+*.sbr
+*.sdf
+ipch/ 
+*.dbmdl
+*.csproj.user
+*.cache
+*.swp
+*.vspscc
+*.vssscc
+*.bak.*
+*.bak
+*.xap
+*.user


### PR DESCRIPTION
**Reasons for making this change:**

This is to add a template file for ignoring common C# project files not wanted in repository

**Links to documentation supporting these rule changes:** 

None

If this is a new template: 

 - **Link to application or project’s homepage**:
None

