### PR TITLE
Add .env to optionally ignored files

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -15,6 +15,9 @@ pickle-email-*.html
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/secrets.yml
+
+# dotenv
+# TODO Comment out this rule if environment variables can be committed
 .env
 
 ## Environment normalization:

--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -15,6 +15,7 @@ pickle-email-*.html
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/secrets.yml
+.env
 
 ## Environment normalization:
 /.bundle


### PR DESCRIPTION
Many twelve-factor apps use environment variables rather than the built in Rails secrets mechanism to store secrets.
The [dotenv](https://github.com/bkeepers/dotenv) gem is widely used for this purpose and allows environment variables to be loaded from the `.env` file. However, this file should not be committed to source control.

This PR just adds the `.env` file to `.gitignore` so that these secrets aren't accidentally committed. In some rare instances, it may be required that this file is committed to source control so I've added it to the list of files that can be removed if the developer is ok with secrets being committed.