### PR TITLE
add MANIFEST

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -23,6 +23,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
add MANIFEST which is GENERATED by distutils

**Reasons for making this change:**

if you use distutils.core to setup, the file MANIFEST is generated by distutils when run 'python setup.py sdist' 


