### PR TITLE
[Swift] adding new rules

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -6,6 +6,10 @@
 build/
 DerivedData/
 
+## Test generated
+*.gcno
+*.gcda
+
 ## Various settings
 *.pbxuser
 !default.pbxuser
@@ -31,6 +35,12 @@ xcuserdata/
 ## Playgrounds
 timeline.xctimeline
 playground.xcworkspace
+
+## Finder
+.DS_Store
+
+## Git
+*.orig # Files created by mergetool
 
 # Swift Package Manager
 #


### PR DESCRIPTION
**Reasons for making this change:**

* **Test generated** - `xcodebuild` generates `.gcno` and `.gcda` files that contains information for code coverage. This kind of information is relative to that test, not to project and all the team members. Usually we don't want those files under revision control or we will have changes every time we run tests.
* **Finder** - Finder generates a `.DS_Store` file with information important only to that user, not all the team members in the team. They can have different finder configurations.
* **Git** - if not disabled`git mergetool` generates temporary `.orig` file which we may not want under revision control. I think this happens more frequently with FileMerge from Apple, ,usually this files should be cleaned after a successful merge.

**Links to documentation supporting these rule changes:** 

**Note**: Those links explains the points not the rule to the changes

https://gcc.gnu.org/onlinedocs/gcc/Gcov-Data-Files.html
https://en.wikipedia.org/wiki/.DS_Store
https://git-scm.com/docs/git-mergetool