### PR TITLE
adding a template for OSX .DS_Store files

### DIFF
--- a/Osx-DS.gitignore
+++ b/Osx-DS.gitignore
@@ -1,0 +1,2 @@
+# files that OSX creates to track metadata that is of no use to a remote system
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

I have to do this every time I create a new repo and do not want OSX metadata files in source control.

If this is a new template: 

 - **Link to application or project’s homepage**: https://en.wikipedia.org/wiki/.DS_Store
