### PR TITLE
Add freeline rules

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -47,3 +47,8 @@ captures/
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json
+
+#Freeline
+freeline.py
+freeline/
+freeline_project_description.json


### PR DESCRIPTION
Freeline is a super fast build tool for Android, an alternative to Instant Run. Many Android projects use it to improve development efficiency. When it was initiated, it will produce some files: 
- `freeline.py` file. A python script to execute project build.
- `freeline/` folder. The implement of freeline.
- `freeline_project_description.json` The freeline description of the project.

All these files only use for developer to improve development efficiency, and should not be commit to VCS.

Freeline project: https://github.com/alibaba/freeline/
