### PR TITLE
Standardize comment capitalization in go

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -26,5 +26,5 @@ _testmain.go
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# external packages folder
+# External packages folder
 vendor/


### PR DESCRIPTION
**Reasons for making this change:**
I noticed the `E` wasn't capitalized in `External` but all the other comments start with a capital letter.

**Links to documentation supporting these rule changes:** 
No new rules, just a single character change in a comment. I'm OCD.