### PR TITLE
Updating Swift.gitignore with Package.pins

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -35,6 +35,7 @@ playground.xcworkspace
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
+# Package.pins
 .build/
 
 # CocoaPods


### PR DESCRIPTION
**Reasons for making this change:**

As they say in SwiftPM documentation: 

> Since package pin information is not inherited across dependencies, our recommendation is that packages which are primarily intended to be consumed by other developers either disable automatic pinning or put the Package.pins file into .gitignore, so that users are not confused why they get different versions of dependencies that are those being used by the library authors while they develop.

`Package.pins` is a new file that will be added in Swift 3.1 release, but is already available for those that uses Swift snapshots.

**Links to documentation supporting these rule changes:** 

- https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#package-pinning
