### PR TITLE
Add new gitignore for Ansible test driven development

### DIFF
--- a/Ansible.gitignore
+++ b/Ansible.gitignore
@@ -1,0 +1,11 @@
+# Ansible retry files
+*.retry
+
+# Test driven development on Ansible with Molecule, Testinfra and pytest
+.cache/
+.idea/
+.molecule/
+.tox/
+__pycache__/
+tests/roles
+*.pyc


### PR DESCRIPTION
Ansible is an automation framework that consist of a series of playbooks written in YAML. 

Reusable collections of playbooks are called roles, and roles can be shared with the world at https://galaxy.ansible.com/

The best practice is to use test driven development when creating these Ansible, and a common test framework in that regard is Molecule, which relies on the Testinfra framework (Python based), which in turn supports the Python pytest framework. 

This Ansible.gitignore will contain support for doing  test driven development on Ansible, and hence ignoring meta files or binary files created by these test frameworks.

**Links to documentation supporting these rule changes:** 
http://docs.ansible.com/ansible/intro_configuration.html#retry-files-enabled
https://molecule.readthedocs.io/en/stable-1.21/index.html
https://testinfra.readthedocs.io/en/latest/index.html
http://doc.pytest.org/en/latest/

If this is a new template: 

 - **Link to application or project’s homepage**:  https://www.ansible.com/
