### PR TITLE
[Scala] exclude Scala IDE related .cache-main .

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -49,3 +49,6 @@ local.properties
 
 # Code Recommenders
 .recommenders/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main

--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -15,6 +15,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.cache-main
 
 # ENSIME specific
 .ensime_cache/

--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -15,7 +15,6 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
-.cache-main
 
 # ENSIME specific
 .ensime_cache/


### PR DESCRIPTION
Originating from https://issues.scala-lang.org/browse/SI-9506. Added exclusion for Eclipse as well.
