### PR TITLE
Ignore target/ build/ bin/ output directories

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -1,4 +1,7 @@
 *.class
+target/
+build/
+bin/
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/


### PR DESCRIPTION
**Reasons for making this change:**

target/ build/ bin/ are very typical output directories in Java projects, which should always be ignored (they are the default directory names for output in Maven, Gradle and Eclipse, respectively).
