### PR TITLE
Added Telerik's JustMock configruation files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -276,3 +276,6 @@ __pycache__/
 # Cake - Uncomment if you are using it
 # tools/**
 # !tools/packages.config
+
+# Telerik's JustMock configuration file
+*.jmconfig


### PR DESCRIPTION
When Telerik's JustMock add-on is used in Visual Studio it generates a .jmconfig file to maintain the JustMock upgrade information.

http://stackoverflow.com/questions/32696176/what-is-creating-these-files-with-a-jmconfig-extension

