### PR TITLE
Ignore wheels directory.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -20,6 +20,7 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
 *.egg-info/
 .installed.cfg
 *.egg


### PR DESCRIPTION
**Reasons for making this change:**

As `eggs/` directory, `wheels/` directory may contain compiled wheels.

**Links to documentation supporting these rule changes:** 

http://pip.readthedocs.io/en/stable/user_guide/#installing-from-wheels
