### PR TITLE
[Unity] ignore meta files for auto-generated files as well

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -17,6 +17,16 @@ ExportedObj/
 *.pidb
 *.booproj
 *.svd
+*.csproj.meta
+*.unityproj.meta
+*.sln.meta
+*.suo.meta
+*.tmp.meta
+*.user.meta
+*.userprefs.meta
+*.pidb.meta
+*.booproj.meta
+*.svd.meta
 
 
 # Unity3D generated meta files


### PR DESCRIPTION
**Reasons for making this change:**

MonoDevelop creates meta files for solutions and user preferences. It would be useful to ignore such files as well.
