### PR TITLE
Create Snapcraft.gitignore

### DIFF
--- a/Snapcraft.gitignore
+++ b/Snapcraft.gitignore
@@ -1,0 +1,5 @@
+# Snapcraft
+parts/
+prime/
+stage/
+*.snap


### PR DESCRIPTION
This adds gitignore for snapcraft, Snapcraft can package any app for every Linux desktop, server, cloud or device, and deliver updates directly.
- http://snapcraft.io/
- https://github.com/snapcore/snapcraft
- https://developer.ubuntu.com/en/snappy/
