### PR TITLE
Eclipse subprojects ignore

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -1,18 +1,18 @@
 
 .metadata
-bin/
+**/bin/
 tmp/
 *.tmp
 *.bak
 *.swp
 *~.nib
 local.properties
-.settings/
+**/.settings/
 .loadpath
 .recommenders
 
 # Eclipse Core
-.project
+**/.project
 
 # External tool builders
 .externalToolBuilders/
@@ -27,7 +27,7 @@ local.properties
 .cproject
 
 # JDT-specific (Eclipse Java Development Tools)
-.classpath
+**/.classpath
 
 # Java annotation processor (APT)
 .factorypath

--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
**Reasons for making this change:**

When import a java project that contains sub-projects, eclipse creates `.settings folder`, `.project` and `.classpath` for each sub-project, and they should also be ignored.

**Links to documentation supporting these rule changes:** 

The updated pattern can be found in https://git-scm.com/docs/gitignore
