### PR TITLE
[Node] make directory rules explicit

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -28,8 +28,8 @@ coverage
 build/Release
 
 # Dependency directories
-node_modules
-jspm_packages
+node_modules/
+jspm_packages/
 
 # Optional npm cache directory
 .npm


### PR DESCRIPTION
**Reasons for making this change:**

Make patterns more standardized for command line tool parsing

https://github.com/monochromegane/go-gitignore/blob/master/pattern.go#L18-L41

Some .gitignore parsers interpret directory vs non-directory patterns strictly (e.g. monochromegane/go-gitignore), so a `node_modules` pattern would not necessarily match against a real `node_modules` directory. It's generally safe to add a trailing slash to directory .gitignore patterns.