### PR TITLE
Create .gitignore rules for JEnv

### DIFF
--- a/Global/JEnv.gitignore
+++ b/Global/JEnv.gitignore
@@ -1,0 +1,5 @@
+# JEnv local Java version configuration file
+.java-version
+
+# Used by previous versions of JEnv
+.jenv-version


### PR DESCRIPTION
**Reasons for making this change:**

Adds a new template for JEnv, a command-line application for easily changing Java version globally or per directory.

When the Java version is set for a specific directory, a `.java-version` file is created (`.jenv-version` in previous versions of JEnv). This file holds the name of the Java version to use for that directory and usually should not be pushed to version control.

**Links to documentation supporting these rule changes:** 

https://github.com/gcuisinier/jenv#jenv-local

**Link to application or project’s homepage**

http://www.jenv.be