### PR TITLE
Update CommonLisp.gitignore

### DIFF
--- a/CommonLisp.gitignore
+++ b/CommonLisp.gitignore
@@ -1,3 +1,17 @@
 *.FASL
 *.fasl
 *.lisp-temp
+*.dfsl
+*.pfsl
+*.d64fsl
+*.p64fsl
+*.lx64fsl
+*.lx32fsl
+*.dx64fsl
+*.dx32fsl
+*.fx64fsl
+*.fx32fsl
+*.sx64fsl
+*.sx32fsl
+*.wx64fsl
+*.wx32fsl


### PR DESCRIPTION

**Reasons for making this change:**

For Clozure Common Lisp, the fast load file is not .fasl or .lisp-temp. It's platform specific. When I use it on Windows, it produce .wx32cl files. On other platforms the suffix is different.

**Links to documentation supporting these rule changes:** 
[ccl-doc](https://www.cs.utexas.edu/users/jared/Milawa/Support/ccl/doc/ccl-documentation.html#Platform-specific-filename-conventions)