### PR TITLE
Add Crystal template

### DIFF
--- a/Crystal.gitignore
+++ b/Crystal.gitignore
@@ -1,0 +1,8 @@
+/doc/
+/lib/
+/bin/
+/.shards/
+
+# Libraries don't need dependency lock
+# Dependencies will be locked in application that uses them
+#/shard.lock


### PR DESCRIPTION
**Reasons for making this change:**

Add Crystal language template.

This PReq is duplicate with #1589, but it's old and not maintained. After the PReq Crystal introduce `shards` as it default dependency management system, so the .gitignore was updated.

**Links to documentation supporting these rule changes:** 

`crystal init lib x` & `crystal init app x` commands create the .gitignore.

If this is a new template: 

 - **Link to application or project’s homepage**: [The Crystal Programming Language - A compiled language with Ruby like syntax and type inference](https://crystal-lang.org/)