### PR TITLE
ignore IML files again

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,6 +1,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# IML
+*.iml
+
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml


### PR DESCRIPTION
IML Files are not crossplatform safe and should be excluded per Jetbrains. From a support request that I had with them. I've also had issues with paths in these file being OS Specific (meaning the windows path is different from the OS X and Linux). IML files are not currently intended to be committed.



> Please vote for this issue in our tracker: https://youtrack.jetbrains.com/issue/IDEA-150283
In IDEA 2016.3 version there has been related fixes to this problem: https://youtrack.jetbrains.com/issue/IDEA-161632 You could try if it works better for you using the latest version from https://confluence.jetbrains.com/display/IDEADEV/IDEA+2016.3+EAP
Also, please note that if you are using Maven to manage project structure and dependencies it is not required to version module .iml file because they are regenerated by IDEA when you synchronize project settings with Maven by re-importing the Maven project.

Also from that conversation is  suggestion allowing easier reimport

> Why can't the system just say "iml files missing, detected maven project, reimport?"
>>We have created an enhancement for this, please vote for this request in our tracker: https://youtrack.jetbrains.com/issue/IDEA-164299 . Thank you for your feedback.