### PR TITLE
add mention bot to improve PR reviews

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,34 @@
+{
+  "maxReviewers": 5, // Maximum  number of people to ping in the PR message, default is 3
+  "numFilesToCheck": 10, // Number of files to check against, default is 5
+  "message": "@pullRequester, thanks! @reviewers, please review this.",
+             // custom message using @pullRequester and @reviewers
+  "alwaysNotifyForPaths": [
+    {
+      "name": "ghuser", // The user's Github username
+      "files": ["src/js/**/*.js"], // The array of file globs associated with the user
+      "skipTeamPrs": false // mention-bot will exclude the creator's own team from mentions
+    }
+  ], // users will always be mentioned based on file glob
+  "fallbackNotifyForPaths": [
+    {
+      "name": "ghuser", // The user's Github username
+      "files": ["src/js/**/*.js"], // The array of file globs associated with the user
+      "skipTeamPrs": false // mention-bot will exclude the creator's own team from mentions
+    }
+  ], // users will be mentioned based on file glob if no other user was found
+  "findPotentialReviewers": true, // mention-bot will try to find potential reviewers based on files history, if disabled, `alwaysNotifyForPaths` is used instead
+  "fileBlacklist": ["*.md"], // mention-bot will ignore any files that match these file globs
+  "userBlacklist": [], // users in this list will never be mentioned by mention-bot
+  "userBlacklistForPR": [], // PR made by users in this list will be ignored
+  "requiredOrgs": [], // mention-bot will only mention user who are a member of one of these organizations
+  "actions": ["opened"], // List of PR actions that mention-bot will listen to, default is "opened"
+  "skipAlreadyAssignedPR": false, // mention-bot will ignore already assigned PR's
+  "skipAlreadyMentionedPR": false, // mention-bot will ignore if there is already existing an exact mention
+  "assignToReviewer": false, // mention-bot assigns the most appropriate reviewer for PR
+  "skipTitle": "", // mention-bot will ignore PR that includes text in the title,
+  "withLabel": "", // mention-bot will only consider PR's with this label. Must set actions to ["labeled"].
+  "delayed": false, // mention-bot will wait to comment until specified time in `delayedUntil` value
+  "delayedUntil": "3d", // Used if delayed is equal true, permitted values are: minutes, hours, or days, e.g.: '3 days', '40 minutes', '1 hour', '3d', '1h', '10m'
+  "skipCollaboratorPR": false, // mention-bot will ignore if PR is made by collaborator
+}


### PR DESCRIPTION
**Reasons for making this change:**

With the Pull Request backlong getting pretty long I think it'd be worthwhile to add something like the [mention-bot](https://github.com/facebook/mention-bot) to help prompt relevant parties to review the changes.

**NOTE:** This PR is just a the mention-bot configuration template, additional configuration and steps are required as documented at https://github.com/facebook/mention-bot#how-to-use

