### PR TITLE
Only ignore the build directory in the same directory as .gitignore for Gradle

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,5 +1,5 @@
 .gradle
-build/
+/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
**Reasons for making this change:**

If you have a package with name `com.mkobit.build` all files in that directory will be ignored.

**Links to documentation supporting these rule changes:** 

None

If you have a Java package with `build` in it, the current version will always ignore files in that directory.
This change makes it so only the root "build" directory is ignored.

I believe that this assumes .gitignore is in the root of a project.