### PR TITLE
ignore HTF test framework artifact directory

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -17,3 +17,4 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
+.HTF/


### PR DESCRIPTION
**Reasons for making this change:**

A popular haskell testing framework is [HTF](http://hackage.haskell.org/package/HTF). By default the framework writes historical testing data to `.HTF` when running test-suites.

**Links to documentation supporting these rule changes:** 

See http://hackage.haskell.org/package/HTF-0.13.1.0/docs/Test-Framework-CmdlineOptions.html (opts_historyFile)