### PR TITLE
ignore gradle wrapper

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -10,5 +10,7 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
+# ignore gradle wrapper scripts & binary
+gradlew    
+gradlew.bat
+gradle/


### PR DESCRIPTION
**Reasons for making this change:**

I don't want to commit an external build tool in my project. 

**Links to documentation supporting these rule changes:** 

Gradle Wrapper files: https://docs.gradle.org/current/userguide/gradle_wrapper.html#using_wrapper_scripts

Gradle Wrapper can be ignored completely, however, to ensure that the correct Gradle version is used to build a project, Gradle version can be set in ``build.gradle`` file.
http://stackoverflow.com/a/28473686

For Android Studio, Gradle version is set in ``build.gradle`` by default
https://developer.android.com/studio/releases/gradle-plugin.html
