### PR TITLE
[TeX] Add *.pax

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -142,6 +142,9 @@ _minted*
 # nomencl
 *.nlo
 
+# pax
+*.pax
+
 # sagetex
 *.sagetex.sage
 *.sagetex.py


### PR DESCRIPTION
**Reasons for making this change:**

[pax](http://dante.ctan.org/tex-archive/help/Catalogue/entries/pax.html) generates `*.pax` files. E.g., `paper.pax` when running `pdfannotextractor.pl paper`

**Links to documentation supporting these rule changes:** 

http://ftp.uni-erlangen.de/ctan/macros/latex/contrib/pax/README:

> It generates usrguide.pax.

EOL is added by the GitHub UI.
