### PR TITLE
Ignore .gradle

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -8,5 +8,8 @@
 *.war
 *.ear
 
+# Temporary directory for Gradle Wrapper
+.gradle/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*


### PR DESCRIPTION
**Reasons for making this change:**

.gradle/ is the temporary directory for Gradle Wrapper cache downloads. see also e.g. http://stackoverflow.com/questions/17200831/should-the-gradle-folder-be-added-to-version-control
