### PR TITLE
Add missing beamer temporary file extension

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -52,6 +52,7 @@ acs-*.bib
 
 # beamer
 *.nav
+*.pre
 *.snm
 *.vrb
 


### PR DESCRIPTION
**Reasons for making this change:**

The `.pre` extension is missing 

**Links to documentation supporting these rule changes:** 

http://mirrors.ctan.org/macros/latex/contrib/beamer/doc/beameruserguide.pdf