### PR TITLE
Corrected ignore settings for Cake

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -271,4 +271,5 @@ __pycache__/
 *.pyc
 
 # Cake - Uncomment if you are using it
-# tools/
+# tools/**
+# !tools/packages.config


### PR DESCRIPTION
- It is recommended to include the packages.config file when using Cake
- This ensures that the Cake version that is being used is *pinned* and updated only when the user decides

