### PR TITLE
Add Altium Designer gitignore file

### DIFF
--- a/Altium.gitignore
+++ b/Altium.gitignore
@@ -1,0 +1,18 @@
+# Previews Folders
+**/__Previews/
+
+# History Folders
+**/History/*
+
+# Project Logs
+Project\ Logs*/
+
+# Project Outputs
+Project\ Outputs*/
+
+# Auto-conversion notices
+*.PcbDoc.htm
+
+# Access lock file for dbLib sources
+**/*.ldb
+


### PR DESCRIPTION
**Reasons for making this change:**

New template!

**Links to documentation supporting these rule changes:** 

The _History_ folder contains a running history of the (binary) source:
http://techdocs.altium.com/display/ADOH/Document+Management+-+Auto+save,+Local+History+and+External+Version+Control

Almost correct :) discussion on Altium files to ignore: http://electronics.stackexchange.com/questions/159220/which-files-to-version-control-for-an-altium-pcb-project
- **Link to application’s homepage**: http://www.altium.com/
