### PR TITLE
 Android gitignore file modified.

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -14,8 +14,17 @@ gen/
 out/
 
 # Gradle files
+.gradle
 .gradle/
 build/
+
+# Crashlytics configuations
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+# Signing files
+.signing/
 
 # Local configuration file (sdk path, etc)
 local.properties
@@ -26,16 +35,76 @@ proguard/
 # Log Files
 *.log
 
-# Android Studio Navigation editor temp files
-.navigation/
-
-# Android Studio captures folder
+# Android Studio
+/*/build/
+/*/local.properties
+/*/out
+/*/*/build
+/*/*/production
 captures/
+.navigation/
+*.ipr
+*~
+*.swp
 
-# Intellij
+# Android Patch
+gen-external-apklibs
+
+# NDK
+obj/
+
+# IntelliJ IDEA
 *.iml
+*.iws
+
+# User-specific configurations
+.idea/libraries/
 .idea/workspace.xml
-.idea/libraries
+.idea/tasks.xml
+.idea/.name
+.idea/compiler.xml
+.idea/copyright/profiles_settings.xml
+.idea/encodings.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/scopes/scope_settings.xml
+.idea/vcs.xml
+.idea/datasources.xml
+.idea/dataSources.ids
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
 
 # Keystore files
 *.jks
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+# OS-specific files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Legacy Eclipse project files
+.classpath
+.project
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs (Reference: http://www.java.com/en/download/help/error_hotspot.xml)
+hs_err_pid*
+


### PR DESCRIPTION
**Reasons for making this change:**

Includes the following types of files that can be ignored.
1) OS-specific files. 
2) Crashlytics configuration files.
3) Android Signing files
4) Virtual Machine crash log files.
5) Jira plugin xml files
6) Mongo Explorer plugin setting files.
7) Legacy eclipse ide and java files.
8) NDK obj folder

**Links to documentation supporting these rule changes:** 

http://stackoverflow.com/questions/16736856/what-should-be-in-my-gitignore-for-an-android-studio-project
https://gist.github.com/vtanathip/9414323
http://unknownerror.org/opensource/github/gitignore/q/stackoverflow/16736856/what-should-be-in-my-gitignore-for-an-android-studio-project