### PR TITLE
Nanoc: Fix capitalisation + config filename

### DIFF
--- a/Nanoc.gitignore
+++ b/Nanoc.gitignore
@@ -1,6 +1,6 @@
 # For projects using Nanoc (http://nanoc.ws/)
 
-# Default location for output (needs to match output_dir's value found in config.yaml)
+# Default location for output (needs to match output_dir's value found in nanoc.yaml)
 output/
 
 # Temporary file directory

--- a/Nanoc.gitignore
+++ b/Nanoc.gitignore
@@ -1,6 +1,6 @@
 # For projects using Nanoc (http://nanoc.ws/)
 
-# Default location for output, needs to match output_dir's value found in config.yaml
+# Default location for output (needs to match output_dir's value found in config.yaml)
 output/
 
 # Temporary file directory

--- a/Nanoc.gitignore
+++ b/Nanoc.gitignore
@@ -1,4 +1,4 @@
-# For projects using nanoc (http://nanoc.ws/)
+# For projects using Nanoc (http://nanoc.ws/)
 
 # Default location for output, needs to match output_dir's value found in config.yaml
 output/


### PR DESCRIPTION
**Reasons for making this change:**

* Fix capitalisation of Nanoc (_Nanoc_, not _nanoc_)
* Use `nanoc.yaml` rather than `config.yaml` (the former is the default filename, while the latter is deprecated)

**Links to documentation supporting these rule changes:** 

* The [Nanoc web site](http://nanoc.ws/)