### PR TITLE
Create Netbeans.gitignore

### DIFF
--- a/Netbeans.gitignore
+++ b/Netbeans.gitignore
@@ -1,0 +1,5 @@
+#netbeans specific
+core
+nbproject/*
+!nbproject/project.properties
+!nbproject/project.xml


### PR DESCRIPTION
**Reasons for making this change:**

Ignoring Netbeans IDE project folder and files

**Links to documentation supporting these rule changes:** 

https://netbeans.org/

If this is a new template: 

 - **Link to application or project’s homepage**: https://netbeans.org/
