### PR TITLE
[C] ignore versions of kernel module build results

### DIFF
--- a/C.gitignore
+++ b/C.gitignore
@@ -45,6 +45,7 @@
 # Kernel Module Compile Results
 *.mod*
 *.cmd
+.tmp_versions/
 modules.order
 Module.symvers
 Mkfile.old


### PR DESCRIPTION
**Reasons for making this change:**

.tmp_versions is a directory that records version of Linux kernel module build result, should be ignored.
