### PR TITLE
Added pattern for expex forward references

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -206,3 +206,6 @@ TSWLatexianTemp*
 
 # auto folder when using emacs and auctex 
 /auto/*
+
+# expex forward references with \gathertags
+*-tags.tex


### PR DESCRIPTION
**Reasons for making this change:**
Linguistic examples package `expex`, with the switch `\gathertags` on, writes forward references to <_mainFile_>`-tags.tex`. It's annoying, because this is a special case of `.tex` that needs to be ignored.

**Links to documentation supporting these rule changes:** 
[Expex documentation](http://mirror.aut.ac.nz/CTAN/macros/plain/contrib/expex/expex-doc.pdf), page 62


