### PR TITLE
Idea: Add StarterContent to UnrealEngine.gitignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -64,3 +64,6 @@ Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+
+# Default location for StarterContent, engine adds these from local storage
+Content/StarterContent/*


### PR DESCRIPTION
A lot of beginners when they make a new project tend to include the StarterContent without realising that it's a huge set of files to add to a repository.
When a repository that should have the StarterContent is downloaded and the content is missing, Unreal will add the content from the local copy.

The pros to adding the StarterContent to the default gitignore are primarily that it will help prevent beginners (and even experienced users) from adding the StarterContent to their repositories, which they will almost never want to do.
The cons are that it's potentially overstepping what a "default" gitignore should do and might result in surprising behaviour if someone does modify the StarterContent (which they shouldn't do, but I'm not the UE4 police).

Personally, I think we should add it because it would save a lot of headaches.
Thoughts?