### PR TITLE
Don't ignore Python coverage configuration

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+!.coveragerc
 
 # Translations
 *.mo


### PR DESCRIPTION
Python's coverage module is configured in `.coveragerc`, which somehow was previously ignored.