### PR TITLE
Add hidden virtualenv to Python template

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -79,6 +79,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 


### PR DESCRIPTION
**Reasons for making this change:**

This pull request add a `.venv` entry to the Python template.

A lot of people I know and myself use this name when instantiating a virtualenv. I can't provide any stats but I think it's fairly common for people to hide their virtualenv from usual `ls` command.

I'm sorry I can't argue more on this suggestion since it's really a question of common usage. It's up to you to juge if it's common enough.

I hope it'll be merged!

Cheers