### PR TITLE
Added BizTalk build output files to ignore list

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -279,3 +279,9 @@ __pycache__/
 
 # Telerik's JustMock configuration file
 *.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs


### PR DESCRIPTION
**Reasons for making this change:**

When compiling BizTalk projects a compiled version of every BizTalk artifact is generated. These should not be version controlled.