### PR TITLE
D: Ignore generated test files

### DIFF
--- a/D.gitignore
+++ b/D.gitignore
@@ -20,5 +20,8 @@ docs.json
 __dummy.html
 docs/
 
+# Ignored test executable created by DUB
+/*-test-*
+
 # Code coverage
 *.lst


### PR DESCRIPTION
**Reasons for making this change:**

DUB (D's default package manager) generated test executables should be ignored by default.

**Links to documentation supporting these rule changes:** 

https://github.com/dlang/dub/pull/1029
https://github.com/dlang/dub/blob/0e45525f85838a53c47f824edbd06af43ef8c2f2/source/dub/dub.d#L513

CC @s-ludwig @MartinNowak 