### PR TITLE
ignore more cmake-generated files

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -4,3 +4,5 @@ CMakeScripts
 Makefile
 cmake_install.cmake
 install_manifest.txt
+CTestTestfile.cmake
+Testing/


### PR DESCRIPTION
**Reasons for making this change:**

`git status` still mentions cmake-generated files.

**Links to documentation supporting these rule changes:** 

https://cmake.org/Wiki/CMake_Generating_Testing_Files

Or I can comment these patterns out by default, like the ruby gitignore.
