### PR TITLE
Add *.wrt produced by scrwfile

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -128,6 +128,9 @@ _minted*
 *.sagetex.py
 *.sagetex.scmd
 
+# scrwfile
+*.wrt
+
 # sympy
 *.sout
 *.sympy


### PR DESCRIPTION
**Reasons for making this change:**

The [LaTeX package scrwfile](https://www.ctan.org/pkg/scrwfile?lang=de) generates `*.wrt` files, which should not be versioned.

**Links to documentation supporting these rule changes:** 

http://mirrors.ctan.org/macros/latex/contrib/koma-script/doc/scrguien.pdf, Section "14.2. The Single File Feature", page 297.
