### PR TITLE
add Phoenix.gitignore

### DIFF
--- a/Phoenix.gitignore
+++ b/Phoenix.gitignore
@@ -1,0 +1,32 @@
+# App artifacts
+/_build
+/db
+/deps
+/*.ez
+*.beam
+.DS_Store
+
+# Generate on crash by the VM
+erl_crash.dump
+
+# Static artifacts
+/node_modules
+
+# npm logs
+npm-debug.log*
+
+# Since we are building assets from web/static,
+# we ignore priv/static. You may want to comment
+# this depending on your deployment strategy.
+/priv/static/
+
+# The config/prod.secret.exs file by default contains sensitive
+# data and you should not commit it into version control.
+#
+# Alternatively, you may comment the line below and commit the
+# secrets file as long as you replace its contents by environment
+# variables.
+/config/prod.secret.exs
+/priv/uploads
+/import/cookies.yml
+/cover


### PR DESCRIPTION
**Reasons for making this change:**

gitignore did not exist, phoenix is a web framework for elixir programming language.

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
