### PR TITLE
Ignore ensime files

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -13,5 +13,7 @@ project/boot/
 project/plugins/project/
 
 # Scala-IDE specific
+.ensime
+.ensime_cache/
 .scala_dependencies
 .worksheet


### PR DESCRIPTION
**Reasons for making this change:**
Ensime is a popular tool for Scala development in editors such as emacs and vim.

**Links to documentation supporting these rule changes:** 
http://ensime.github.io/getting_started/
The .ensime file describes the project layout.

If this is a new template: 
- **Link to application or project’s homepage**:
  https://github.com/ensime
  http://ensime.github.io
