### PR TITLE
Add eslint cache ignore for node projects.

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -34,5 +34,8 @@ jspm_packages
 # Optional npm cache directory
 .npm
 
+# Optional eslint cache
+.eslintcache
+
 # Optional REPL history
 .node_repl_history


### PR DESCRIPTION
**Reasons for making this change:**

I have been using the Node gitignore from this repo for my projects but I keep manually having to add this line. Now that JSCS has merged into eslint I feel like eslint is widely used enough to be considered for many node projects.

**Links to documentation supporting these rule changes:** 

https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2#.8h4plwmvh

