### PR TITLE
Add PyCharm work folder to python ignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm
+.idea/


### PR DESCRIPTION
PyCharm usually generate ".idea" folder to record Project info, configuration and etc.

Python Project need to ignore this folder