### PR TITLE
Create Kotlin.gitignore

### DIFF
--- a/Kotlin.gitignore
+++ b/Kotlin.gitignore
@@ -1,0 +1,30 @@
+# User
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Kotlin lang - https://github.com/JetBrains/kotlin/blob/master/.gitignore
+.DS_Store
+.idea/shelf
+/android.tests.dependencies
+/confluence/target
+/dependencies
+/dist
+/gh-pages
+/ideaSDK
+/android-studio/sdk
+out
+tmp
+*.versionsBackup
+/idea/testData/debugger/tinyApp/classes*
+/jps-plugin/testData/kannotator
+ultimate/.DS_Store
+ultimate/.idea/shelf
+ultimate/dependencies
+ultimate/ideaSDK
+ultimate/out
+ultimate/tmp
+ultimate/workspace.xml
+ultimate/*.versionsBackup


### PR DESCRIPTION
**Reasons for making this change:**

The Kotlin language git ignore file did not exist in the repository. 

**Links to documentation supporting these rule changes:** 

I am adding the git ignore file used in the Kotlin language open sourced repo. The link can be found here: [Kotlin Github](https://github.com/JetBrains/kotlin/blob/master/.gitignore)

If this is a new template: 

As mentioned above, the link to the Kotlin language can be found here: [Kotlin Github](https://github.com/JetBrains/kotlin/blob/master/.gitignore)