### PR TITLE
Removed LaunchSettings.json from being committed

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -44,6 +44,7 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
+Properties/launchSettings.json
 
 *_i.c
 *_p.c


### PR DESCRIPTION
**Reasons for making this change:**
Removed Properites/launchSettings.json as others may be using other web servers and ports. Doesn't make sense to include my version.

**Links to documentation supporting these rule changes:** 
https://github.com/aspnet/Mvc/pull/3525
