### PR TITLE
Update Erlang.gitignore

### DIFF
--- a/Erlang.gitignore
+++ b/Erlang.gitignore
@@ -4,7 +4,7 @@ deps
 *.beam
 *.plt
 erl_crash.dump
-ebin
+ebin/*.beam
 rel/example_project
 .concrete/DEV_MODE
 .rebar


### PR DESCRIPTION
**Reasons for making this change:**

`/ebin` can't be simplely ignored because `*.app` should be put here.

**Links to documentation supporting these rule changes:** 

[Erlang Applications](http://erlang.org/doc/design_principles/applications.html)
> ### 8.4  Directory Structure
> ebin - Contains the Erlang object code, the beam files. The .app file is also placed here.