### PR TITLE
Add *.VC.db for Visual C++ intellisense new db

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -80,6 +80,7 @@ ipch/
 *.opensdf
 *.sdf
 *.cachefile
+*.VC.db
 
 # Visual Studio profiler
 *.psess


### PR DESCRIPTION
*.VC.db is the new database used by the sqlite backend to intellisense,
as compared to the old *.sdf SQL Server Compact database