### PR TITLE
Add injection folder to ignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -51,3 +51,10 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/screenshots
+
+#Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/


### PR DESCRIPTION
**Reasons for making this change:**

New tool of code injection creates a folder with information that is no useful and should be left outside the working repository

**Links to documentation supporting these rule changes:** 

Project documentation for the code injection tool: https://github.com/johnno1962/injectionforxcode