### PR TITLE
Added .ropeproject directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -83,3 +83,6 @@ ENV/
 
 # Spyder project settings
 .spyderproject
+
+# Rope project settings
+.ropeproject


### PR DESCRIPTION
Anybody using python could be using the rope refactoring library, so the output directory is missing from this file.