### PR TITLE
Add sublime-text-3 gitignore for package control

### DIFF
--- a/Global/SublimeText.gitignore
+++ b/Global/SublimeText.gitignore
@@ -12,3 +12,16 @@
 
 # sftp configuration file
 sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings

--- a/SublimeText3.gitignore
+++ b/SublimeText3.gitignore
@@ -1,0 +1,8 @@
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+bh_unicode_properties.cache
+GitHub.sublime-settings

--- a/SublimeText3.gitignore
+++ b/SublimeText3.gitignore
@@ -1,8 +1,0 @@
-Package Control.last-run
-Package Control.ca-list
-Package Control.ca-bundle
-Package Control.system-ca-bundle
-Package Control.cache/
-Package Control.ca-certs/
-bh_unicode_properties.cache
-GitHub.sublime-settings


### PR DESCRIPTION
**Reasons for making this change:**

Add a .gitignore for Sublime Text 3 package control

**Links to documentation supporting these rule changes:** 

https://packagecontrol.io/docs/syncing
https://www.sublimetext.com/3

------------------------------------------------------

This gitignore is used to make a repo with sublime text 3 package preferences stored in
{sublime-text-3}/Packages/User/

https://www.sublimetext.com/3

The .gitignore files are listed here

https://packagecontrol.io/docs/syncing

I added GitHub.sublime-settings to the .gitignore since its a config file added
from a popular github package that contains sensible information about your account