### PR TITLE
Update TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -134,6 +134,9 @@ acs-*.bib
 *.mlf
 *.mlt
 *.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
 
 # minted
 _minted*


### PR DESCRIPTION
When running latex and using [minitoc](https://www.ctan.org/pkg/minitoc), it also generates .stc, .slf, and .slt files.

**Links to documentation supporting these rule changes:** See manual page 29: http://texdoc.net/texmf-dist/doc/latex/minitoc/minitoc.pdf

![grafik](https://cloud.githubusercontent.com/assets/1366654/23016789/19a708d6-f438-11e6-8488-1b3d282c5249.png)