### PR TITLE
Ignore mypy's cache directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -96,3 +96,6 @@ ENV/
 
 # mkdocs documentation
 /site
+
+# mypy
+.mypy_cache/


### PR DESCRIPTION
**Reasons for making this change:**

 The latest release of mypy caches results in a directory.

**Links to documentation supporting these rule changes:** 

https://mypy.readthedocs.io/en/latest/command_line.html (search for `.mypy_cache`)