### PR TITLE
added prerequisites for C and C++

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -1,3 +1,6 @@
+# Prerequisites
+*.d
+
 # Compiled Object files
 *.slo
 *.lo

--- a/C.gitignore
+++ b/C.gitignore
@@ -1,3 +1,6 @@
+# Prerequisites
+*.d
+
 # Object files
 *.o
 *.ko


### PR DESCRIPTION
**Reasons for making this change:**

With GNU make the preferred way to deal with dependencies is to generate a file of prerequisites (i.e., a makefile) called name.d

**Links to documentation supporting these rule changes:** 

https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_

