### PR TITLE
Create Y86.gitignore

### DIFF
--- a/Y86.gitignore
+++ b/Y86.gitignore
@@ -1,0 +1,2 @@
+# Object File
+*.yo


### PR DESCRIPTION
**Reasons for making this change:**
No template exists for Y86 object code generated by Y86 assemblers. The Y86 instruction set is heavily used in educational environments but lacks centralized documentation. Typically an assembler produces assembled object files with extension *.yo as seen in the following YAS instructions and documentation:

**Links to documentation supporting these rule changes:** 

https://www.cs.unm.edu/~bradykey/simguide.pdf

If this is a new template: 

https://www.cs.unm.edu/~bradykey/lab4Y86Sim341.html (Original project)
