### PR TITLE
[Python] add .venv as file

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -80,10 +80,9 @@ celerybeat-schedule
 .env
 
 # virtualenv
-.venv/
+.venv
 venv/
 ENV/
-.venv
 
 # Spyder project settings
 .spyderproject

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -83,6 +83,7 @@ celerybeat-schedule
 .venv/
 venv/
 ENV/
+.venv
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
**Reasons for making this change:**

I use virtualenvwrapper with auto loading of python environment after changing directory containing `.venv`.

**Links to documentation supporting these rule changes:** 

https://virtualenvwrapper.readthedocs.io/en/latest/tips.html?highlight=venv#automatically-run-workon-when-entering-a-directory

[Oh-My-ZSH's plugin for virtualenvwrapper](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh#L33-L35) uses this file, too.