### PR TITLE
Merge conflict left over (.orig) files to be ignored

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -250,3 +250,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# GIT merge conflict remains
+*.orig


### PR DESCRIPTION
**Reasons for making this change:**

Whenever there are merge conflicts and if it is resolved from command line, .orig files are left in workspace which then gets added to source control by mistake. This is a common problem which many teams have.
