### PR TITLE
Update TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -141,6 +141,9 @@ sympy-plots-for-*.tex/
 *.pytxcode
 pythontex-files-*/
 
+# thmtools
+*.loe
+
 # TikZ & PGF
 *.dpth
 *.md5


### PR DESCRIPTION
**Reasons for making this change:**

When we use 'thmtools' package for creating 'List of Theorems', auxiliary file '.loe' is created, just as '.toc' for 'Table of Contents' and '.lof' for 'List of Figures'.

**Links to documentation supporting these rule changes:** 

Example : 

https://gist.github.com/seungwonpark/759ab6110391bfaa34a066984a7a920e
