### PR TITLE
Added PublishProfiles/ folder, with pertaining comment

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -250,3 +250,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Comment line below for publishing profiles (warning: it might contain 
+# sensitive data) 
+PublishProfiles/


### PR DESCRIPTION
**Reasons for making this change:**

The PublishProfiles folder, generated when you create a publish profile for deployment within VS 2015, may contain sensitive data. We should therefore ignore it by default, allowing the user to make the decision of whether he or she should commit it.

**Links to documentation supporting these rule changes:** 

N/A


