### PR TITLE
[TeX] delete Leading blanks

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -204,7 +204,7 @@ TSWLatexianTemp*
 # KBibTeX
 *~[0-9]*
 
-# auto folder when using emacs and auctex 
+# auto folder when using emacs and auctex
 /auto/*
 
 # expex forward references with \gathertags


### PR DESCRIPTION
**Reasons for making this change:**

Template of TeX includes a leading blank.
I think You had better delete it.