### PR TITLE
.project and .classpath should be inside VC

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -11,9 +11,6 @@ local.properties
 .loadpath
 .recommenders
 
-# Eclipse Core
-.project
-
 # External tool builders
 .externalToolBuilders/
 
@@ -25,9 +22,6 @@ local.properties
 
 # CDT-specific (C/C++ Development Tooling)
 .cproject
-
-# JDT-specific (Eclipse Java Development Tools)
-.classpath
 
 # Java annotation processor (APT)
 .factorypath


### PR DESCRIPTION
**Reasons for making this change:**

Having the .project and .classpath files inside version control makes sure that people building the project for the first time have all the right configuration.

From the eclipse website itself: "Make sure that the .project and .classpath files are under version control. These files must be stored in the repository so that other users checking out the projects for the first time will get the correct type of project and will get the correct Java build path."

**Links to documentation supporting these rule changes:** 
From the Eclipse website itself:
http://wiki.eclipse.org/FAQ_How_do_I_set_up_a_Java_project_to_share_in_a_repository%3F
