### PR TITLE
Added "Python Tools for Visual Studio" to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -254,3 +254,7 @@ paket-files/
 
 # CodeRush
 .cr/
+
+# Python Tools for Visual Studio (PTVS)
+__pycache__/
+*.pyc


### PR DESCRIPTION
**Reasons for making this change:**

Python Tools for Visual Studio:

1.  __pycache__/

2.  *.pyc

**Links to documentation supporting these rule changes:** 

1. Anaconda

2. Python byte code