### PR TITLE
Add *.pyc to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.pyc
 
 # C extensions
 *.so


### PR DESCRIPTION
**Reasons for making this change:**
- *.pyc is the binary output from py_compile in Python 3

**Links to documentation supporting these rule changes:** 
- Ref: https://docs.python.org/3/library/py_compile.html

