### PR TITLE
Removed bower asset exclusion

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -31,9 +31,6 @@
 /web/bundles/
 /web/uploads/
 
-# Assets managed by Bower
-/web/assets/vendor/
-
 # PHPUnit
 /app/phpunit.xml
 /phpunit.xml


### PR DESCRIPTION
**Reasons for making this change:**

- Bower asset inclusion is encouraged by the Symfony documentation

**Links to documentation supporting these rule changes:** 

- http://symfony.com/doc/current/frontend/bower.html#should-i-git-ignore-or-commit-bower-assets
