### PR TITLE
Add ehthumbs_vista.db as Windows thumbnail cache file

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -1,6 +1,7 @@
-# Windows image file caches
+# Windows thumbnail cache files
 Thumbs.db
 ehthumbs.db
+ehthumbs_vista.db
 
 # Folder config file
 Desktop.ini


### PR DESCRIPTION
**Reasons for making this change:**

Add the missing entry `ehthumbs_vista.db` used by Windows Vista Media Center to store thumbnails, like `ehthumbs.db`

**Links to documentation supporting these rule changes:** 

- https://nctritech.wordpress.com/tag/ehthumbs_vista-db/
- https://thumbsviewer.github.io/
- https://www.file-extensions.org/db-file-extension-windows-thumbnail-database