### PR TITLE
[Android.gitignore] Add .idea/gradle.xml

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -36,6 +36,7 @@ captures/
 *.iml
 .idea/workspace.xml
 .idea/tasks.xml
+.idea/gradle.xml
 .idea/libraries
 
 # Keystore files


### PR DESCRIPTION
**Reasons for making this change:**

gradle.xml may contain user-specific local Gradle location.

**Links to documentation supporting these rule changes:** 

Please refer to [the official guide](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems).
