### PR TITLE
Update link to Fastlane's .gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -57,7 +57,7 @@ Carthage/Build
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
-# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
+# https://docs.fastlane.tools/best-practices/Gitignore/
 
 fastlane/report.xml
 fastlane/Preview.html


### PR DESCRIPTION
**Reasons for making this change:**

Fastlane moved their docs. The previous link is broken. 

**Links to documentation supporting these rule changes:** 

https://github.com/fastlane/fastlane/commit/8831ded60972086cbe088c14beeb80009998cf9e

If this is a new template: 
- **Link to application or project’s homepage**: _TODO_

Old link broken, replaced with new docs link.
