### PR TITLE
Julia: ignore deps/deps.jl

### DIFF
--- a/Julia.gitignore
+++ b/Julia.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+deps/deps.jl


### PR DESCRIPTION
**Reasons for making this change:**

`deps/deps.jl` is an autogenerated file created by `BinDeps.jl`, Julia's package for managing binary dependencies.

**Links to documentation supporting these rule changes:** 

The fact that `BinDeps` generates this file is not documented; however, here is a link to the code in BinDeps.jl that [generates this file](https://github.com/JuliaLang/BinDeps.jl/blob/1e03521858e51ea2fa681fbdf75bd38bbcf1d092/src/dependencies.jl#L857-L865). 

Thanks to @hlaaftana for submitting the original PR for Julia, #1950.