### PR TITLE
Ignore elm-stuff project-wide

### DIFF
--- a/Elm.gitignore
+++ b/Elm.gitignore
@@ -1,4 +1,4 @@
 # elm-package generated files
-elm-stuff/
+elm-stuff
 # elm-repl generated files
 repl-temp-*


### PR DESCRIPTION
**Reasons for making this change:**

`elm-stuff` is a folder with modules from Elm package repository. Just as it is with `node_modules` in [Node template](https://github.com/github/gitignore/blob/master/Node.gitignore#L31), it has to be ignored project-wide.

**Links to documentation supporting these rule changes:** 

I can't find any docs on the matter, but `elm-stuff` should have the same ignore pattern applied as `node_modules`.

 Currently the standard ignore pattern for `node_modules` is:

`node_modules`
