### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -54,6 +54,9 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Yarn lock file
+yarn.lock
+
 # dotenv environment variables file
 .env
 


### PR DESCRIPTION
Yarn lock is autogenerated, I see no reason to keep track of it.