### PR TITLE
Add stackdump to Windows.gitignore

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -3,6 +3,9 @@ Thumbs.db
 ehthumbs.db
 ehthumbs_vista.db
 
+# Dump file
+*.stackdump
+
 # Folder config file
 Desktop.ini
 


### PR DESCRIPTION
**Reasons for making this change:**

Ignore the stack dump generated when a program has crashed under Windows.

**Links to documentation supporting these rule changes:** 

http://www.drupalonwindows.com/en/blog/git-shell-windows-reports-shexe-has-stopped-working-appcrash
https://community.atlassian.com/t5/SourceTree-questions/Sourcetree-cannot-clone-pull-anymore-sh-exe-stackdump/qaq-p/82962