### PR TITLE
Add *.VC.db (New IntelliSense database) for VS2015 Update2 ignore.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -268,5 +268,9 @@ paket-files/
 __pycache__/
 *.pyc
 
+# New IntelliSense database, VS2015 Update 2 or later
+*.VC.db
+
+
 # Cake - Uncomment if you are using it
 # tools/


### PR DESCRIPTION
After the Visual Studio 2015 Update 2 is installed, the solution with VC projects will create a new IntelliSense database, named <solution-name>.VC.db, it replaces the *.sdf file.



