### PR TITLE
Ignoring more generated file for Java project

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -18,6 +18,9 @@
 *.jar
 *.war
 *.ear
+*.zip
+*.tar.gz
+*.rar
 
 # Vagrant
 .vagrant

--- a/Java.gitignore
+++ b/Java.gitignore
@@ -1,5 +1,13 @@
 *.class
 
+# Eclipse editor
+.classpath
+.project
+.settings/
+
+# Log file
+.log
+
 # BlueJ files
 *.ctxt
 
@@ -10,6 +18,9 @@
 *.jar
 *.war
 *.ear
+
+# Vagrant
+.vagrant
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*


### PR DESCRIPTION
**Reasons for making this change:**

- Adding generated Eclipse project to ignore
- Adding log file, zip, tar.gz, rar to ignore
- Adding generated vagrant file to ignore
