### PR TITLE
[Maven] ignore files for common IDEs

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -1,3 +1,4 @@
+# Ignores for Maven and common Maven plugins
 target/
 pom.xml.tag
 pom.xml.releaseBackup
@@ -7,6 +8,22 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+
+# Ignores for common IDEs used with Maven
+
+## Eclipse (https://eclipse.org/)
+.settings/
+.project
+.classpath
+
+## NetBeans (https://netbeans.org/)
+nbproject/
+nbactions.xml
+nb-configuration.xml
+
+## IntelliJ IDEA (https://www.jetbrains.com/idea/)
+.idea
+*.iml
 
 # Exclude maven wrapper
 !/.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
**Reasons for making this change:**

This change updates the existing Maven.gitignore ruleset. (previous PR #2076 requesting a new separate ignore ruleset was rejected)

This change saves user time and effort by adding IDE-related rules for the existing Maven ruleset, for commonly used IDEs. It also protects user privacy because IDE configuration could contain sensitive user information pertaining to the project, and that should not be committed and pushed to GitHub.

**Links to documentation supporting these rule changes:** 

N/A
