### PR TITLE
Add vendor folder to Go.gitignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# external packages folder
+vendor/


### PR DESCRIPTION
**Reasons for making this change:**

if use [Masterminds/glide](https://github.com/Masterminds/glide) Vendor Package Management for Golang, the dependencies are exported to the `vendor/` directory


**Links to documentation supporting these rule changes:** 
>Go 1.5 introduced experimental support for a "vendor" directory, enabled by the GO15VENDOREXPERIMENT environment variable. Go 1.6 enabled this behavior by default, and in Go 1.7, this switch has been removed and the "vendor" behavior is always enabled.

https://blog.golang.org/go1.7