### PR TITLE
Remove Composer's file and directory from Symfony.

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -25,7 +25,6 @@
 /bin/*
 !bin/console
 !bin/symfony_requirements
-/vendor/
 
 # Assets and user uploads
 /web/bundles/
@@ -37,9 +36,6 @@
 
 # Build data
 /build/
-
-# Composer PHAR
-/composer.phar
 
 # Backup entities generated with doctrine:generate:entities command
 **/Entity/*~


### PR DESCRIPTION
**Reasons for making this change:**

We have already a Composer gitignore. 

**Links to documentation supporting these rule changes:** 

https://github.com/github/gitignore/blob/master/Composer.gitignore

