### PR TITLE
Ignore '*.DS_Store' instead of ignore '.DS_Store'

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -1,9 +1,10 @@
-.DS_Store
+*.DS_Store
 .AppleDouble
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*


### PR DESCRIPTION
**Reasons for making this change:**

There are many .DS_Store files in subfolders. We still should ignore these files.

**Links to documentation supporting these rule changes:** 

http://stackoverflow.com/questions/18393498/gitignore-all-the-ds-store-files-in-every-folder-and-subfolder