### PR TITLE
Ignore .pdf

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -19,6 +19,9 @@
 # *.eps
 # *.pdf
 
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl
 *.bcf


### PR DESCRIPTION
**Reasons for making this change:**

On Windows, when PDF is opened with Acrobat Reader, one gets following output:

    ! I can't write on file `document.pdf'.
    Please type another file name for output:

If one simply presses "Enter" to continue, the file `.pdf` is generated. Since this is a common case and `.pdf` is never used as full file name, this file should be ignored, too.