### PR TITLE
Correcting a wrong written "extension"

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -47,7 +47,7 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
+*.po
 
 # Django stuff:
 *.log


### PR DESCRIPTION
**Reasons for making this change:**

Because it was a mistake in a extension

**Links to documentation supporting these rule changes:** 

https://docs.djangoproject.com/es/1.10/topics/i18n/translation/

specified in the "Comments for translators" section.

There was an extension that was wrong written, in translations paragraph