### PR TITLE
Edit ignore for Microsoft Visio autosave files to include Office <= 2003

### DIFF
--- a/Global/MicrosoftOffice.gitignore
+++ b/Global/MicrosoftOffice.gitignore
@@ -13,4 +13,4 @@
 ~$*.ppt*
 
 # Visio autosave temporary files
-*.~vsdx
+*.~vsd*


### PR DESCRIPTION
**Reasons for making this change:**

The rule for Microsoft Visio autosave files is specialized for Office 2003 and higher, where the default Visio file extention is `.vsdx`
But older versions of Visio used the file extention `.vsd` thus generating `*.~vsd` autosave files.
The new rule matches both autosave file types.

**Links to documentation supporting these rule changes:** 

https://fileinfo.com/extension/vsd
