### PR TITLE
Consolidate all environments in one section

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -79,11 +78,10 @@ celerybeat-schedule
 # SageMath parsed files
 *.sage.py
 
-# dotenv
+# Environments
 .env
-
-# virtualenv
 .venv
+env/
 venv/
 ENV/
 


### PR DESCRIPTION
**Reasons for making this change:**

Some of these names relate to specific tools, others could be used by multiple tools. In particular, virtualenv, the most popular tool for creating Python environments, does not mandate any of these and venv/ or .venv are simply conventional. It is more readable to group all of these together.

**Links to documentation supporting these rule changes:** 

* https://virtualenv.pypa.io/en/stable/userguide/ (virtualenv docs, suggest ENV as directory name)
* https://docs.python.org/3/library/venv.html (`venv` is now a virtualenv tool which is part of Python 3)
* http://stackoverflow.com/questions/37287964/virtual-environments-python-m-venv-vs-echo-layout-python3 (example showing use of venv as the name for environment made with virtualenv)
