### PR TITLE
Update scala.gitignore add intellij

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -21,3 +21,6 @@ project/plugins/project/
 # ENSIME specific
 .ensime_cache/
 .ensime
+
+# intellij specific
+.idea


### PR DESCRIPTION
Add intellij. It seems to be more popular than scala-ide.

**Reasons for making this change:**

Add a usefull .gitignore entry.

**Links to documentation supporting these rule changes:** 

As in https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore