### PR TITLE
Update Python.gitignore for vim

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -90,3 +90,5 @@ ENV/
 
 # Vim swp temp files
 *.swp
+*.swo
+*~

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Vim swp temp files
+*.swp


### PR DESCRIPTION
**Reasons for making this change:**

Ignore all .swp/.swo/~ files created by vim 

**Links to documentation supporting these rule changes:** 

Vim's so good and popular. `vim as python ide` returned over 410,000 results. It's worth to be added. Below link also got over 57260 views

http://stackoverflow.com/questions/4824188/git-ignore-vim-temporary-files


