### PR TITLE
added Arcanist gitignore

### DIFF
--- a/Arcanist.gitignore
+++ b/Arcanist.gitignore
@@ -1,0 +1,2 @@
+.phutil_module_cache
+.divinercache/


### PR DESCRIPTION
This PR adds [Arcanist](https://github.com/phacility/arcanist) .gitignore rules. Arcanist is the command line utility for [Phabricator](https://secure.phabricator.com/), a project management system.

We use Phab here at Uber, and I realized [gitignore.io](http://gitignore.io) doesn't have an arcanist/phabricator preset, and upon further investigation it uses this repository for its sources.

I suspect it might come up, but these files _do_ occur in repositories that have custom Arcanist linters or other modules that are loaded in as part of the development workflow that _are_ repository-specific. Just pointing that out since Arcanist has the same ignore rules.
