### PR TITLE
Add Racket.gitignore

### DIFF
--- a/Racket.gitignore
+++ b/Racket.gitignore
@@ -1,0 +1,8 @@
+*.rkt~
+*.rkt.bak
+\#*.rkt#
+\#*.rkt#*#
+*.dep
+*.zo
+
+compiled


### PR DESCRIPTION
**Reasons for making this change:**

Add [Racket](https://racket-lang.org/) support (similar to Lisp/Scheme)

**Links to documentation supporting these rule changes:** 
- [DrRacket files](https://docs.racket-lang.org/drracket/drracket-files.html) (`*.rkt~`, `*.rkt.back`, `#*.rkt#*#`)
- [raco bytecode](https://docs.racket-lang.org/raco/Bytecode_Files.html) (`compiled/`, `*.zo`)
- [raco dependency tracking files](https://docs.racket-lang.org/raco/Dependency_Files.html) (`compiled/`, `*.dep`)

**Commit Message**
Dr Racket the official Racket IDE produces quite a large number of
temporary files (see: https://docs.racket-lang.org/drracket/drracket-files.html )
- Backup files are the src filename + `~` on UNIX and `.bak` on Windows
- DrRacket autosave files are src filename prepended with `#`, suffixed
  with `#`, a number and then another `#`.
- `raco`, the Racket CLI build/package/test tool produces a `compiled`
  directory to store bytecode. It also produces `*.dep` and `*.zo`
  files.

**Noteworthy**
Although similar to Scheme, Racket has it's own file suffixes (`.rkt`) and is a much larger and versatile language with first class meta programming support. This would nicely complement  the Scheme gitignore. 
