### PR TITLE
Add AppCode .idea folder

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -31,6 +31,11 @@ xcuserdata/
 timeline.xctimeline
 playground.xcworkspace
 
+# AppCode
+#
+# Local project settings
+.idea/
+
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.


### PR DESCRIPTION
**Reasons for making this change:**

The number of developers using AppCode is non trivial so their needs should probably be taken into account.

**Links to documentation supporting these rule changes:** 

https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore

*\* Actual Changes**
The files in the .idea folder are either user-specific, sensitive or high churn files.
They are probably best not committed to the repo.
