### PR TITLE
Create IntellijScala.gitignore

### DIFF
--- a/IntellijScala.gitignore
+++ b/IntellijScala.gitignore
@@ -1,0 +1,18 @@
+target
+*.class
+*.iml
+*.ipr
+.idea
+!.idea/workspace.xml
+
+# File-based project format:
+*.iws
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# IntelliJ
+/out/
+
+# JIRA plugin
+atlassian-ide-plugin.xml


### PR DESCRIPTION
.gitignore file for scala projects on IntelliJ IDEA

**Reasons for making this change:**

To make this template default on our company. Current Scala.gitignore template does not fit to Intellij projects.


If this is a new template: 

 - **Link to application or project’s homepage**: https://github.com/fatihcataltepe/gitignore
