### PR TITLE
Rename 'IPython Notebook' comment to 'Jupyter Notebook'

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -66,7 +66,7 @@ docs/_build/
 # PyBuilder
 target/
 
-# IPython Notebook
+# Jupyter Notebook
 .ipynb_checkpoints
 
 # pyenv


### PR DESCRIPTION
**Reasons for making this change:**

IPython Notebooks are now called Jupyter Notebooks. Making this change is more accurate and helps spread adoption of the new name.

**Links to documentation supporting these rule changes:** 

[Project Jupyter](http://jupyter.org/)

