### PR TITLE
Added .DS_Store files to Swift and Objective-C gitignore files

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -60,3 +60,8 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# macOS
+#
+# No need to add system files like .DS_Store
+.DS_Store

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -63,3 +63,8 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+# macOS
+#
+# No need to add system files like .DS_Store
+.DS_Store


### PR DESCRIPTION
Since .DS_Store is a hidden system file and act no role in a source code directory, no need to add this to repository.