### PR TITLE
[SBT] Add some excludes kept in Scala.gitignore .

### DIFF
--- a/Global/SBT.gitignore
+++ b/Global/SBT.gitignore
@@ -1,9 +1,12 @@
 # Simple Build Tool
 # http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
 
+dist/*
 target/
 lib_managed/
 src_managed/
 project/boot/
+project/plugins/project/
 .history
 .cache
+.lib/


### PR DESCRIPTION
Scala.gitignore currently has more entries for SBT than SBT.gitignore itself.
Copy missing entries to SBT.gitignore.

Cleanup Scala.gitignore: https://github.com/github/gitignore/pull/2289