### PR TITLE
cmake: add Testing/ directory created by ctest

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -1,6 +1,7 @@
 CMakeCache.txt
 CMakeFiles
 CMakeScripts
+Testing
 Makefile
 cmake_install.cmake
 install_manifest.txt


### PR DESCRIPTION
Ignore logs and other junk generated by cmake's `ctest` command in `Testing/`