### PR TITLE
[Gradle] ignore the buildSrc/build directory

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,6 +1,9 @@
 .gradle
 /build/
 
+# Ignore the buildSrc build directory
+buildSrc/build/
+
 # Ignore Gradle GUI config
 gradle-app.setting
 


### PR DESCRIPTION
**Reasons for making this change:**

The last change I submitted was to only ignore root _build_ directory (https://github.com/github/gitignore/pull/2026). This was because I am working with Java packages that have `build` in them, like `com.mkobit.build.my.code`.

That change causes the _buildSrc/build_ to no longer be ignored.
This change is the proposal to fix that.

**Links to documentation supporting these rule changes:** 

https://docs.gradle.org/current/userguide/organizing_build_logic.html#sec:build_sources

Gradle uses the _buildSrc_ directory as an additional "project" that is compiled and added to the _build.gradle_'s classpath. It also produces  _build_ directory, in the same manner that other Gradle projects do.

---

Gradle allows users to write [build logic in the _buildSrc_ directory](https://docs.gradle.org/current/userguide/organizing_build_logic.html#sec:build_sources).
The change made in [#2026](https://github.com/github/gitignore/pull/2026) ignores the root project build directory, but leaves all other _build_ directories alone.
This means that the _build_ directory created by Gradle in any Gradle Project that uses the _buildSrc_ will not be ignored.

This change makes it so that the _build_ directory that is in _buildSrc_ is explicitly ignored.
