### PR TITLE
nbactions.xml must not be ignored (?)

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -3,5 +3,4 @@ build/
 nbbuild/
 dist/
 nbdist/
-nbactions.xml
 .nb-gradle/


### PR DESCRIPTION
**Reasons for making this change:**

This file as documentation (which seems lacking) states is used for calling custom Maven goals from the IDE.
Ignoring this file was a source much confusion in few projects (mapping Run action to custom goals... etc etc) 
Also this file does anything worth ignoring
Added by #145
Exclusion of `nbactions.xml`  from `.gitgnore` should be discussed.