### PR TITLE
Laravel: ignore homestead config and npm debug.

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -1,5 +1,6 @@
 vendor/
 node_modules/
+npm-debug.log
 
 # Laravel 4 specific
 bootstrap/compiled.php


### PR DESCRIPTION
**Reasons for making this change:**

About the homestead configurations: /.idea, Homestead.json, Homestead.yaml is provided by default in newest laravel 5.3 installation.
About npm log files: laravel-elixir uses npm. If something happen (e.g failed npm install), then npm will create npm-debug.log.

**Links to documentation supporting these rule changes:** 

https://github.com/laravel/laravel/blob/master/.gitignore
https://github.com/laravel/elixir
