### PR TITLE
.gitignore for OpenFrameworks.cc

### DIFF
--- a/OpenFrameworks.gitignore
+++ b/OpenFrameworks.gitignore
@@ -1,26 +1,22 @@
 # openFrameworks
-
-[Bb]in/*  
-![Bb]in/data/  
-[Bb]uild/  
-[Oo]bj/  
-*.o  
-[Dd]ebug*/  
-[Rr]elease*/  
-*.mode*  
-*.app/  
-*.pyc  
-*.log  
+[Bb]in/*
+![Bb]in/data/
+[Bb]uild/
+[Oo]bj/
+*.o
+[Dd]ebug*/
+[Rr]elease*/
+*.mode*
+*.app/
+*.pyc
+*.log
 
 # Code::Blocks
-
 *.depend  
 *.layout  
 
-# Windows
-
-# Windows image file caches  
-Thumbs.db  
+# (Windows-Specific) Windows image file caches  
+Thumbs.db
 
 # Folder config file  
 Desktop.ini

--- a/OpenFrameworks.gitignore
+++ b/OpenFrameworks.gitignore
@@ -1,6 +1,11 @@
-# openFrameworks
-[Bb]in/*
-![Bb]in/data/
+# ignore generated binaries
+# but not the data folder
+
+/bin/*
+!/bin/data/
+
+# general
+
 [Bb]uild/
 [Oo]bj/
 *.o
@@ -9,14 +14,60 @@
 *.mode*
 *.app/
 *.pyc
+.svn/
 *.log
 
+# IDE files which should
+# be ignored
+
+# XCode
+*.pbxuser
+*.perspective
+*.perspectivev3
+*.mode1v3
+*.mode2v3
+# XCode 4
+xcuserdata
+*.xcworkspace
+
 # Code::Blocks
-*.depend  
-*.layout  
+*.depend
+*.layout
 
-# (Windows-Specific) Windows image file caches  
+# Visual Studio
+*.sdf
+*.opensdf
+*.suo
+*.pdb
+*.ilk
+*.aps
+ipch/
+
+# Eclipse
+.metadata
+local.properties
+.externalToolBuilders
+
+# operating system
+
+# Linux
+*~
+# KDE
+.directory
+.AppleDouble
+
+# OSX
+.DS_Store
+*.swp
+*~.nib
+# Thumbnails
+._*
+
+# Windows
+# Image file caches
 Thumbs.db
-
-# Folder config file  
+# Folder config file
 Desktop.ini
+
+# Android
+.csettings

--- a/OpenFrameworks.gitignore
+++ b/OpenFrameworks.gitignore
@@ -1,0 +1,26 @@
+# openFrameworks
+
+[Bb]in/*  
+![Bb]in/data/  
+[Bb]uild/  
+[Oo]bj/  
+*.o  
+[Dd]ebug*/  
+[Rr]elease*/  
+*.mode*  
+*.app/  
+*.pyc  
+*.log  
+
+# Code::Blocks
+
+*.depend  
+*.layout  
+
+# Windows
+
+# Windows image file caches  
+Thumbs.db  
+
+# Folder config file  
+Desktop.ini


### PR DESCRIPTION
**Enhancement to the current gitignore repository**

Adds .gitignore for [OpenFrameworks](http://openframeworks.cc/)

Github Repository Link: [Github-OpenFrameworks](https://github.com/openframeworks/openFrameworks)

Here's a link to the official HomePage: **http://openframeworks.cc/**
