### PR TITLE
Add .swp files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Vim/Swap files
+.swp


### PR DESCRIPTION
**Reasons for making this change:**

`.swp` files are created by Vim while editing any file. I mainly face this while developing something in Python, so I'm adding it in `Python.gitignore` but should be in all of the files, I believe.
