### PR TITLE
Add gitignore file for Automation Studio IDE

### DIFF
--- a/Global/BrAutomationStudio.gitignore
+++ b/Global/BrAutomationStudio.gitignore
@@ -1,0 +1,10 @@
+# Binaries folder (Optional, can be integrated in git)
+Binaries
+# Temporary folder
+Temp
+# Diagnosis data
+Diagnosis
+# User local settings
+*.set
+# Project is open by the editor
+*.isopen


### PR DESCRIPTION
**Reasons for making this change:**

Adding gitignore file for an IDE not represented in the list

**Links to documentation supporting these rule changes:** 

If this is a new template: 
- **Link to application or project’s homepage**: 
  https://github.com/benlbrm/ASprojectExample
