### PR TITLE
Add FlashDevelop and executables to Actionscript

### DIFF
--- a/Actionscript.gitignore
+++ b/Actionscript.gitignore
@@ -2,9 +2,17 @@
 bin/
 bin-debug/
 bin-release/
+[Oo]bj/ # FlashDevelop obj
+[Bb]in/ # FlashDevelop bin
 
 # Other files and folders
 .settings/
+
+# Executables
+*.swf
+*.air
+*.ipa
+*.apk
 
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important


### PR DESCRIPTION
**Reasons for making this change:**

It's quite common for AIR developers to use FlashDevelop if they're on Windows. The structure of an AIR project generated by FD has a slightly different bin and obj folder naming which isn't on here. There is also no listing of the executables often generated by AIR developers such as: ipa, apk, air files. These have been added these as well under a separate sub-section.