### PR TITLE
Adding index.html files for cache and upload folders

### DIFF
--- a/SugarCRM.gitignore
+++ b/SugarCRM.gitignore
@@ -7,6 +7,7 @@
 # For development the cache directory can be safely ignored and
 # therefore it is ignored.
 /cache/
+!/cache/index.html
 # Ignore some files and directories from the custom directory.
 /custom/history/
 /custom/modulebuilder/
@@ -22,4 +23,5 @@
 *.log
 # Ignore the new upload directories.
 /upload/
+!/upload/index.html
 /upload_backup/


### PR DESCRIPTION
**Reasons for making this change:**

Security

**Links to documentation supporting these rule changes:** 

There is no written documentation. SugarCRM Out of box comes these index.html files in order to protect direct access to these folders.


index.html should be in the upload and cache folders in order to avoid direct access