### PR TITLE
Create Nwjs

### DIFF
--- a/Nwjs.
+++ b/Nwjs.
@@ -1,0 +1,33 @@
+# NW.js (node-webkit) binary files to be excluded from git
+# https://nwjs.io/
+# https://github.com/nwjs/nw.js
+
+
+## Seen in standard and sdk versions
+credits.html
+locales/
+libEGL.dll
+libGLEv2.dll
+node.dll
+nw.dll
+nw.exe
+natives_blob.bin
+nw_100_percent.pak
+nw_200_percent.pak
+nw_elf.dll
+snapshot_blob.bin
+resources.pak
+
+
+## Seen only in standard
+d3dcompiler_47.dll
+ffmpeg.dll
+icudtl.dat
+
+
+## Seen only in sdk
+pnacl/
+chromedriver.exe
+nacl_irt_x86_64.nexe
+nwjc.exe
+payload.exe


### PR DESCRIPTION
**Reasons for making this change:**
This is becoming a hugely popular project, and I've benefited from this .gitignore many times. Nwjs is a cross-platform application framework using Chromium to display web-apps, and Node.js for back-end processing. Similar to Phonegap/Apache Cordova but for Windows/Linux/Mac desktops.

**Links to documentation supporting these rule changes:**
https://nwjs.io/

**Link to application or project’s homepage:**
https://github.com/nwjs/nw.js