### PR TITLE
Do NOT ignore maven-wrapper JAR files

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,3 +7,4 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+!.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
The Maven Wrapper has a JAR file that must NOT be left out.

Resolves https://github.com/joeblau/gitignore.io/issues/237
