### PR TITLE
Create Mule.gitignore

### DIFF
--- a/Mule.gitignore
+++ b/Mule.gitignore
@@ -1,0 +1,10 @@
+# --------------- #
+# Mule-specific #
+# --------------- #
+.studio/
+flows/
+target/
+catalog/
+reports/
+.mule/
+**/*.mflow


### PR DESCRIPTION
Mulesoft's[1] toolset is popular in the Middleware Application development and API enablement industry[2]. Its offerings are used by development teams at multiple organisations.

Here's a brief description of why the listed files need to be ignored
 - *.studio/*: IDE specific configuration files
 - *flows/*: (No more valid. Preserved for the purpose of old projects)
 - *target/*: Compiled data
 - *catalog/*: Compiled data
 - *reports/*: Non-critical and runtime generated (unit test related) assets
 - *.mule/*: Runtime storage
 - * **/*.mflow *: (No more valid. Preserved for the purpose of old projects)

[1] https://www.mulesoft.com/platform/enterprise-integration
[2] http://www.investors.com/news/technology/mulesoft-ipo/

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
