### PR TITLE
Add nyc test coverage output directory

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -14,6 +14,9 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
+# nyc test coverage
+.nyc_output
+
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 


### PR DESCRIPTION
**Reasons for making this change:**

[nyc](https://github.com/bcoe/nyc#require-additional-modules) is quite popular. And it outputs to `.nyc_output` directory under some circumstances.

**Links to documentation supporting these rule changes:** 

This directory is ignored in [nyc itself](https://github.com/bcoe/nyc/blob/master/.gitignore)
