### PR TITLE
Added pattern to exclude temp .sln files generated by Visual Studio when using Git

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.sln~*
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
**Reasons for making this change:**

When using Visual Studio Community on Windows 10 Pro with Git I noticed that temporary solution files were being generated in the project's root directory I believe after a prior commit. The format is:

Project.sln~_commit hash_
Project.sln~HEAD

where "Project" is an arbitrary project name.

**Links to documentation supporting these rule changes:** 

Nothing that specifically mentions this. All solutions for removing temp files points to here essentially.
