### PR TITLE
Add moc_*.h in Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -20,6 +20,7 @@
 *.qbs.user.*
 *.moc
 moc_*.cpp
+moc_*.h
 qrc_*.cpp
 ui_*.h
 Makefile*


### PR DESCRIPTION
**Reasons for making this change:**

Add moc_\*.h in Qt.gitignore.
(example: moc_predefs.h)
(moc_\*.cpp is already present)

Note: moc_* are auto-generated files (see Qt moc)