### PR TITLE
Ignore JetBrains project settings

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -86,3 +86,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# JetBrains project settings
+.idea/


### PR DESCRIPTION
Ignores `.idea/` folder generated by JetBrains IDEs (e.g. PyCharm) to store project settings.
See https://www.jetbrains.com/help/idea/2016.1/project.html for more information.