### PR TITLE
ignore Properties/launchSettings.json even if Properties is a subfolder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -47,7 +47,7 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
-Properties/launchSettings.json
+**/Properties/launchSettings.json
 
 *_i.c
 *_p.c


### PR DESCRIPTION
**Reasons for making this change:**

to support the situation that the Properties folder is a subfolder 


