### PR TITLE
Create Drupal8.gitignore

### DIFF
--- a/Drupal8.gitignore
+++ b/Drupal8.gitignore
@@ -1,0 +1,42 @@
+# Ignore configuration files that may contain sensitive information
+/sites/*/*settings*.php
+/sites/*/*services*.yml
+
+# Ignore paths that may contain user-generated content
+/sites/*/files
+/sites/*/public
+/sites/*/private
+/sites/*/files-public
+/sites/*/files-private
+
+# Ignore paths that may contain temporary files
+/sites/*/translations
+/sites/*/tmp
+/sites/*/cache
+
+# Ignore drupal core (if not versioning drupal sources)
+/core
+/modules/README.txt
+/profiles/README.txt
+/sites/README.txt
+/sites/example.sites.php
+/sites/example.settings.local.php
+/sites/development.services.yml
+/themes/README.txt
+/vendor
+/.csslintrc
+/.editorconfig
+/.eslintignore
+/.eslintrc.json
+/.gitattributes
+/.htaccess
+/autoload.php
+/composer.json
+/composer.lock
+/example.gitignore
+/index.php
+/LICENSE.txt
+/README.txt
+/robots.txt
+/update.php
+/web.config


### PR DESCRIPTION
Create a new Drupal8.gitignore for Drupal 8 with the code from dvcs/gitignore
See the latest [gitignore](https://github.com/dvcs/gitignore/blob/master/templates/Drupal8.gitignore)
And the [pull request](https://github.com/dvcs/gitignore/pull/4)

Drupal 8's directory structure is fundamentally different from past versions.