### PR TITLE
VisualStudio: Don't ignore project filters

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -8,7 +8,6 @@
 *.user
 *.userosscache
 *.sln.docstates
-*.vcxproj.filters
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
**Reasons for making this change:**

These filters provide structure to the project tree and are thus important to make sure every team member see the same structure. This is not necessarily a user-specific file unless the team decides that they want to manage the filters per-user.

**Links to documentation supporting these rule changes:** 

http://stackoverflow.com/questions/1826901/should-i-add-vcxproj-filter-files-to-source-control
