### PR TITLE
Ignore Pycharm project settings

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -88,3 +88,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm project settings
+.idea


### PR DESCRIPTION
**Reasons for making this change:**

PyCharm's project settings are stored with each specific project as a set of `xml` files under the `.idea` folder.

**Links to documentation supporting these rule changes:** 

https://www.jetbrains.com/help/pycharm/2016.1/configuring-project-and-ide-settings.html
