### PR TITLE
Add Cordova gitignore

### DIFF
--- a/Cordova.gitignore
+++ b/Cordova.gitignore
@@ -1,0 +1,9 @@
+# Dependency directories
+node_modules
+
+# App platform binaries and built files
+# Use `cordova prepare` to copy files to platform/ for building
+platforms
+
+# Plugin Git clones; optinally exclude
+# plugins


### PR DESCRIPTION
**Reasons for making this change:**

GitHub is in need of a Cordova gitignore, to facilitate the adding of gitignore files for Cordova projects.

**Links to documentation supporting these rule changes:** 

StackOverflow discussion on topic: http://stackoverflow.com/questions/17911204/gitignore-for-phonegap-cordova-3-0-projects-what-should-i-commit

Cordova documentation highlighting the use of `cordova prepare` to download platform binaries and generated coniguration files:

http://cordova.apache.org/docs/en/6.x/reference/cordova-cli/index.html#project-command-list

If this is a new template: 
- **Link to application or project’s homepage**: https://cordova.apache.org/
