### PR TITLE
[Python Gitignore] Ignore Sage's parsed files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -76,7 +76,7 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
-#Sage parsed files
+# SageMath parsed files
 *.sage.py
 
 # dotenv

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -76,6 +76,9 @@ target/
 # celery beat schedule file
 celerybeat-schedule
 
+#Sage parsed files
+*.sage.py
+
 # dotenv
 .env
 


### PR DESCRIPTION
Ignore Sage's parsed files (*.sage.py) that are left after running a .Sage program.

**Reasons for making this change:**

- [Sage](https://www.sagemath.org/) (or SageMath) is a popular mathematics software built atop Python. 
- Sage uses .sage files that it translates into .sage.py files to run.  Essentially these .sage.py are rather irrelevant as one wouldn't want to save them in most cases.
- I suggest this edit to the Python .gitignore, seeing as it would be an overkill to add a whole new template for just for Sage (seeing as Sage is essentially an extension Python).

**Links**
[Sage Official Page](https://www.sagemath.org/)
[Wikipedia on Sage](https://en.wikipedia.org/wiki/SageMath)
[Explanation of Sage extensions](https://doc.sagemath.org/html/en/tutorial/programming.html)
