### PR TITLE
Add debugging files to the gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -18,6 +18,7 @@ ExportedObj/
 *.pidb
 *.booproj
 *.svd
+*.pdb
 
 
 # Unity3D generated meta files


### PR DESCRIPTION
**Reasons for making this change:**

`.pdb` files are created by Visual Studio in the root directory solely for Windows debugging. These files cannot be used in other supported IDEs and are therefore not needed.

**Links to documentation supporting these rule changes:** 

https://docs.unity3d.com/Manual/WindowsDebugging.html