### PR TITLE
move vendor out of gitignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -26,5 +26,3 @@ _testmain.go
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# external packages folder
-vendor/


### PR DESCRIPTION
**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_

vendor folder was use to freeze third package depences of some version