### PR TITLE
Ruby: Ignore .env

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.env
 
 ## Specific to RubyMotion:
 .dat*

--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -10,6 +10,7 @@
 /test/version_tmp/
 /tmp/
 
+# Used by dotenv library to load environment variables.
 # .env
 
 ## Specific to RubyMotion:

--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -9,7 +9,8 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
-.env
+
+# .env
 
 ## Specific to RubyMotion:
 .dat*


### PR DESCRIPTION
**Reasons for making this change:**

This file is used moderately commonly to store environment variables locally. I often find myself adding it to the Ruby gitignore manually in my Ruby applications.

**Links to documentation supporting these rule changes:** 

The Python gitignore ignores the same file for the same reason. And before the fact that this file is only used when the dotenv gem is also used, that is the same with Python.