### PR TITLE
[VisualStudio] ignore files after UWP package was created..

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -174,8 +174,10 @@ rcf/
 # Windows Store app package directories and files
 AppPackages/
 BundleArtifacts/
-Package.StoreAssociation.xml
 _pkginfo.txt
+_scale-*.appx
+_language-*.appx 
+Package.StoreAssociation.xml
 
 # Visual Studio cache files
 # files ending in .cache can be ignored


### PR DESCRIPTION
**Reasons for making this change:**

Because VS  makes a lot of unnecessary files like that - https://dl.dropboxusercontent.com/u/22639368/ShareX/2016/08/2016-08-26_00-56-28.png
after package was created, the vs git ignore contains some ignored files from this list.  
