### PR TITLE
Ignore all forms of CMakeLists.txt.user

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -34,5 +34,5 @@ Makefile*
 *.qmlproject.user.*
 
 # QtCtreator CMake
-CMakeLists.txt.user
+CMakeLists.txt.user*
 


### PR DESCRIPTION
In some cases Qt Creator will create a CMakeLists.txt.user file with a short hash which should also be ignored. For example:

    CMakeLists.txt.user.1fa15d5