### PR TITLE
Added .spyproject to ignored paths

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -89,6 +89,7 @@ ENV/
 
 # Spyder project settings
 .spyderproject
+.spyproject
 
 # Rope project settings
 .ropeproject


### PR DESCRIPTION
**Reasons for making this change:**

Looks like Spyder 3.1 uses .spyproject folder to store workspace config

**Links to documentation supporting these rule changes:** 
[Spyder Config](https://github.com/spyder-ide/spyder/blob/46c9dbd9713d6095e634f4ade430e2dd235acfec/spyder/widgets/projects/config.py)

