### PR TITLE
Create DBeaver.gitignore

### DIFF
--- a/DBeaver.gitignore
+++ b/DBeaver.gitignore
@@ -1,0 +1,2 @@
+# ide config file
+.dbeaver-data-sources*.xml


### PR DESCRIPTION
**Reasons for making this change:**

DBeaver can be installed on any eclipse based "ide" 

**Links to documentation supporting these rule changes:** 

[documentation](https://github.com/serge-rider/dbeaver/wiki/Admin-Manage-Connections)

 **Link to application or project’s homepage**:  

[homepage](http://dbeaver.jkiss.org/)
[GitHub](https://github.com/serge-rider/dbeaver)