### PR TITLE
ignore .dSYM along with .ipa files

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -24,6 +24,8 @@ xcuserdata/
 ## Obj-C/Swift specific
 *.hmap
 *.ipa
+*.dSYM.zip
+*.dSYM
 
 # CocoaPods
 #

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -24,6 +24,8 @@ xcuserdata/
 ## Obj-C/Swift specific
 *.hmap
 *.ipa
+*.dSYM.zip
+*.dSYM
 
 ## Playgrounds
 timeline.xctimeline


### PR DESCRIPTION
**Reasons for making this change:**

Often .dSYM and .dSYM files stored with .ipa files, so they should also be ignored if .ipa ignored.

**Links to documentation supporting these rule changes:** 

_Not clear what should be here._

You can get more info what is .dSYM file [here](http://stackoverflow.com/questions/3656391/whats-the-dsym-and-how-to-use-it-ios-sdk)
