### PR TITLE
Update Xcode.gitignore to include macOS ignore

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -17,7 +17,36 @@ DerivedData/
 !default.perspectivev3
 xcuserdata/
 
+## For macOS
+
 ## Other
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
**Reasons for making this change:**

Xcode should include os specific ignore... you are not going to use Xcode without macOS

**Links to documentation supporting these rule changes:** 

https://github.com/github/gitignore/blob/master/Global/macOS.gitignore