### PR TITLE
Haskell: Ignore .eventlog files

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -14,4 +14,5 @@ cabal.sandbox.config
 *.prof
 *.aux
 *.hp
+*.eventlog
 .stack-work/


### PR DESCRIPTION
"EventLog is a fast, extensible event logging framework in the GHC run-time system (RTS) to support profiling of GHC run-time events" (from https://ghc.haskell.org/trac/ghc/wiki/EventLog).

One normally doesn't want to add these files to a repo, because they are only for profiling and debugging purposes.