### PR TITLE
Ignore .jfm files in Visual Studio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -189,6 +189,7 @@ ClientBin/
 *~
 *.dbmdl
 *.dbproj.schemaview
+*.jfm
 *.pfx
 *.publishsettings
 node_modules/


### PR DESCRIPTION
**Reasons for making this change:**

.jfm files have started blocking checking for .sqlproj projects in Visual Studio. .jfm files are a new file-type created by the Microsoft ESENT database engine - this is a recent improvement only in Windows 10 Anniversary update. As the SSDT .sqlproj type in Visual Studio uses this engine for .dbmdl metadata files, and this file is locked by the user, this currently blocks users from checking into Git repositories.

This fix helps mitigate this by avoiding checkin of this file type.

**Links to documentation supporting these rule changes:** 
An example of this issue is this [StackOverflow post
](http://stackoverflow.com/questions/37704514/visual-studio-2015-database-project-directory-contains-a-file-with-extension-jfm) which shows the issues cause by this, and an explanation of the cause. At present, the file type is not documented by the ESENT team, so there is no official doc covering this.

Disclosure: I work for Microsoft on the SSDT team shipping .sqlproj support into Visual Studio. 


