### PR TITLE
Change *.mtc patterns to single *.mtc[0-9]*

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -123,9 +123,7 @@ acs-*.bib
 *.maf
 *.mlf
 *.mlt
-*.mtc
-*.mtc[0-9]
-*.mtc[1-9][0-9]
+*.mtc[0-9]*
 
 # minted
 _minted*


### PR DESCRIPTION
**Reasons for making this change:**

Single pattern instead of those 3. 

**Links to documentation supporting these rule changes:** 

This pattern encompasses the previous ones, now including the pattern *.mtc0[0-9] that was previously missing but shouldn't happen in practice since LaTeX creates single digits indices instead.



