### PR TITLE
ignore public/storage for laravel 5

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -7,6 +7,7 @@ app/storage/
 
 # Laravel 5 & Lumen specific
 bootstrap/cache/
+public/storage
 .env.*.php
 .env.php
 .env


### PR DESCRIPTION
**Reasons for making this change:**

Ignore public storage path.

**Links to documentation supporting these rule changes:** 

Ref: https://github.com/laravel/laravel/blob/master/.gitignore#L2