### PR TITLE
Ignore GNU Global GSYMS database of other symbols

### DIFF
--- a/Global/Tags.gitignore
+++ b/Global/Tags.gitignore
@@ -9,6 +9,7 @@ gtags.files
 GTAGS
 GRTAGS
 GPATH
+GSYMS
 cscope.files
 cscope.out
 cscope.in.out


### PR DESCRIPTION
**Reasons for making this change:**

Support older versions of gnu global, for instance Debian Jessie includes 5.7.1

