### PR TITLE
Update Elixir.gitignore

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+*.beam


### PR DESCRIPTION
**Reasons for making this change:**

Elixir code compiled into .beam files shouldn't be checked in to git. These are typically located in the __build_ folder, but in the case of Elixir files compiled with `elixirc`, or `iex`'s `c` helper function, these files can be created elsewhere.

**Links to documentation supporting these rule changes:** 

The creation of BEAM files is briefly touched upon in the [Elixir module docs](http://elixir-lang.org/getting-started/modules.html#compilation)
