### PR TITLE
Replace DNX with .NET Core

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -43,7 +43,7 @@ TestResult.xml
 [Rr]eleasePS/
 dlldata.c
 
-# DNX
+# .NET Core
 project.lock.json
 project.fragment.lock.json
 artifacts/


### PR DESCRIPTION
**Reasons for making this change:**

DNX-name is replaced with .NET Core. Could also be named `dotnet` perhaps.

**Links to documentation supporting these rule changes:** 

https://docs.microsoft.com/nb-no/dotnet/articles/core/migrating-from-dnx

