### PR TITLE
Upgrade gradle gitignore

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -7,9 +7,10 @@ libs/
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
-# Package Files #
+# Package Files
 *.war
 *.ear
+*.jar
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,14 +1,75 @@
-.gradle
-/build/
+*.class
+*.bat
+*.setting
 
-# Ignore Gradle GUI config
-gradle-app.setting
+libs/
 
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
 
-# Cache of project
-.gradletasknamecache
+# Package Files #
+*.war
+*.ear
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must ends with two \r.
+Icon
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Windows
+# =========================
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Gradle
+build/
+.gradle/
+/bin/
+
+# Eclipse
+.project
+.classpath
+.settings/
+
+# IDEA
+.idea/
+out/
+*.ipr
+*.iml
+*.iws
+
+# Runtime Generic
+eclipse/
+logs/


### PR DESCRIPTION
**Reasons for making this change:**

This PR brings proper support for gradle projects (especially in subfolders) and adds IDE files and package files to the gitignore since they can be generated via gradle. This also properly ignores system-generated files for example `.DS_Store` and the like.

**Links to documentation supporting these rule changes:** 

* https://docs.gradle.org/current/userguide/idea_plugin.html
* https://docs.gradle.org/current/userguide/eclipse_plugin.html
* https://docs.gradle.org/current/userguide/ear_plugin.html