### PR TITLE
Update to take into account Dart SDK 1.20

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,12 +1,18 @@
 # See https://www.dartlang.org/tools/private-files.html
 
 # Files and directories created by pub
-.buildlog
+
+# SDK 1.20 and later (no longer creates packages directories)
 .packages
-.project
 .pub/
 build/
+
+# Older SDK versions
+# (Include if the minimum SDK version specified in pubsepc.yaml is earlier than 1.20)
+.project
+.buildlog
 **/packages/
+
 
 # Files created by dart2js
 # (Most Dart developers will use pub build to compile Dart, use/modify these 


### PR DESCRIPTION
**Reasons for making this change:**

Dart SDK 1.20 no longer creates `packages` directories

**Links to documentation supporting these rule changes:** 

http://news.dartlang.org/2016/10/good-bye-symlinks.html

Dart SDK 1.20 no longer creates `packages` directories. Added comments to `pub` files section to differentiate  what is needed for >= SDK 1.20 and what is additionally needed for older SDK versions.