### PR TITLE
Add knitr and R markdown patterns to R.gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -23,3 +23,11 @@ vignettes/*.pdf
 
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth
+
+# knitr and R markdown default cache directories
+/*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md


### PR DESCRIPTION
**Reasons for making this change:**

In the R community, many people use [R markdown](http://rmarkdown.rstudio.com/) and [knitr](http://yihui.name/knitr/), which allow for literate programming with R chunks embedded in output formats, most commonly, markdown. This is supported and encouraged by the R IDE RStudio. 

These tools can create both cache directories to hold objects in intermediate R computations, and intermediate files that should not be checked in to git.

**Links to documentation supporting these rule changes:** 

- The default directory for knitr cache files is named `cache`: http://yihui.name/knitr/options/#cache
- R markdown sets the cache directory to have the suffix `_cache`: http://rmarkdown.rstudio.com/authoring_rcodechunks.html
- I cannot find documentation on the temporary files created by R markdown, but they appear [https://github.com/rstudio/rmarkdown/blob/f4291667255caab91661869c830ed3357f8786c8/R/render.R#L137](here) in the code.


These patterns handle cache diretories and temporary files created
by the widely used [knitr](http://yihui.name/knitr/) and [R markdown](http://rmarkdown.rstudio.com/)
packages.