### PR TITLE
ignore logs on /administrator/logs/*

### DIFF
--- a/Joomla.gitignore
+++ b/Joomla.gitignore
@@ -251,7 +251,7 @@
 /administrator/language/en-GB/en-GB.tpl_hathor.sys.ini
 /administrator/language/en-GB/en-GB.xml
 /administrator/language/overrides/*
-/administrator/logs/index.html
+/administrator/logs/*
 /administrator/manifests/*
 /administrator/modules/mod_custom/*
 /administrator/modules/mod_feed/*


### PR DESCRIPTION
**Reasons for making this change:**

new logs created on the server need to be merged and that not Necessary   


