### PR TITLE
updated link to fastlane docs

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -45,10 +45,10 @@ Carthage/Build
 
 # fastlane
 #
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
-# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
 
 fastlane/report.xml
 fastlane/Preview.html

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -59,7 +59,7 @@ Carthage/Build
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
-# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
 
 fastlane/report.xml
 fastlane/Preview.html


### PR DESCRIPTION
Supersedes #2094 

**Reasons for making this change:**

The URL has moved.

**Links to documentation supporting these rule changes:** 

https://docs.fastlane.tools/best-practices/source-control/#source-control