### PR TITLE
Create MASM assembly (ASM) gitignore file

### DIFF
--- a/MASM.gitignore
+++ b/MASM.gitignore
@@ -1,0 +1,5 @@
+# Object files
+*.obj
+
+# Executables
+*.exe


### PR DESCRIPTION
**Reasons for making this change:**

there is no ASM gitignore and no MASM in particular

**Links to documentation supporting these rule changes:** 

I haven't

If this is a new template: 
- **Link to application or project’s homepage**: https://github.com/shark-oxi/MASM-assembly-beginner/

MASM assembly (ASM) gitignore file
For example under windows keep *.bat (makefiles) and *.asm (ASM source code) and ignore *.obj (Object files) and *.exe (Executables)
There is no no need for linux output because MASM is windows only.
