### PR TITLE
Add zip and gzip extensions to Perl.gitignore

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -1,23 +1,34 @@
-/blib/
-/.build/
-_build/
-cover_db/
-inc/
-Build
 !Build/
-Build.bat
 .last_cover_stats
-/Makefile
-/Makefile.old
-/MANIFEST.bak
 /META.yml
 /META.json
 /MYMETA.*
-nytprof.out
-/pm_to_blib
 *.o
 *.bs
-/_eumm/
+
+# Devel::Cover
+cover_db/
+
+# Devel::NYTProf
+nytprof.out
+
+# Dizt::Zilla
+/.build/
+
+# Module::Build
+_build/
+Build
+Build.bat
+
+# Module::Install
+inc/
+
 # ExtUitls::MakeMaker
-/*.zip
+/blib/
+/_eumm/
 /*.gz
+/Makefile
+/Makefile.old
+/MANIFEST.bak
+/pm_to_blib
+/*.zip

--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -18,3 +18,6 @@ nytprof.out
 *.o
 *.bs
 /_eumm/
+# ExtUitls::MakeMaker
+/*.zip
+/*.gz


### PR DESCRIPTION
**Reasons for making this change:**

ExtUtils::MakeMaker based builds can generate .zip and .gz files

**Links to documentation supporting these rule changes:** 

http://perldoc.perl.org/ExtUtils/MakeMaker.html#Distribution-Support


