### PR TITLE
Ignore NCrunch temporary files for Visual Studio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -250,3 +250,8 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# NCrunch
+_NCrunch_SOLUTION/*
+SOLUTION.ncrunchsolution.user
+nCrunchTemp_*


### PR DESCRIPTION
**Reasons for making this change:**

NCrunch produces quite a few cached files for each project. These are ignored by the patterns in this commit.

**Links to documentation supporting these rule changes:** 

http://www.ncrunch.net/documentation/considerations-and-constraints_using-ncrunch-with-source-control

If this is a new template: 

**Link to application or project’s homepage**
 http://www.ncrunch.net/