### PR TITLE
Add ignore file for the Xill development platform

### DIFF
--- a/Xill.gitignore
+++ b/Xill.gitignore
@@ -1,0 +1,6 @@
+.project
+.xlib
+testit-reports/
+.generated-tests/
+generated-tests/
+xill.properties


### PR DESCRIPTION
**Reasons for making this change:**

There is no support for Xill projects yet. This pull request add this.

**Links to documentation supporting these rule changes:** 

https://support.xillio.com/support/solutions/folders/6000201089

 **Link to application or project’s homepage**: http://xill.io/
