### PR TITLE
VisualStudio ignore project.fragment.lock.json

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -42,6 +42,7 @@ dlldata.c
 
 # DNX
 project.lock.json
+project.fragment.lock.json
 artifacts/
 
 *_i.c


### PR DESCRIPTION
**Reasons for making this change:**

I've just upgraded to ASP.NET Core RC2, and found that Visual Studio is producing a file called `project.fragment.lock.json`. When I delete the file it is recreated during build. Given project.lock.json is already ignored this looks like another file to ignore.

**Links to documentation supporting these rule changes:** 

I can't find any real _documentation_, though from a [quick Google](http://lmgtfy.com/?q=%22project.fragment.lock.json%22), I can find evidance of others ignoring this file, most notably the [ASP.NET Scaffolding project](https://github.com/aspnet/Scaffolding/blob/1.0.0-rc2/.gitignore#L32).