### PR TITLE
Symfony: Fix rule for backed up entities

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -42,4 +42,4 @@
 /composer.phar
 
 # Backup entities generated with doctrine:generate:entities command
-*/Entity/*~
+**/Entity/*~


### PR DESCRIPTION
**Reasons for making this change:**

The current rule is not correct.

**Links to documentation supporting these rule changes:**

http://symfony.com/doc/current/doctrine.html#generating-getters-and-setters