### PR TITLE
Ignore the workspace.xml file

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -2,7 +2,7 @@
 *.apk
 *.ap_
 
-# Files for the Dalvik VM
+# Files for the ART/Dalvik VM
 *.dex
 
 # Java class files
@@ -34,6 +34,7 @@ captures/
 
 # Intellij
 *.iml
+.idea/workspace.xml
 
 # Keystore files
 *.jks


### PR DESCRIPTION
**Reasons for making this change:**

The workspace.xml file contains Android Studio layout properties, open tabs, and many others. This file will mess up your configuration if you aren't careful.

For the second change, the Dalvik VM was renamed to ART with Android API 21

**Links to documentation supporting these rule changes:** 

_workspace.xml_: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems
_ART_: https://source.android.com/devices/tech/dalvik/