### PR TITLE
ignore .DS_Store file in MacOS platform.

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -16,6 +16,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+.DS_Store
 
 ## Other
 *.moved-aside

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -16,6 +16,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+.DS_Store
 
 ## Other
 *.moved-aside

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -16,6 +16,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+.DS_Store
 
 ## Other
 *.moved-aside


### PR DESCRIPTION
**Reasons for making this change:**

.DS_Store is a Mac-specific hidden file. It's also not something that you generally want to add to source control, as its contents may change without you necessarily interacting with it.

**Links to documentation supporting these rule changes:** 

[Wikipedia introduce info](https://en.wikipedia.org/wiki/.DS_Store)
[stackoverflow data](https://stackoverflow.com/questions/30246832/is-ds-store-file-important)


