### PR TITLE
Add gitignore for Construct2 projects

### DIFF
--- a/Construct2.gitignore
+++ b/Construct2.gitignore
@@ -1,0 +1,3 @@
+*.autosave
+*.backup*
+*.uistate.xml


### PR DESCRIPTION
**Reasons for making this change:**

Add the basic gitignore file for Construct2 projects due to it is becoming popular.

**Links to documentation supporting these rule changes:** 

This tutorial on collaboration with svn has the necessary rules to apply it to git.
www.scirra.com/tutorials/537/how-to-collaborate-on-projects-with-svn

If this is a new template: 

 - **Link to application or project’s homepage**: www.scirra.com/construct2
