### PR TITLE
Ignore dictionaries to reflect docs

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -37,6 +37,7 @@ captures/
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml
+.idea/dictionaries
 .idea/libraries
 
 # Keystore files

--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -4,6 +4,7 @@
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml
+.idea/dictionaries
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/


### PR DESCRIPTION
The official docs have been updated regarding this.
https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

Dictionaries are saved under `.\dictionaries\username.xml` and should thus be ignored.