### PR TITLE
Create MikroC.gitignore

### DIFF
--- a/MikroC.gitignore
+++ b/MikroC.gitignore
@@ -1,0 +1,25 @@
+# Backup
+*.pdsbak
+
+# Debug
+Debug
+
+# Generated files
+*.workspace
+*.log
+*.bmk
+*.brk
+*.cfg
+*.dbg
+*.dct
+*.dlt
+*.hex
+*.lst
+*.dic
+*_callertable.txt
+*.user.dic
+*.asm
+*.c.ini
+*.h.ini
+*.cp
+*.mcl


### PR DESCRIPTION
**Reasons for making this change:**

I would like to add a MikroC.gitignore file.

**Links to documentation supporting these rule changes:** 

I did not do any changes, I only added based on my own projects.

**If this is a new template:**

 - **mikroC**:  http://www.mikroe.com/mikroc
