### PR TITLE
SublimeText: ignore new Package Control certs

### DIFF
--- a/Global/SublimeText.gitignore
+++ b/Global/SublimeText.gitignore
@@ -20,6 +20,9 @@ Package Control.ca-bundle
 Package Control.system-ca-bundle
 Package Control.cache/
 Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
 bh_unicode_properties.cache
 
 # Sublime-github package stores a github token in this file


### PR DESCRIPTION
**Reasons for making this change:**

Sublime Text's Package Control now has a number of bundles for certificates instead
of the old directory. This ignores them as per comments from Package Control's author.

**Links to documentation supporting these rule changes:** 

http://github.com/wbond/package_control/issues/1153
https://forum.sublimetext.com/t/generating-oscrypto-ca-bundle-crt-after-mac-os-install-and-security/23020
