### PR TITLE
[Scala] remove external tools excludes.

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -1,23 +1,2 @@
 *.class
 *.log
-
-# sbt specific
-.cache
-.history
-.lib/
-dist/*
-target/
-lib_managed/
-src_managed/
-project/boot/
-project/plugins/project/
-
-# Scala-IDE specific
-.ensime
-.ensime_cache/
-.scala_dependencies
-.worksheet
-
-# ENSIME specific
-.ensime_cache/
-.ensime


### PR DESCRIPTION
Remove excludes for SBT, Eclipse and ENSIME. They'll be added to appropriate
Global/ gitignore files:

Excludes moved to SBT: https://github.com/github/gitignore/pull/2287
Excludes moved to Eclipse: https://github.com/github/gitignore/pull/2288

ENSIME.gitignore has already all excludes.