### PR TITLE
Add gitignore for Cypress Semiconductor IDE

### DIFF
--- a/Global/PSoCCreator.gitignore
+++ b/Global/PSoCCreator.gitignore
@@ -1,0 +1,16 @@
+# Project Settings
+*.cywrk.*
+*.cyprj.*
+
+# Generated Assets and Resources
+Debug/
+Release/
+Export/
+*/codegentemp
+*/Generated_Source
+*_datasheet.pdf
+*_timing.html
+*.cycdx
+*.cyfit
+*.rpt
+*.svd

--- a/Global/PSoCCreator.gitignore
+++ b/Global/PSoCCreator.gitignore
@@ -14,3 +14,5 @@ Export/
 *.cyfit
 *.rpt
 *.svd
+*.log
+*.zip


### PR DESCRIPTION
Could not find a good gitignore online, and Cypress Semiconductor is a huge player so I think it's good to help people collaborate and share the _neccessary_ resources
- http://www.cypress.com/products/psoc-creator-integrated-design-environment-ide

If you open up a USB3 hub or device, you will most likely see a Cypress Semi in there :)

The PSoC is a popular microcontroller and the PSoC Creator is a great IDE that deserves a .gitignore so it's easier for people to share the _neccessary_ files for collaboration. 

> not affiliated
