### PR TITLE
ignore Eclipse Checkstyle Plugin temporary configuration file

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -8,5 +8,8 @@
 *.war
 *.ear
 
+# Eclipse Checkstyle Plugin temporary configuration file
+.checkstyle
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*


### PR DESCRIPTION
**Reasons for making this change:**

http://eclipse-cs.sourceforge.net/ creates temporary .checkstyle files, which should never be in source control.