### PR TITLE
Exclude folder for CodeRush settings

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -251,3 +251,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# CodeRush
+.cr/


### PR DESCRIPTION
Exclude the folder for [CodeRush for Roslyn](https://visualstudiogallery.msdn.microsoft.com/8a8390ae-1f71-4659-9d8d-5dd56fd8a72e) settings. I assume it is OK to add this to the VisualStudio settings, since already other similar Tools (like eg R#) contained in this setting.