### PR TITLE
Add .com.apple.timemachine.donotpresent to OSX

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -15,6 +15,7 @@ Icon
 .TemporaryItems
 .Trashes
 .VolumeIcon.icns
+.com.apple.timemachine.donotpresent
 
 # Directories potentially created on remote AFP share
 .AppleDB


### PR DESCRIPTION
**Reasons for making this change:**

On OSX if an external volume is excluded from being available as a TimeMachine drive, a system file named *.com.apple.timemachine.donotpresent* will be created at the volume's root. Since this is an user choice, there is no need for this file to be included in a git-repo.