### PR TITLE
Add .vscode/ directory to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -27,6 +27,10 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+
+# Visual Studio Code user/workspace Settings directory
+.vscode/
+                                
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
**Reasons for making this change:**

If one sets up his environment using VS Code on the same directory that he has a Visual Studio project, he will have a .vscode/ folder created for options/cache.

**Links to documentation supporting these rule changes:** 

https://code.visualstudio.com/Docs/customization/userandworkspace
