### PR TITLE
Fixed/Added ignore rules

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -13,7 +13,8 @@ _autosave-*
 *.net
 
 # Autorouter files (exported from Pcbnew)
-.dsn
+*.dsn
+*.ses
 
 # Exported BOM files
 *.xml


### PR DESCRIPTION
**Reasons for making this change:**

- *.ses files are generated by Freerouting (which is the partially integrated autorouter)
- *.dsn files weren't actually being ignored

**Links to documentation supporting these rule changes:** 

http://kicad-pcb.org/help/file-formats/
