### PR TITLE
Update TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -192,3 +192,6 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~[0-9]*
+
+# auto folder when using emacs and auctex 
+/auto/*


### PR DESCRIPTION
Added a line that includes the `auto` folder that Emacs+ AUCTex automatically creates in the gitignore list. 

**Reasons for making this change:**

Emacs + AUCTex creates a folder called `auto` in the local dir. 
This is due to the automatic parsing of the TeX files. 

**About this auto folder** 
https://www.gnu.org/software/auctex/manual/auctex/Parsing-Files.html