### PR TITLE
[TeX] Add .spl and .soc

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -56,8 +56,14 @@ acs-*.bib
 *.snm
 *.vrb
 
+# changes
+*.soc
+
 # cprotect
 *.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
 
 # endnotes
 *.ent


### PR DESCRIPTION
**Reasons for making this change:**

`.soc` and `.spl` were missing for TeX

- .soc - package [changes](https://www.ctan.org/pkg/changes)
- .spl - documentclass [elsarticle](https://www.ctan.org/pkg/elsarticle) (Elsevier journals)

**Links to documentation supporting these rule changes:** 

http://tex.stackexchange.com/a/256803/9075

