### PR TITLE
Add Google Services

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -44,3 +44,6 @@ captures/
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json


### PR DESCRIPTION
**Reasons for making this change:**

Many [Android](https://www.android.com/) apps use Google Services like the Google APIs or [Firebase](https://firebase.google.com/). The file google-services.json contains unique and personal information which should be kept secret. 

**Links to documentation supporting these rule changes:** 

https://developers.google.com/android/guides/google-services-plugin
https://github.com/googlesamples/google-services/blob/master/.gitignore

