### PR TITLE
ignore .DS_Store

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -267,6 +267,9 @@ paket-files/
 # CodeRush
 .cr/
 
+# Mac
+.DS_Store
+
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc


### PR DESCRIPTION
**Reasons for making this change:**

To ignore `.DS_Store` on Visual Studio gitignore file.

