### PR TITLE
Add .env to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -46,3 +46,6 @@ jspm_packages
 # Yarn Integrity file
 .yarn-integrity
 
+# dotenv environment variables file
+.env
+


### PR DESCRIPTION
[dotenv](https://github.com/motdotla/dotenv) is sufficiently popular in the Node world (over 1200 dependents in the npm registry, over 2400 stars on GitHub), along with other tools that can utilize `.env` files like node-foreman, to make this a valuable, security-focused convenience. As a precedent, `.env` is already included in the Python, Ruby/Rails and Laravel `.gitignore` files.