### PR TITLE
Add ignore rules for SonarQube Sonar Scanner and SonarLint

### DIFF
--- a/SonarQube.gitignore
+++ b/SonarQube.gitignore
@@ -1,0 +1,9 @@
+# SonarQube ignore files.
+#
+# https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner
+# Sonar Scanner working directories
+.sonar/
+
+# http://www.sonarlint.org/commandline/
+# SonarLint working directories, configuration files (including credentials)
+.sonarlint/

--- a/SonarQube.gitignore
+++ b/SonarQube.gitignore
@@ -3,7 +3,9 @@
 # https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner
 # Sonar Scanner working directories
 .sonar/
+.sonarqube/
 
 # http://www.sonarlint.org/commandline/
 # SonarLint working directories, configuration files (including credentials)
 .sonarlint/
+


### PR DESCRIPTION
**Reasons for making this change:**

SonarQube is a code-quality tool used on many projects. The scanners (Sonar Scanner and SonarLint) for SonarQube create working directories in the source tree that should be ignored. These working directories may also contain credentials, which should definitely be ignored.

**Links to documentation supporting these rule changes:** 

Analysis engine links:

https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner
http://www.sonarlint.org/commandline/

General product docs:

https://docs.sonarqube.org/display/HOME/SonarQube+Platform
https://docs.sonarqube.org/display/SONAR/Documentation

 - **Link to application or project’s homepage**:

https://www.sonarqube.org/
