### PR TITLE
Update Java.gitignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -10,3 +10,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IntelliJ integration files #
+*.iws
+*.iml
+*.ipr


### PR DESCRIPTION
**Reasons for making this change:**

In order to use IntelliJ for Spring, Grails,... projects; you may need to generate some files, and this files are useful for developers that uses the same IDE. If anyone use Eclipse or Netbeans instead of IntelliJ, this 3 files are unnecesary. IMPORTANT: I think that this configuration works too for Android Studio.

**Links to documentation supporting these rule changes:** 

https://www.jetbrains.com/help/idea/2016.2/project.html#newProjectFormat
The documentation says that the .ipr file should be versioned, but this is in the context that all devs in the project are using IntelliJ

IntelliJ integration files