### PR TITLE
Ignore *.DS_Store

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -250,3 +250,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# OSX ds_stores
+*.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

To ignore the .DS_Store file which generated by OSX. Many developers were using Visual Studio in a virtual machine, such as Parallels Desktop. So, their system will generate many .DS_Store files. However, we do not need these files when we commit to the git repository.

**Links to documentation supporting these rule changes:** 

https://en.wikipedia.org/wiki/.DS_Store

/cc @Eilon @shiftkey