### PR TITLE
Add clean gitignore

### DIFF
--- a/clean.gitignore
+++ b/clean.gitignore
@@ -1,0 +1,11 @@
+# Binaries
+*.exe
+*.out
+
+# Directory used to store object files, abc files and assembly files
+Clean System Files/
+
+# iTasks environment extra data
+*-data/
+*-www/
+sapl/

--- a/clean.gitignore
+++ b/clean.gitignore
@@ -2,10 +2,20 @@
 *.exe
 *.out
 
+# Generated ABC Bytecode
+*.bc
+*.pbc
+
+# Project files and IDE settings
+*.prj
+*.prp
+
 # Directory used to store object files, abc files and assembly files
 Clean System Files/
 
 # iTasks environment extra data
 *-data/
 *-www/
-sapl/
+
+# Deprecated
+*-sapl/


### PR DESCRIPTION
This replaces PR #1665, I messed up the repo and this combines the original `clean.gitignore` and adds the new webresource folder produced by the iTasks system.

**Reasons for making this change:**
`*.exe` are the executables produced on Windows.
`*.out` are the executables produced on Unix like systems.
`*.prj` are the project files generated by the clean project manager (cpm). 
`*.prp` are the IDE settings generated by the IDE on Windows.
`Clean System Files` is the directory containing the intermediate compiler files. (object, assembly, abc)
`*-data` is the directory created by the iTasks system storing the Shared Data Sources (SDS).
`*-www` is the directory created by the iTasks system storing the web resources that are collected from the libraries.
`*-sapl` is the directory created by the iTasks system storing the sapl resources, this has been deprecated very recently in favour of bytecode generation.
`*.bc` is the the linked bytecode
`*.pbc` is the prelinked bytecode

**Links to documentation supporting these rule changes:**
`*-www` https://gitlab.science.ru.nl/clean-and-itasks/iTasks-SDK/blob/master/Tools/WebResourceCollector.icl#L60
`*.bc, *.pbc` https://gitlab.science.ru.nl/clean-and-itasks/iTasks-SDK/merge_requests?scope=all&utf8=%E2%9C%93&state=merged

**Link to application or project’s homepage**
- Clean homepage: http://clean.cs.ru.nl/Clean
- iTasks framework homepage: http://clean.cs.ru.nl/ITasks

