### PR TITLE
add the *.VC.db to unreal engine ignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,9 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# Visual Studio 2015 database file
+*.VC.db
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
**Reasons for making this change:**

as of visual studio 2015 update 2 this file stores the intellisense database.
this file is generated by visual studio and shouldn't be included in a repository, particularly because for an unreal project this file seems to start at around 300MB.

*.VC.db has already been added to the standard visual studio ignore [here](https://github.com/github/gitignore/blob/master/VisualStudio.gitignore)