### PR TITLE
add fusetools gitignore

### DIFF
--- a/FuseTools.gitignore
+++ b/FuseTools.gitignore
@@ -1,0 +1,5 @@
+# Built and preview application files
+build
+
+# Scripts conversion file
+.uno


### PR DESCRIPTION
**Reasons for making this change:**
Fuse is a developing frame for mobile application development, and I think adding this gitignore will help the new developers.  ^_^

**Links to documentation supporting these rule changes:** 

https://www.fusetools.com/learn/fuse#

If this is a new template: 
- **Link to application or project’s homepage**: https://www.fusetools.com
