### PR TITLE
Add Ansible.gitignore

### DIFF
--- a/Ansible.gitignore
+++ b/Ansible.gitignore
@@ -1,0 +1,7 @@
+# Ansible gitignore
+# https://github.com/ansible/ansible
+
+# When playbook fails, Ansible creates .retry files to allow users to
+# retry the playbooks only on failed nodes
+# http://docs.ansible.com/ansible/intro_configuration.html#retry-files-enabled
+*.retry


### PR DESCRIPTION
**Reasons for making this change:**

Add support for Ansible Playbooks git repositories

When playbook fails, Ansible creates .retry files to allow users to
retry the playbooks only on failed nodes

**Links to documentation supporting these rule changes:** 

http://docs.ansible.com/ansible/intro_configuration.html#retry-files-enabled


App:
https://github.com/ansible/ansible
