### PR TITLE
Add support for Cake.Net

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -264,5 +264,5 @@ paket-files/
 __pycache__/
 *.pyc
 
-# Cake
-tools/
+# Cake - Uncomment if you are using it
+# tools/

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -263,3 +263,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Cake
+tools/


### PR DESCRIPTION
Cake.Net creates a tools folder at the root which contains downloaded packages and should not be checked in. See [documentation](http://cakebuild.net/docs/tutorials/getting-started) for reference to the tools folder where NuGet packages are downloaded.