### PR TITLE
Create PuTTY.gitignore

### DIFF
--- a/Global/PuTTY.gitignore
+++ b/Global/PuTTY.gitignore
@@ -1,0 +1,2 @@
+# Private key
+*.ppk


### PR DESCRIPTION
**Reasons for making this change:**

PuTTYgen is a widely used alternative to OpenSSH under Windows.
This rule allows private keys ignoring.

If this is a new template: 

 - **Link to application or project’s homepage**: https://www.chiark.greenend.org.uk/~sgtatham/putty/
