### PR TITLE
ignore Visual Studio 6 workspace file

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -239,6 +239,9 @@ FakesAssemblies/
 # Visual Studio 6 workspace options file
 *.opt
 
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
 # Visual Studio LightSwitch build output
 **/*.HTMLClient/GeneratedArtifacts
 **/*.DesktopClient/GeneratedArtifacts


### PR DESCRIPTION
**Reasons for making this change:**

The vbw file doesn't server a purpose besides the last opened files etc. Especially when working in teams this file will basically differ as soon as you open the project and could lead to unnecessary merge conflicts. There's basically no sense in keeping this file.

**Links to documentation supporting these rule changes:** 

http://stackoverflow.com/a/1530193
http://stackoverflow.com/a/37311186
https://msdn.microsoft.com/en-us/library/aa241721(v=vs.60).aspx