### PR TITLE
ignore gradle build folder of subprojects

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
**Reasons for making this change:**

When the gradle project is a mulit-project, there are build folders in each sub-project. The updated pattern will ignore all the build folders both in parent project directory and sub-project directories.

**Links to documentation supporting these rule changes:** 

The updated pattern can be found in https://git-scm.com/docs/gitignore


