### PR TITLE
ignore compile_commands.json

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -4,4 +4,5 @@ CMakeScripts
 Makefile
 cmake_install.cmake
 install_manifest.txt
+compile_commands.json
 CTestTestfile.cmake


### PR DESCRIPTION
**Reasons for making this change:**

CMake may generate `compile_commands.json` file with `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` Option

**Links to documentation supporting these rule changes:** 

https://cmake.org/cmake/help/v3.7/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html?highlight=cmake_export_compile_commands

