### PR TITLE
Ignore maven files of subprojects

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -1,18 +1,18 @@
 
 .metadata
-bin/
+**/bin/
 tmp/
 *.tmp
 *.bak
 *.swp
 *~.nib
 local.properties
-.settings/
+**/.settings/
 .loadpath
 .recommenders
 
 # Eclipse Core
-.project
+**/.project
 
 # External tool builders
 .externalToolBuilders/
@@ -27,7 +27,7 @@ local.properties
 .cproject
 
 # JDT-specific (Eclipse Java Development Tools)
-.classpath
+**/.classpath
 
 # Java annotation processor (APT)
 .factorypath

--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -1,8 +1,8 @@
-target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
+**/target/
+**/pom.xml.tag
+**/pom.xml.releaseBackup
+**/pom.xml.versionsBackup
+**/pom.xml.next
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties


### PR DESCRIPTION
**Reasons for making this change:**

When the maven project is a multi-project, each sub-project have a `target` folder. They should be ignored.

**Links to documentation supporting these rule changes:** 

The updated pattern can be found in https://git-scm.com/docs/gitignore
