### PR TITLE
Add macOS related entries to Xcode.gitignore

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,7 +1,36 @@
+# macOS
+#
+# gitignore contributors: remember to update Global/macOS.gitignore, Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
 # Xcode
 #
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
 ## Build generated
 build/
 DerivedData/

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -1,3 +1,7 @@
+# macOS
+#
+# gitignore contributors: remember to update Global/macOS.gitignore, Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
 *.DS_Store
 .AppleDouble
 .LSOverride

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -1,7 +1,36 @@
+# macOS
+#
+# gitignore contributors: remember to update Global/macOS.gitignore, Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
 # Xcode
 #
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
 ## Build generated
 build/
 DerivedData/

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -1,7 +1,36 @@
+# macOS
+#
+# gitignore contributors: remember to update Global/macOS.gitignore, Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
 # Xcode
 #
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
 ## Build generated
 build/
 DerivedData/
@@ -31,6 +60,9 @@ xcuserdata/
 ## Playgrounds
 timeline.xctimeline
 playground.xcworkspace
+
+# macOS
+
 
 # Swift Package Manager
 #


### PR DESCRIPTION
* Add macOS related entries to Swift.gitignore
* Add macOS related entries to Objective-C.gitignore
* Update reminder comments in all 4 gitignore files

**Reasons for making this change:**

Swift/Obj-C developers (mostly) using macOS as their development platform, Xcode is currently available only for macOS. So it is logical to have macOS gitignore file in same group as Swift, Obj-C and Xcode.

**Links to documentation supporting these rule changes:** 

[Xcode](https://en.wikipedia.org/wiki/Xcode)
[Swift](https://en.wikipedia.org/wiki/Swift_(programming_language))
[Objective-C](https://en.wikipedia.org/wiki/Objective-C)
