### PR TITLE
Ignore project-local Glide cache

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -28,3 +28,6 @@ _testmain.go
 
 # External packages folder
 vendor/
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/


### PR DESCRIPTION
**Reasons for making this change:**

If `$GLIDE_HOME` is not set, it will default to either `$HOME/.glide` or `./glide` depending on whether [@Masterminds/#736](https://github.com/Masterminds/glide/issues/736) has been applied. 

**Links to documentation supporting these rule changes:** 

[@Masterminds/#736](https://github.com/Masterminds/glide/issues/736)
