### PR TITLE
Ignore terraform module directory

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -1,3 +1,6 @@
 # Compiled files
 *.tfstate
 *.tfstate.backup
+
+# Module directory
+.terraform/


### PR DESCRIPTION
**Reasons for making this change:**

The documentation suggests that do not commit `.terraform` directory.

**Links to documentation supporting these rule changes:** 

https://www.terraform.io/docs/commands/get.html
