### PR TITLE
Adding cmake-build-debug

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -19,6 +19,9 @@
 .idea/**/gradle.xml
 .idea/**/libraries
 
+# CMake
+cmake-build-debug/
+
 # Mongo Explorer plugin:
 .idea/**/mongoSettings.xml
 


### PR DESCRIPTION
**Reasons for making this change:**

CLion (which uses the CMake build system) creates cmake-build-debug/ as a temporary folder for storing build related files

**Links to documentation supporting these rule changes:** 

Link to the CLion 2016.3 CMake changes:
https://blog.jetbrains.com/clion/2016/10/clion-2016-3-eap-cmake-overload-resolution/#cmake

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
