### PR TITLE
TeX: ignore endnotes *.ent files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -59,6 +59,9 @@ acs-*.bib
 # cprotect
 *.cpt
 
+# endnotes
+*.ent
+
 # fixme
 *.lox
 


### PR DESCRIPTION
The `endnotes` package generates `*.ent` files. These should also be
ignored.