### PR TITLE
Added yarn.lock file to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -34,6 +34,9 @@ jspm_packages
 # Optional npm cache directory
 .npm
 
+# Optional yarn lockfile
+yarn.lock
+
 # Optional eslint cache
 .eslintcache
 


### PR DESCRIPTION
**Reasons for making this change:**

Yarn is a new package manager for NodeJS released by facebook

**Links to documentation supporting these rule changes:** 

https://yarnpkg.com/

