### PR TITLE
[Android] feat: Ignore VSCode Eclipse JDT files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -47,3 +47,9 @@ captures/
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json
+
+# Visual Studio Code
+.classpath
+.project
+.settings
+javac-services.*


### PR DESCRIPTION
**Reasons for making this change:**

VSCode Java IntelliSense creates some files unrelated to Android
application and should not be added to project history.

Java language on [Visual Studio Code](https://code.visualstudio.com/) is supported via [java-language-server](https://github.com/gorkem/java-language-server),
which internally utilizes [Eclipse JDT](http://www.eclipse.org/jdt/).

**Links to documentation supporting these rule changes:** 
  - [Visual Studio Code](https://code.visualstudio.com/)
  - [Language Support for Java(TM) by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java)
  - [Java Language Server](https://github.com/gorkem/java-language-server)
  - [Eclipse JDT](http://www.eclipse.org/jdt/)
