### PR TITLE
[Eclipse] Add excludes kept in Scala.gitignore .

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -52,3 +52,5 @@ local.properties
 
 # Scala IDE specific (Scala & Java development for Eclipse)
 .cache-main
+.scala_dependencies
+.worksheet


### PR DESCRIPTION
Scala.gitignore currently has more entries for Eclipse than Eclipse.gitignore
itself. Copy missing entries to Eclipse.gitignore .

Cleanup Scala.gitignore: https://github.com/github/gitignore/pull/2289