### PR TITLE
Add yarn ignored file

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -42,3 +42,7 @@ jspm_packages
 
 # Output of 'npm pack'
 *.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+


### PR DESCRIPTION
**Reasons for making this change:**

Yarn may add this file in its workflow. 

**Links to documentation supporting these rule changes:** 

https://github.com/yarnpkg/yarn/blob/113fab9698611d6e24f355c1a66e2ad9e7325317/src/cli/commands/install.js#L649
