### PR TITLE
Add new gitignore for CMS 1C-Bitrix.gitignore

### DIFF
--- a/1C-Bitrix.gitignore
+++ b/1C-Bitrix.gitignore
@@ -1,0 +1,24 @@
+# core
+/bitrix/
+
+# uploaded files
+/upload/
+
+# other files
+test.php
+*.zip
+*.gzip
+*.gz
+*.tgz
+*.tar
+*.gz.[0-9]
+*.sql
+*.log
+*.mp3
+*.exe
+*.db
+*.csv
+*.xml
+*.psd
+*.[oa]
+*~


### PR DESCRIPTION
**Reasons for making this change:**

The most popular CMS in Russia. And the 6th place in terms of the number of uses in the world.

**Links to documentation supporting these rule changes:** 

https://dev.1c-bitrix.ru/learning/course/index.php?COURSE_ID=43&LESSON_ID=5119

If this is a new template: 

 - https://dev.1c-bitrix.ru/
