### PR TITLE
Do not ignore Laravel's storage/ directory

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -7,7 +7,6 @@ app/storage/
 
 # Laravel 5 & Lumen specific
 bootstrap/cache/
-storage/
 .env.*.php
 .env.php
 .env


### PR DESCRIPTION
**Reasons for making this change:**

Laravel's `storage/` directory structure has own .gitignores.
If ignore `storage/`, cause errors to access these child directories when execute requests.

**Links to documentation supporting these rule changes:** 

https://github.com/laravel/laravel/tree/master/storage