### PR TITLE
add .appx to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -183,6 +183,7 @@ AppPackages/
 BundleArtifacts/
 Package.StoreAssociation.xml
 _pkginfo.txt
+.appx
 
 # Visual Studio cache files
 # files ending in .cache can be ignored

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -183,7 +183,7 @@ AppPackages/
 BundleArtifacts/
 Package.StoreAssociation.xml
 _pkginfo.txt
-.appx
+*.appx
 
 # Visual Studio cache files
 # files ending in .cache can be ignored


### PR DESCRIPTION
**Reasons for making this change:**

Visual Studio creates .appx files in the UWP project root directory. These files are not needed when writing code.

**Links to documentation supporting these rule changes:** 

These are packages created for the Windows Store, you don't need them when you write code. I asked a question on [StackOverflow](http://stackoverflow.com/questions/43862861/is-it-safe-to-ignore-appx-files-in-git-repository-of-a-uwp-app/43865908#43865908) on this topic.
