### PR TITLE
Remove Backup*/ entry

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -212,7 +212,6 @@ Generated_Code/
 # to a newer Visual Studio version. Backup files are not needed,
 # because we have git ;-)
 _UpgradeReport_Files/
-Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 


### PR DESCRIPTION
There are many valid use cases for having a folder with a name that **starts** with "Backup". Having `Backup*/` gitignored is too aggressive. 

The user will simply delete the `Backup` folder if they don't want it anyway, since it isn't a regularly generated artifact, so it doesn't make any sense to have it in `.gitignore`.