### PR TITLE
Added .vscode and tags for VSCode projects

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -93,8 +93,5 @@ ENV/
 # Visual Studio Code project settings
 .vscode
 
-#ctags tags file (common in Visual Studio Code Python projects)
-tags
-
 # Rope project settings
 .ropeproject

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -90,5 +90,11 @@ ENV/
 # Spyder project settings
 .spyderproject
 
+# Visual Studio Code project settings
+.vscode
+
+#ctags tags file (common in Visual Studio Code Python projects)
+tags
+
 # Rope project settings
 .ropeproject


### PR DESCRIPTION
Visual Studio Code creates a .vscode folder to hold project settings, much like .spyderproject for Spyder. Since this is relevant for basically anyone developing Python projects in Visual Studio Code, I think this is a good edition.

Cheers,
Shay

**Reasons for making this change:**

I now manually insert this common ignore rule into any .gitignore file manually, everytime I start a new project, and I guess so does everyone else writing Python with Visual Studio Code.

**Links to documentation supporting these rule changes:** 

Visual Studio Code documentation mentioning the .vscode folder:
https://code.visualstudio.com/Docs/customization/userandworkspace
