### PR TITLE
Ignore cabal.project.local

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -16,3 +16,4 @@ cabal.sandbox.config
 *.hp
 *.eventlog
 .stack-work/
+cabal.project.local


### PR DESCRIPTION
**Reasons for making this change:**

`cabal-install-1.24` features new commands which generate a `dist-newstyle` directory and `cabal.project.local` file which aren't meant to be checked to VCS. Luckily, `dist-newstyle` is already ignored, but `cabal.project.local` needs to be added.

**Links to documentation supporting these rule changes:** 

This blog post by a Edward Yang, a `Cabal` developer, explains it: http://blog.ezyang.com/2016/05/announcing-cabal-new-build-nix-style-local-builds/