### PR TITLE
ignore *.VC.db files

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -37,6 +37,7 @@
 *.suo
 *.opensdf
 *.sdf
+*.VC.db
 *.VC.opendb
 
 # Precompiled Assets


### PR DESCRIPTION
**Reasons for making this change:**

In addition to *.VC.opendb, *.VC.db file should be regenerated by Visual Studio automatically. So, it makes sense to ignore *.VC.db file too as it's been ignored in https://github.com/github/gitignore/blob/master/VisualStudio.gitignore

**Links to documentation supporting these rule changes:** 

https://github.com/github/gitignore/blob/master/VisualStudio.gitignore

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_

In addition to *.VC.opendb, *.VC.db file should be regenerated by Visual Studio automatically. So, it makes sense to ignore *.VC.db file too as it's been ignored in https://github.com/github/gitignore/blob/master/VisualStudio.gitignore