### PR TITLE
Add .jfm extension to visualstudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -251,3 +251,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# new extension (of unknown origin or purpose) being generated that is breaking the changes section of the team explorer
+# (http://stackoverflow.com/questions/37704514/visual-studio-2015-database-project-directory-contains-a-file-with-extension-jfm)
+*.jfm


### PR DESCRIPTION
**Reasons for making this change:**

Changes section of the Team Explorer is listing no changes as git plugin fails terminally because of the presence of the jfm file

**Links to documentation supporting these rule changes:** 

There are none except for this [stack overflow question](http://stackoverflow.com/questions/37704514/visual-studio-2015-database-project-directory-contains-a-file-with-extension-jfm)



There is a new file that has appeared recently in the database project directory with extension of jfm.

I have filed a [stack overflow question](http://stackoverflow.com/questions/37704514/visual-studio-2015-database-project-directory-contains-a-file-with-extension-jfm) to enquire what this file is, however no one seems to know. Nor is there any mention of it anywhere on MS sites or the tinternet...

I was happy to wait to find out what it is before submitting this PR. However, as of yesterday, it is now breaking the visual studio git plugin leading to no changes being listed in the relevant section in the Team Explorer.

As such, it needs to be added to the VS gitignore to ensure no one else wastes time investigating this issue as I have done.