### PR TITLE
Added NCrunch v2 files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -115,6 +115,10 @@ _NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
 
+# NCrunch v2
+*.ncrunchsolution
+*.ncrunchproject
+
 # MightyMoose
 *.mm.*
 AutoTest.Net/


### PR DESCRIPTION
**Reasons for making this change:**

NCrunch v2 adds different files that should be ignored.



