### PR TITLE
Addin .vscode/ folder to be ignored.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -27,6 +27,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio Code cache/options directory
+.vscode/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
**Reasons for making this change:**

Adding vscode folder to be ignored for those of us who also develop using Visual Studio Code. This folder holds workspace settings and options as well as extensions.

**Links to documentation supporting these rule changes:** 

https://code.visualstudio.com/docs/customization/userandworkspace


