### PR TITLE
Fix capitalization and spacing of comments

### DIFF
--- a/Global/Archives.gitignore
+++ b/Global/Archives.gitignore
@@ -12,11 +12,11 @@
 *.lzma
 *.cab
 
-#packing-only formats
+# Packing-only formats
 *.iso
 *.tar
 
-#package management formats
+# Package management formats
 *.dmg
 *.xpi
 *.gem

--- a/Global/SublimeText.gitignore
+++ b/Global/SublimeText.gitignore
@@ -1,16 +1,16 @@
-# cache files for sublime text
+# Cache files for Sublime Text
 *.tmlanguage.cache
 *.tmPreferences.cache
 *.stTheme.cache
 
-# workspace files are user-specific
+# Workspace files are user-specific
 *.sublime-workspace
 
-# project files should be checked into the repository, unless a significant
-# proportion of contributors will probably not be using SublimeText
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
 # *.sublime-project
 
-# sftp configuration file
+# SFTP configuration file
 sftp-config.json
 
 # Package control specific files

--- a/Global/Vim.gitignore
+++ b/Global/Vim.gitignore
@@ -1,12 +1,14 @@
-# swap
+# Swap
 [._]*.s[a-v][a-z]
 [._]*.sw[a-p]
 [._]s[a-v][a-z]
 [._]sw[a-p]
-# session
+
+# Session
 Session.vim
-# temporary
+
+# Temporary
 .netrwhist
 *~
-# auto-generated tag files
+# Auto-generated tag files
 tags

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -1,3 +1,4 @@
+# General
 *.DS_Store
 .AppleDouble
 .LSOverride


### PR DESCRIPTION
This is a cleanup of the comments so they follow the style of comments in some of the more heavily trafficked gitignote files.