### PR TITLE
[Go] Update ignore patterns.

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -1,5 +1,7 @@
-# Binary on Windows
+# Binaries for programs and plugins
 *.exe
+*.dll
+*.so
 
 # Test binary, build with `go test -c`
 *.test

--- a/Go.gitignore
+++ b/Go.gitignore
@@ -2,6 +2,7 @@
 *.exe
 *.dll
 *.so
+*.dylib
 
 # Test binary, build with `go test -c`
 *.test

--- a/Go.gitignore
+++ b/Go.gitignore
@@ -1,33 +1,11 @@
-# Compiled Object files, Static and Dynamic libs (Shared Objects)
-*.o
-*.a
-*.so
-
-# Folders
-_obj
-_test
-
-# Architecture specific extensions/prefixes
-*.[568vq]
-[568vq].out
-
-*.cgo1.go
-*.cgo2.c
-_cgo_defun.c
-_cgo_gotypes.go
-_cgo_export.*
-
-_testmain.go
-
+# Binary on Windows
 *.exe
+
+# Test binary, build with `go test -c`
 *.test
-*.prof
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# External packages folder
-vendor/
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/


### PR DESCRIPTION
### Remove old patterns for legacy Go versions (pre 1.0, when `Makefile`s were used instead of `go` command).

It hurts me to see those remnants over and over again.

### Remove `vendor/`.

To quote https://blog.gopheracademy.com/advent-2015/vendor-folder/:

> Advice on how to use the vendor folder is varied. Some will shutter at the thought of including dependencies in the project repository. Others hold it is unthinkable to _not_ include the dependencies in the project repository. Some will just want to include a manifest or lock file and fetch the dependencies before building.

Go doesn't have widely used `gem` and rubygems.org equivalent yet. Instead, [several third-party tools are used](https://github.com/golang/go/wiki/PackageManagementTools), which fetch dependencies from Github and other places, and lock versions to particular commit hashes. `go` tool is then used to build programs. `go` is aware of `vendor/` directory, but knows nothing about lock files, commit hashes, etc. If `vendor/` is not included in the repository, then `go get` will download sources – but it will be the latest commit for each import path (more or less is equivalent of repository URL), not specified commits from lock file. In you are lucky, and all package authors do care about backward compatibility (but that's not true in general – many packages are broken regularly), it may work. If you are less lucky, you will get a broken build. In the worst case, your code will explode in runtime, not during compilation. Therefore, I'm strongly _for_ inclusion of `vendor/`. I think the majority of the community thinks the same way.

Even people who disagree with this opinion would agree that omitting `vendor/` should be opt-in, not opt-out.

Related pull requests:
https://github.com/github/gitignore/pull/2198 (closed as duplicate).
https://github.com/github/gitignore/pull/2183 (closed due to conflicts).