### PR TITLE
Delete IPythonNotebook.gitignore

### DIFF
--- a/Global/IPythonNotebook.gitignore
+++ b/Global/IPythonNotebook.gitignore
@@ -1,2 +1,0 @@
-# Temporary data
-.ipynb_checkpoints/


### PR DESCRIPTION
**Reasons for making this change:**

The IPython Notebook is now known as the Jupyter Notebook. Jupyter ignore values are already found in the Python.gitignore.

**Links to documentation supporting these rule changes:** 

http://ipython.org/notebook.html
http://jupyter.org
https://github.com/github/gitignore/blob/master/Python.gitignore