### PR TITLE
Create ds_store.gitignore

### DIFF
--- a/ds_store.gitignore
+++ b/ds_store.gitignore
@@ -1,0 +1,2 @@
+# Mac Folder custom attributes
+*.DS_Store


### PR DESCRIPTION
Ignore macOS's `.DS_Store` file - project-wide

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
