### PR TITLE
added VS code coverage files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -110,6 +110,10 @@ _TeamCity*
 # DotCover is a Code Coverage Tool
 *.dotCover
 
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml


### PR DESCRIPTION
**Reasons for making this change:**

Automatically ignore VS Enterprise code coverage files.

**Links to documentation supporting these rule changes:** 

https://msdn.microsoft.com/en-us/library/dd537628.aspx#Anchor_1

Mentions of the extensions:

> The coverage coloring might be incorrect if the source code has changed since the .coverage file was generated. 

> (...)

> To make results readable as text, choose Export Code Coverage Results. This generates a readable .coveragexml file which you could process with other tools or send easily in mail.

