### PR TITLE
VisualStudio - Add VS Code folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -24,6 +24,9 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+# Visual Studio Code
+.vscode/
+
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot


### PR DESCRIPTION
**Reasons for making this change:**

Includes VS Code folder in ignored files


If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_

[VS Code site ](https://code.visualstudio.com/?wt.mc_id=DX_841432&utm_source=vscom&utm_medium=ms%20web&utm_campaign=VSCOM%20Home)
