### PR TITLE
Create MavenWithIDE

### DIFF
--- a/MavenWithIDE
+++ b/MavenWithIDE
@@ -1,0 +1,26 @@
+# Ignores for Maven and common Maven plugins
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Ignores for common IDEs used with Maven
+
+# Eclipse (https://eclipse.org/)
+.settings/
+.project
+.classpath
+
+# NetBeans (https://netbeans.org/)
+nbproject/
+nbactions.xml
+nb-configuration.xml
+
+# IntelliJ IDEA (https://www.jetbrains.com/idea/)
+.idea
+*.iml


### PR DESCRIPTION
**Reasons for making this change:**

This change adds a new Maven template which includes the ignores in the existing Maven template, but also includes ignores for three common IDE project files used with Maven (Eclipse, NetBeans, and IntelliJ IDEA). This will help developers who do not wish IDE project files to be committed with other changes. The ignores are organized with comments to provide documentation for their purpose and links to the IDEs whose files are ignored. Additional IDEs could be added later.

**Links to documentation supporting these rule changes:** 

N/A

If this is a new template: 
- **Link to application or project’s homepage**: N/A

Create gitignore template for Maven with common IDEs used with Maven
