### PR TITLE
Removed trailing '\r' character related to platform incompatibility

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -2,9 +2,8 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
+# Icon must end with two
 Icon
-
 
 # Thumbnails
 ._*


### PR DESCRIPTION
**Reasons for making this change:**

A trailing escape character at the end of a comment line [\r] was causing the entire document to render with carriage returns [^G] at the end of each line. This is due to a Linux/Windows incompatibility issue as pertains to line endings.

Performing a curl redirection of the HTML into a text document and opening in Vim will show this behavior.

**Links to documentation supporting these rule changes:** 

Stack Overflow example of this behavior.
https://stackoverflow.com/questions/799417/gvim-showing-carriage-return-m-even-when-file-mode-is-explicitly-dos