### PR TITLE
autotools.gitignore: add missing files

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -1,6 +1,11 @@
 # http://www.gnu.org/software/automake
 
 Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
 
 # http://www.gnu.org/software/autoconf
 
@@ -9,10 +14,20 @@ Makefile.in
 /autoscan-*.log
 /aclocal.m4
 /compile
+/config.guess
 /config.h.in
+/config.sub
 /configure
 /configure.scan
 /depcomp
 /install-sh
 /missing
 /stamp-h1
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex


### PR DESCRIPTION
**Reasons for making this change:**

autotools.gitignore was missing some files which are in my source tree after `autoreconf -fi`

**Links to documentation supporting these rule changes:** 

See AC_CONFIG_AUX_DIR in https://www.gnu.org/software/automake/manual/html_node/Optional.html
