### PR TITLE
Allow PakBlacklist-*.txt files inside Build dir in UnrealEngine.gitignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -54,6 +54,11 @@ Binaries/*
 # Builds
 Build/*
 
+# Whitelist PakBlacklist-<BuildConfiguration>.txt files
+!Build/*/
+Build/*/**
+!Build/*/PakBlacklist*.txt
+
 # Don't ignore icon files in Build
 !Build/**/*.ico
 


### PR DESCRIPTION
**Reasons for making this change:**

The PakBlacklist-<BuildConfiguration>.txt is used to disallow some files to be packaged in the pak file.
This can be very helpful to reduce pak file size for mobile platforms.

To avoid the user-defined blueprint class Debug.uasset located in Content/Blueprints folder to be packaged in shipping build, one has to do the following steps:
1. Create the PakBlacklist-Shipping.txt file in Build/Android directory.
2. Insert the content "../../../MyGameName/Blueprints/Debug.uasset
3. Package the game


**Links to documentation supporting these rule changes:** 

https://docs.unrealengine.com/latest/INT/Platforms/Android/ReducingAPKSize/#packageblacklist
