### PR TITLE
Add .nfs files to Linux.gitignore

### DIFF
--- a/Global/Linux.gitignore
+++ b/Global/Linux.gitignore
@@ -8,3 +8,6 @@
 
 # Linux trash folder which might appear on any partition or disk
 .Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*


### PR DESCRIPTION
**Reasons for making this change:**
.nfs files are created when an open file is removed but is still being accessed

**Links to documentation supporting these rule changes:** 
http://serverfault.com/questions/201294/nfsxxxx-files-appearing-what-are-those

