### PR TITLE
Remove config/secrets.yml

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -12,9 +12,11 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 
-# TODO Comment out these rules if you are OK with secrets being uploaded to the repo
+# TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
-config/secrets.yml
+
+# Only include if you have production secrets in this file, which is no longer a Rails default
+# config/secrets.yml
 
 # dotenv
 # TODO Comment out this rule if environment variables can be committed


### PR DESCRIPTION
**Reasons for making this change:**

Rails no longer generates this file with sensitive secrets (default now is to do `secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>` in production).

There's nothing wrong with checking development & test env secrets into git.

**Links to documentation supporting these rule changes:** 

[Stackoverflow](http://stackoverflow.com/a/36210036/495637)
[Rails source](https://github.com/rails/rails/blob/a8a3a8cc691facad4ba7487a7b66362b498720c9/railties/lib/rails/generators/rails/app/templates/config/secrets.yml#L30)