### PR TITLE
Add exclusion for OpenCover UI results

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -286,3 +286,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/


### PR DESCRIPTION
**Reasons for making this change:**

OpenCover UI generates a number of XML files containing code coverage information upon execution, placing them in an OpenCover directory in the solution root.

**Links to documentation supporting these rule changes:** 

No concrete documentation, only anecdotal based on experience.  Project is on GitHub [here](https://github.com/OpenCoverUI/OpenCover.UI).