### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -252,4 +252,4 @@ paket-files/
 *.sln.iml
 
 # KoreBuild
-*.build
+*.build/

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -250,3 +250,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# KoreBuild
+*.build


### PR DESCRIPTION
**Reasons for making this change:**

Kore Build will create a temp folder named `.build`.

**Links to documentation supporting these rule changes:** 

https://github.com/aspnet/KoreBuild/blob/dev/template/build.sh#L10

/cc @shiftkey 