### PR TITLE
Add PyCharm project settings

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -88,3 +88,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm project settings
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**

Many python programmers use PyCharm, which stores config files in 
a .idea directory located at inside project's root directory. 
These files are PyCharm specific, and should not be tracked 
by source control. 

**Links to documentation supporting these rule changes:** 

The following link leads to a page describing PyCharm
project structure in greater detail.

[https://www.jetbrains.com/help/pycharm/2016.1/project.html](https://www.jetbrains.com/help/pycharm/2016.1/project.html)