### PR TITLE
C: Ignore gcc Static Stack Usage Analysis .su files

### DIFF
--- a/C.gitignore
+++ b/C.gitignore
@@ -30,3 +30,4 @@
 
 # Debug files
 *.dSYM/
+*.su


### PR DESCRIPTION
**Reasons for making this change:**

Compiling C code using gcc option -fstack-usage also creates files with ending .su. Each line of this file is made up of three fields:
- The name of the function. 
- A number of bytes.
- One or more qualifiers: static, dynamic, bounded.

Those files are compile time artefacts and only useful for debugging purposes.

**Links to documentation supporting these rule changes:** 

 - **Link to application or project’s homepage**: [GCC Online Docs for switch -fstack-usage](https://gcc.gnu.org/onlinedocs/gnat_ugn/Static-Stack-Usage-Analysis.html)

