### PR TITLE
Create THEOS-Tweak.gitignore

### DIFF
--- a/THEOS-Tweak.gitignore
+++ b/THEOS-Tweak.gitignore
@@ -1,0 +1,7 @@
+._*
+*.deb
+.debmake
+_
+obj
+.theos
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

No such template exists yet.

**Links to documentation supporting these rule changes:** 

[Ryan Petrich](https://github.com/rpetrich) uses this gitignore in all of his tweak projects, he's about as close to official documentation on this as we will get. His gitnigores were the most thorough out of the many open source projects I browsed.
