### PR TITLE
Go: Revert "Add vendor folder to Go.gitignore"

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -25,6 +25,3 @@ _testmain.go
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# external packages folder
-vendor/


### PR DESCRIPTION
This reverts commit 14740a52c50fabdab1758808e995dcd9766bd76f.

**Reasons for making this change:**

Any Go developers sometimes static vendoring into vendor directory.
Because for the delete vendoring packages repository, reliably build with
vendor packages or etc.
Also, A typical vendoring tool such as `gb`, `gvt` will create `manifest` file on `vendor` directory.

In Go language development, ignoring vendor directory is should be
left to the package authors.(I think)

**Links to documentation supporting these rule changes:** 

https://github.com/derekparker/delve/tree/master/vendor
https://github.com/zchee/docker-machine-driver-xhyve/tree/master/vendor