### PR TITLE
Add ignoring PyCharm IDE project settings directory to Python.gitigno…

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -89,3 +89,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm project settings
+.idea


### PR DESCRIPTION
Add ignoring PyCharm IDE project settings directory to Python.gitignore file.

**Reasons for making this change:**

PyCharm IDE creates own project settings directory. Ignoring it is a good practice