### PR TITLE
Add Pimcore v3

### DIFF
--- a/Pimcore3.gitignore
+++ b/Pimcore3.gitignore
@@ -1,0 +1,11 @@
+
+website/var/assets/
+website/var/backup/
+website/var/cache/
+website/var/config/
+website/var/log/
+website/var/recyclebin/
+website/var/search/
+website/var/system/
+website/var/tmp/
+website/var/versions/


### PR DESCRIPTION
**Link to application or project’s homepage**: 
http://pimcore.org
https://github.com/pimcore/pimcore

Notes:
Current version is v4, v5 in Alpha state, but there are still a lot of projects using v3.
This template covers the ignorable directories when using Pimcore to develop a website, not CMS development itself