### PR TITLE
Ignore *.DS_Store

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -5,6 +5,7 @@
 ## Build generated
 build/
 DerivedData/
+*.DS_Store
 
 ## Various settings
 *.pbxuser


### PR DESCRIPTION
**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_

Why is not ignore it?