### PR TITLE
Added PyCharm Settings to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -89,3 +89,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm or IntelliJ IDEA project settings
+.idea


### PR DESCRIPTION
**Reasons for making this change:**

[PyCharm](https://www.jetbrains.com/pycharm/) is an IDE for writing Python software, developed by JetBrains. It has the annoying habit of creating a directory called `.idea` in the root folder of the project, where it stores its project settings. I believe this directory should not be included in in a repo, and have added it to all my personal .gitignore files.

**Links to documentation supporting these rule changes:** [PyCharm project settings documentation](https://www.jetbrains.com/help/pycharm/2016.3/project-and-ide-settings.html).

**Link to application or project’s homepage**: https://www.jetbrains.com/pycharm/