### PR TITLE
Update Objective-C and Swift to match Xcode.gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -19,7 +19,8 @@ xcuserdata/
 
 ## Other
 *.moved-aside
-*.xcuserstate
+*.xccheckout
+*.xcscmblueprint
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -19,7 +19,8 @@ xcuserdata/
 
 ## Other
 *.moved-aside
-*.xcuserstate
+*.xccheckout
+*.xcscmblueprint
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
**Reasons for making this change:**

The Objective-C and Swift gitignore files are missing `*.xccheckout` and `*.xcscmblueprint`, but these are still included in the Xcode gitignore. This commit synchronises the three files.

The files themselves contain information about the user's local source control status and shouldn't be included in most Xcode repositories.

`*.xcuserstate` appears to always be contained in `xcuserdata/` which is already ignored. For this reason `*.xcuserstate` isn't included in Xcode.gitignore.

**Links to documentation supporting these rule changes:** 

There doesn't exist any official documentation on the matter, however investigation has been conducted in the following stackoverflow threads:

http://stackoverflow.com/questions/31584297/xcode-7-ignore-xcscmblueprint-in-repository
http://stackoverflow.com/questions/18340453/should-xccheckout-files-in-xcode5-be-ignored-under-vcs/19260712#comment29617170_19260712

Investigation shows that these files are automatically generated by Xcode, and that their contents differ based on your repository setup. Specifically for git, because each user is using their own repository (as apposed to a single, central repository like SVN) the contents of these files are always going to be different for each user.