### PR TITLE
Existing .gitignore for vim incorrectly matched matched ".swq" through ".swz". 

### DIFF
--- a/Global/Vim.gitignore
+++ b/Global/Vim.gitignore
@@ -1,6 +1,8 @@
 # swap
-[._]*.s[a-w][a-z]
-[._]s[a-w][a-z]
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
 # session
 Session.vim
 # temporary


### PR DESCRIPTION
**Reasons for making this change:**

Existing .gitignore for vim is overzealous and incorrectly matched matched ".swq" through ".swz". 

**Links to documentation supporting these rule changes:** 
You can see the source code here and see that those file extensions can not be generated:

http://unix.stackexchange.com/questions/326707/vim-what-are-all-the-possible-swapfile-extensions