### PR TITLE
Drastically simplify .gitignore for Dart

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -4,9 +4,9 @@
 .packages
 .pub/
 build/
-# If you're building an application, you may want to check-in your pubspec.lock.
+# If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 
-# Directory created by dartdoc.
+# Directory created by dartdoc
 # If you don't generate documentation locally you can remove this line.
 doc/api/

--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -6,3 +6,7 @@
 build/
 # If you're building an application, you may want to check-in your pubspec.lock.
 pubspec.lock
+
+# Directory created by dartdoc.
+# If you don't generate documentation locally you can remove this line.
+doc/api/

--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,33 +1,8 @@
 # See https://www.dartlang.org/tools/private-files.html
 
 # Files and directories created by pub
-
-# SDK 1.20 and later (no longer creates packages directories)
 .packages
 .pub/
 build/
-
-# Older SDK versions
-# (Include if the minimum SDK version specified in pubsepc.yaml is earlier than 1.20)
-.project
-.buildlog
-**/packages/
-
-
-# Files created by dart2js
-# (Most Dart developers will use pub build to compile Dart, use/modify these 
-#  rules if you intend to use dart2js directly
-#  Convention is to use extension '.dart.js' for Dart compiled to Javascript to
-#  differentiate from explicit Javascript files)
-*.dart.js
-*.part.js
-*.js.deps
-*.js.map
-*.info.json
-
-# Directory created by dartdoc
-doc/api/
-
-# Don't commit pubspec lock file 
-# (Library packages only! Remove pattern if developing an application package)
+# If you're building an application, you may want to check-in your pubspec.lock.
 pubspec.lock


### PR DESCRIPTION
Our typical workflow has JS and related build outputs in the `build` directory.

Most users are on new SDKs, so we don't have to worry about these ignores.
Most users don't generate docs locally. If they do, it's easy to add the entry to their .gitignore later.

**Reasons for making this change:**

Most of the entries are legacy – relating to releases that are over 6 months old.

**Links to documentation supporting these rule changes:** 

Just starting the cleanup. See this issue for our doc site
https://github.com/dart-lang/site-www/issues/250
