### PR TITLE
add *_plugin_import.cpp to Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -12,6 +12,7 @@
 
 # Qt-es
 
+*_plugin_import.cpp
 /.qmake.cache
 /.qmake.stash
 *.pro.user


### PR DESCRIPTION
This file is autogenerated by qmake. It imports static plugin classes for
static plugins specified using QTPLUGIN and QT_PLUGIN_CLASS.<plugin> variables.

This file is autogenerated for static build.
