### PR TITLE
Added /project/project to PlayFramework.gitignore

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -5,6 +5,7 @@ bin/
 /lib/
 /logs/
 /modules
+/project/project
 /project/target
 /target
 tmp/


### PR DESCRIPTION
**Reasons for making this change:**

Play generates build files into /project/project, it's recommended to add this directory to the .gitignore

**Links to documentation supporting these rule changes:** 

https://www.playframework.com/documentation/2.5.x/Anatomy

If this is a new template: No

 - **Link to application or project’s homepage**: https://www.playframework.com/
