### PR TITLE
Added gregoriotex

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -88,6 +88,10 @@ acs-*.bib
 # gnuplottex
 *-gnuplottex-*
 
+# gregoriotex
+*.gaux
+*.gtex
+
 # hyperref
 *.brf
 


### PR DESCRIPTION
**Reasons for making this change:**

Recently, in [TeXlive 2016 changes](https://www.tug.org/texlive/doc/texlive-en/texlive-en.html#x1-840009.2), gregoriotex was added. In [GregorioTeX](http://gregorio-project.github.io/), new kind of auxiliary files such as `*.gaux` and `*.gtex` are made. I added these files in this commit.

**Links to documentation supporting these rule changes:** 

[GregorioTeX Documentation](https://github.com/gregorio-project/gregorio/releases/download/v4.2.0-rc2/GregorioRef.pdf)

At page 3,
> Gregorio Controls These macros are written by the command line tool to **gtex** files and should not appear outside of gtex files. They should have names which are in CamelCase and be prefixed with Gre.

At page 168,
> GregorioTeX creates its own auxiliary file (extension **gaux**) which it uses to store information between successive typesetting runs. This allows for such features as the dynamic interline spacing. Te following functions are used to interact with that auxiliary file
