### PR TITLE
IntelliJ gitignore into java

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -32,13 +32,19 @@ proguard/
 # Android Studio captures folder
 captures/
 
-# Intellij
-*.iml
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/gradle.xml
+# IntelliJ User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
 .idea/dictionaries
-.idea/libraries
+
+# IntelliJ Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
 
 # Keystore files
 *.jks

--- a/Java.gitignore
+++ b/Java.gitignore
@@ -20,3 +20,17 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IntelliJ User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# IntelliJ Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml


### PR DESCRIPTION
I added the jetbrains .gitignore rules into the java gitignore, since it is a popular IDE used for java development.

I also corrected the android .gitignore with the rules from the jetbrains.gitignore.

**Reasons for making this change:**

The android .gitignore had jetbrains specific rules, but not the java one.

**Links to documentation supporting these rule changes:** 

[jetbrains](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839)
[jetbrains.gitignore](https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore)
