### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -39,3 +39,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Output of 'npm pack'
+*.tgz


### PR DESCRIPTION
**Reasons for making this change:**

`npm pack` creates *.tgz files in the current working directory, containing what would be published. They may be the output of other build-steps, but it is unlikely they should be considered for committing by default. `npm publish` includes all non-tracked files in the repository directory, unless ignored by `.gitignore` or `.npmignore`, leading to a published package containing a copy of itself.

**Links to documentation supporting these rule changes:** 

https://docs.npmjs.com/cli/pack

~~If this is a new template:~~ 

~~**Link to application or project’s homepage**:~~

Add `*.tgz`, the output of `npm pack`, or other build-steps.