### PR TITLE
Updating VisualStudio.gitignore to ignore thumbs.db

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -201,6 +201,7 @@ ClientBin/
 *.publishsettings
 node_modules/
 orleans.codegen.cs
+thumbs.db
 
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)


### PR DESCRIPTION
**Reasons for making this change:**
The thumbs.db file is added by Windows when adding images. This file is used to quickly show thumbnails when browsing in Windows and is not needed by source control.

**Links to documentation supporting these rule changes:** 
[https://en.wikipedia.org/wiki/Windows_thumbnail_cache](https://en.wikipedia.org/wiki/Windows_thumbnail_cache)
