### PR TITLE
Qt unit tests

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -12,6 +12,8 @@
 
 # Qt-es
 
+object_script.*.Release
+object_script.*.Debug
 *_plugin_import.cpp
 /.qmake.cache
 /.qmake.stash

--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -27,6 +27,11 @@ ui_*.h
 Makefile*
 *build-*
 
+
+# Qt unit tests
+target_wrapper.*
+
+
 # QtCreator
 
 *.autosave


### PR DESCRIPTION
1. add target_wrapper.* to Qt.gitignore

This file is autogenerated by qmake for run auto(unit) tests.

- For Windows: **target_wrapper.bat**
- For Unix: **target_wrapper.sh**

2. add object_script to Qt.gitignore

For template rules (modern style) in Qt project file,
qmake auto generate files with list of objects

-  object_script.*.Debug
-  object_script.*.Release