### PR TITLE
Ignore *.ctxt in Java.gitignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -1,5 +1,8 @@
 *.class
 
+# BlueJ files
+*.ctxt
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 


### PR DESCRIPTION
Similar to .class files, .ctxt files are generated every time a project is compiled in BlueJ. Just like .class files, if a .ctxt file is not present when a Java program is compiled, it will be  recreated automatically.

BlueJ has a downloadable extension featured on its website to clear out .class and .ctxt files automatically.
http://www.bluej.org/extensions/extensions.html