### PR TITLE
Add Advanced Installer gitignore

### DIFF
--- a/Global/AdvancedInstaller.gitignore
+++ b/Global/AdvancedInstaller.gitignore
@@ -1,0 +1,3 @@
+# Advanced Installer caches and default build output
+*-cache/
+*-SetupFiles/

--- a/Global/AdvancedInstaller.gitignore
+++ b/Global/AdvancedInstaller.gitignore
@@ -1,3 +1,4 @@
 # Advanced Installer caches and default build output
 *-cache/
 *-SetupFiles/
+Prerequisites/


### PR DESCRIPTION
**Reasons for making this change:**

There is currently no .gitignore file for Advanced Installer, a product that creates installer files for Windows. Advanced Installer projects are appropriate for version control, however it creates binaries and cache files that are not.

**Links to documentation supporting these rule changes:** 

Cache: http://www.advancedinstaller.com/user-guide/project-cache-tab.html
Default output folder: http://www.advancedinstaller.com/user-guide/set-output-build-location.html

If this is a new template: 

 - **Link to application or project’s homepage**: http://www.advancedinstaller.com/
