### PR TITLE
Ignore mkdocs site directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# mkdocs documentation
+site/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -94,4 +94,4 @@ ENV/
 .ropeproject
 
 # mkdocs documentation
-site/
+/site


### PR DESCRIPTION
[mkdocs](http://www.mkdocs.org/) is rising as an alternative to Sphinx for project's documentation. The default build command puts the generated documentation in a `site` directory at the root of the project which should be ignored.