### PR TITLE
Create Vue-cli.gitignore

### DIFF
--- a/Vue-cli.gitignore
+++ b/Vue-cli.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+node_modules
+test/e2e/mock-template-build
+*.log
+dist/


### PR DESCRIPTION
**Reasons for making this change:**

dosn't exist ^^

**Links to documentation supporting these rule changes:** 

https://github.com/vuejs/vue-cli/blob/master/.gitignore

If this is a new template: 

 https://github.com/vuejs/vue-cli
