### PR TITLE
[VisualStudio] fixed packages ignore in order to prevent whole-directory deletion on git stash

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -153,7 +153,7 @@ PublishScripts/
 # NuGet Packages
 *.nupkg
 # The packages folder can be ignored because of Package Restore
-**/packages/*
+**/packages/
 # except build/, which is used as an MSBuild target.
 !**/packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed


### PR DESCRIPTION
**Reasons for making this change:**

I don't see a reason why to use the asterisk at the end of the packages include:

```
**/packages/*
```

So, I propose to use:

```
**/packages/
```

Using the asterisk has a major downside: on "git stash", the whole directory is deleted, which is not what you want to happen per default.

**Links to documentation supporting these rule changes:** 

https://github.com/joeblau/gitignore.io/issues/194
