### PR TITLE
ignore busy indicator of uncompressed .synctex file

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -31,6 +31,7 @@
 ## Build tool auxiliary files:
 *.fdb_latexmk
 *.synctex
+*.synctex(busy)
 *.synctex.gz
 *.synctex.gz(busy)
 *.pdfsync


### PR DESCRIPTION
**Reasons for making this change:**

When running `pdflatex`  with `-synctex=-1`, the `.synctech` file is generated uncompressed. Thus, the extension `gz` is missing. Analoguos to `-synctex=1`, a `.synctex(busy)` file is generated. Although `*.synctex.gz(busy)` is currently ignroed, `*.synctex(busy)` isn't. This PR makes the ignoring rules consistent.