### PR TITLE
Adds BenchmarkDotNet.Artifacts to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -42,6 +42,9 @@ TestResult.xml
 [Rr]eleasePS/
 dlldata.c
 
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
 # .NET Core
 project.lock.json
 project.fragment.lock.json


### PR DESCRIPTION
**Reasons for making this change:**

[BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) is a benchmarking library supported by the [.NET foundation](https://dotnetfoundation.org/benchmarkdotnet). It became the de facto benchmarking tool in the .net ecosystem and its output is embedded in project websites, blog posts etc. 

However, this output pollutes the git repository, since the library generates it directly into the project's folder. This folder contains benchmark results that are not source code and are not considered essential (subsequent runs overwrite existing artifacts without any prompt.)

Sample BenchmarkDotNet output:
![image](https://user-images.githubusercontent.com/1673956/26963672-b17236be-4ca2-11e7-8242-c08257d28823.png)

**Links to documentation supporting these rule changes:** 

http://benchmarkdotnet.org/Configs/Exporters.htm
 > An exporter allows you to export results of your benchmark in different formats. By default, files with results will be located in .\BenchmarkDotNet.Artifacts\results directory. Default exporters are: csv, html and markdown. Here is list of all available exporters:
