### PR TITLE
Adding a rule for ignoring the target directory from the build

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -19,3 +19,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Build directory
+target/


### PR DESCRIPTION
**Reasons for making this change:**

I think adding an ignore for the target directory produced by the build would be very useful for others, just like I find it useful myself.
