### PR TITLE
Add macOS missing metadata and system files

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -1,22 +1,35 @@
 *.DS_Store
 .AppleDouble
 .LSOverride
+.metadata_never_index
 
 # Icon must end with two \r
 Icon
 
 
-# Thumbnails
+# Resource forks
 ._*
 
-# Files that might appear in the root of a volume
+# Files and directories that might appear in the root of a volume
 .DocumentRevisions-V100
 .fseventsd
+.dbfseventsd
 .Spotlight-V100
 .TemporaryItems
 .Trashes
 .VolumeIcon.icns
 .com.apple.timemachine.donotpresent
+.com.apple.timemachine.supported
+.PKInstallSandboxManager
+Desktop DB
+Desktop DF
+.file
+.hotfiles.btree
+.quota.ops.user
+.quota.user
+.quota.ops.group
+.quota.group
+.vol
 
 # Directories potentially created on remote AFP share
 .AppleDB
@@ -24,3 +37,10 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Sherlock files
+TheFindByContentFolder
+TheVolumeSettingsFolder
+.FBCIndex
+.FBCSemaphoreFile
+.FBCLockFolder


### PR DESCRIPTION
**Reasons for making this change:**

There is items missing

**Links to documentation supporting these rule changes:** 

- https://alexkaloostian.com/2015/01/22/what-are-all-these-hidden-items-on-my-mac-part-1/
- http://superuser.com/questions/180582/what-are-desktop-db-or-desktop-df-files-on-external-hd
- http://forum.mac4ever.com/pourquoi-t73534.html#p997828 (For `.PKInstallSandboxManager` used by Sandboxed Applications)
- http://netatalk.sourceforge.net/wiki/index.php/Special_Files_and_Folders