### PR TITLE
Add ignoring rules what working on create new PyCharm project

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -4,6 +4,10 @@
 # User-specific stuff:
 .idea/workspace.xml
 .idea/tasks.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/vcs.xml
+.idea/misc.xml
 
 # Sensitive or high-churn files:
 .idea/dataSources/


### PR DESCRIPTION
**Reasons for making this change:**

I've add some ignoring rules what working on create new PyCharm project.

**Links to documentation supporting these rule changes:** 

Don't know

If this is a new template: 

 - **Link to application or project’s homepage**: [https://www.jetbrains.com/pycharm/](https://www.jetbrains.com/pycharm/)
