### PR TITLE
Prevent unintended folders from being ignored

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -2,10 +2,6 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-# Icon
-
-
 # Thumbnails
 ._*
 

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -3,7 +3,7 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+# Icon
 
 
 # Thumbnails


### PR DESCRIPTION
**Reasons for making this change:**

I'm not sure of the best way to fix this (would rather flag it as an issue than suggest this solution get merged), but keeping this in causes any folder in a any project with the name "Icon" to be ignored. I use GitHub for Mac and couldn't figure out why any folder I named "icon" (for front-end assets on a web app) kept disappearing from my code editor (Atom). It's because of this line.

Looking at the history, I understand it was added to prevent custom Finder icons from being included, but is there a way to make this exclusion less general?

Sorry if this is the wrong place – please point me towards where I should raise this as an issue.