### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -10,6 +10,9 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# Roslyn Compiler temporary files
+**.ide/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
Reasons for making this change:

VS2015 .sln.ide folder containing Roslyn Compiler temporary files not being ignored.

**Links to documentation supporting these rule changes:** 

http://stackoverflow.com/questions/28144621/visual-studio-2015-should-i-commit-project-sln-ide-files-into-git
