### PR TITLE
Add ATS.gitignore

### DIFF
--- a/ATS.gitignore
+++ b/ATS.gitignore
@@ -1,0 +1,7 @@
+# Compiled C Files
+*~
+*_?ats.c
+*_?ats.o
+
+# Compiled Javascript Files
+*_?ats.js


### PR DESCRIPTION
This change will allow anyone working on a project in the ATS programming language to easily add a gitignore in when creating their repository.