### PR TITLE
[MPLabX] add new template

### DIFF
--- a/MPLabX.gitignore
+++ b/MPLabX.gitignore
@@ -1,5 +1,5 @@
 #Ignore List for Microchips MPLabX IDE
-#Form of eclipse with vendor specific changes
+#Form of netbeans with vendor specific changes
 #Taken from zeha on GIST https://gist.github.com/zeha/5999375
 
 *.d

--- a/MPLabX.gitignore
+++ b/MPLabX.gitignore
@@ -1,0 +1,26 @@
+#Ignore List for Microchips MPLabX IDE
+#Form of eclipse with vendor specific changes
+#Taken from zeha on GIST https://gist.github.com/zeha/5999375
+
+*.d
+*.pre
+*.p1
+*.lst
+*.sym
+*.obj
+*.o
+*.sdb
+*.obj.dmp
+html/
+nbproject/private/
+nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+funclist
+nbproject/Makefile-*
+disassembly/
+*.map


### PR DESCRIPTION
created the ignore file for Microchip MPLabX

**Reasons for making this change:**
No file exists for Microchip MPLabX.  Some C could be used, but that doesn't include all of the files for this particular suite.

**Links to documentation supporting these rule changes:** 

http://microchip.wikidot.com/faq:72

If this is a new template: 

http://www.microchip.com/mplab/mplab-x-ide
