### PR TITLE
PureBasic

### DIFF
--- a/PureBasic.gitignore
+++ b/PureBasic.gitignore
@@ -1,0 +1,15 @@
+# PureBasic
+
+# Settings files
+*.pb.cfg
+*.pbi.cfg
+project.cfg
+
+# Shared libraries
+*.so
+*.dylib
+*.dll
+
+# Binary executables
+*.exe
+*.app


### PR DESCRIPTION
New .gitignore template for the PureBasic language and IDE.

**Reasons for making this change:**

Currently there is no .gitignore template for the PureBasic language.

**Official PureBasic documentation:** 

- http://www.purebasic.com/documentation/index.html

**PureBasic project’s homepage**:

- http://www.purebasic.com/