### PR TITLE
Update TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -152,6 +152,9 @@ pythontex-files-*/
 # todonotes
 *.tdo
 
+# easy-todo
+*.lod
+
 # xindy
 *.xdy
 


### PR DESCRIPTION
**Reasons for making this change:**

Add support for easy-todo package (that produces .lod file during the compilation)

**Links to documentation supporting these rule changes:** 

[https://www.ctan.org/tex-archive/macros/latex/contrib/easy-todo](https://www.ctan.org/tex-archive/macros/latex/contrib/easy-todo)

