### PR TITLE
Ignore Jetbrains IDE folders

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -42,3 +42,6 @@ jspm_packages
 
 # Output of 'npm pack'
 *.tgz
+
+#Webstorm/Jetbrains
+.idea


### PR DESCRIPTION
**Application homepage**  
https://www.jetbrains.com/webstorm/

**Documentation**  
Jetbrains IDEs store user settings in the project folder under a `.idea`

**Reasons for making this change:**  
Adds Jetbrains Webstorm IDE folder 
