### PR TITLE
[Global/macOS] adding non-breaking spaces

### DIFF
--- a/Global/OSX.gitignore
+++ b/Global/OSX.gitignore
@@ -20,6 +20,6 @@ Icon
 # Directories potentially created on remote AFP share
 .AppleDB
 .AppleDesktop
-Network Trash Folder
-Temporary Items
+Network\ Trash\ Folder
+Temporary\ Items
 .apdisk


### PR DESCRIPTION
**Reasons for making this change:**

making it compatible with this plugin http://www.vim.org/scripts/script.php?script_id=2557 and in general to avoid breaking space issues

**Links to documentation supporting these rule changes:** 

https://en.wikipedia.org/wiki/Non-breaking_space
