### PR TITLE
[VisualStudio] ASP.NET Core - bower - default config

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -205,6 +205,9 @@ orleans.codegen.cs
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
 #bower_components/
 
+# VS15: by default bower location is moved, bower restore is true
+**/wwwroot/lib/
+
 # RIA/Silverlight projects
 Generated_Code/
 

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -204,8 +204,7 @@ orleans.codegen.cs
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
 #bower_components/
-
-# VS15: by default bower location is moved, bower restore is true
+# ASP.NET Core default setup: bower directory is configured as wwwroot/lib/ and bower restore is true
 **/wwwroot/lib/
 
 # RIA/Silverlight projects


### PR DESCRIPTION
In VS15 (2017) the default .bowerrc repoints the default location to wwwroot/lib, and bower package restore is ON.

**Reasons for making this change:**

VS default flow is bower package restore to wwwroot/lib.

**Links to documentation supporting these rule changes:** 

None that I could find, TBH.
