### PR TITLE
Laravel: fixed incorrect ignoring of cache folder

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -6,7 +6,6 @@ bootstrap/compiled.php
 app/storage/
 
 # Laravel 5 & Lumen specific
-bootstrap/cache/
 public/storage
 .env.*.php
 .env.php


### PR DESCRIPTION
**Reasons for making this change:**

This rule causes an unintended side effect of not tracking the directory `bootstrap/cache/`. By default, there is a [`.gitignore`](https://github.com/laravel/laravel/blob/d22b32f4e8e07a57e89c5227e1180e92e6889835/bootstrap/cache/.gitignore) file present in [`bootstrap/cache/`](https://github.com/laravel/laravel/tree/d22b32f4e8e07a57e89c5227e1180e92e6889835/bootstrap/cache) which makes sure that only the contents of the directory is untracked by git while the (almost empty) directory `boostrap/cache/` is present because of the presence of `.gitignore` in it. 

Ignoring `bootstrap/cache/` with the gitignore file in the repository root would result in the absence of a cache folder, to which Laravel's artisan throws an error.

```
[ErrorException] file_put_contents($APP_PATH/bootstrap/cache/services.php): failed to open stream: No such file or directory  
```

Creating the `cache` folder again fixes this.

By removing the line `bootstrap/cache/` from the project level gitignore, the one present in the sub-directory will kick in and everything will work as the project maintainers intended it to be.

**Links to documentation supporting these rule changes:** 

This is not documented. But, can easily be verified by looking at the source repository. 

default gitignore file: [bootstrap/cache/.gitignore](https://github.com/laravel/laravel/blob/d22b32f4e8e07a57e89c5227e1180e92e6889835/bootstrap/cache/.gitignore)
directory: [bootstrap/cache/](https://github.com/laravel/laravel/tree/d22b32f4e8e07a57e89c5227e1180e92e6889835/bootstrap/cache)
