### PR TITLE
Ignore Passport-generated OAuth keys

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -8,6 +8,7 @@ app/storage/
 # Laravel 5 & Lumen specific
 bootstrap/cache/
 public/storage
+storage/*.key
 .env.*.php
 .env.php
 .env


### PR DESCRIPTION
**Reasons for making this change:**

Ignore Passport-generated OAuth keys.

**Links to documentation supporting these rule changes:** 

reason: https://github.com/laravel/laravel/commit/f7a79a33cfa1627938deec5d2d3c0075cc86f3fb

ref: https://github.com/laravel/laravel/blob/master/.gitignore#L3
