### PR TITLE
exclude .vscode folder from VisualStuido.ignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -29,6 +29,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio Code setting folder
+.vscode/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
**Reasons for making this change:**

.vscode folder should only be committed when user want to share setting with team or others.

**Links to documentation supporting these rule changes:** 

[https://code.visualstudio.com/Docs/customization/userandworkspace](https://code.visualstudio.com/Docs/customization/userandworkspace)

[http://stackoverflow.com/questions/32964920/should-i-commit-the-vscode-folder-to-source-control](http://stackoverflow.com/questions/32964920/should-i-commit-the-vscode-folder-to-source-control)

If this is a new template:  No.

 - **Link to application or project’s homepage**: 

[Visual Studio Code](https://code.visualstudio.com/)
