### PR TITLE
fix(Node): ignore yarn logs

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -2,6 +2,8 @@
 logs
 *.log
 npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 
 # Runtime data
 pids


### PR DESCRIPTION
This adds ignores for the `yarn-debug.log*` and `yarn-error.log*` files sometimes produced by the [Yarn package manager](https://yarnpkg.com).

**Reasons for making this change:**

Yarn, similar to npm, has log files that should be ignored.

**Links to documentation supporting these rule changes:** 

Didn't find documentation, but here is code in Yarn that creates `yarn-error.log`:
* https://github.com/yarnpkg/yarn/blob/e2f4a3cf1b3cc863f078b68cf4f9195d0ebe423e/src/cli/index.js#L364

And here are some issues and PRs as evidence:
* https://github.com/yarnpkg/yarn/issues/1600
* https://github.com/yarnpkg/yarn/issues/1460
* https://github.com/yarnpkg/yarn/pull/2095

For `yarn-debug.log`, here's an issue comment as evidence:
* https://github.com/chentsulin/electron-react-boilerplate/issues/655#issuecomment-271772311

As well as other projects I've found that ignore it:
* https://github.com/thebigredgeek/microlock/blob/a1c3279e63ddbb32713572c1461162309aec319c/.gitignore#L5
* https://github.com/calebmer/graphql-strong/blob/d0357619cc7eb43bb199616a780543eae145c799/.gitignore#L4
