### PR TITLE
Add Cursive's REPL history file

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -36,6 +36,9 @@
 # JIRA plugin
 atlassian-ide-plugin.xml
 
+# Cursive Clojure plugin
+.idea/replstate.xml
+
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties


### PR DESCRIPTION
**Reasons for making this change:**

The file `replstate.xml` contains the history of the Clojure REPL that [Cursive] adds to IntelliJ. Obviously that's user-specific, and not relevant to other users.

[Cursive]: https://cursive-ide.com/

**Links to documentation supporting these rule changes:**

This file is not well-documented, but in cursive-ide/cursive#1325, the Cursive developers state that this is the REPL history file, and that deleting it is acceptable troubleshooting if it's causing trouble.