### PR TITLE
Create Julia.gitignore

### DIFF
--- a/Julia.gitignore
+++ b/Julia.gitignore
@@ -1,0 +1,3 @@
+*.jl.cov
+*.jl.*.cov
+*.jl.mem


### PR DESCRIPTION
**Reasons for making this change:**

Provide a template for Julia projects

If this is a new template: 

 - **Link to application or project’s homepage**: http://julialang.org/

