### PR TITLE
Add names of backup folders created by terrarium

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -83,8 +83,9 @@ celerybeat-schedule
 .venv
 env/
 venv/
-venv.bak/
 ENV/
+env.bak/
+venv.bak/
 
 # Spyder project settings
 .spyderproject

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -83,6 +83,7 @@ celerybeat-schedule
 .venv
 env/
 venv/
+venv.bak/
 ENV/
 
 # Spyder project settings


### PR DESCRIPTION
Just as env and venv are standard names for virtual environments, the environment tool Terrarium will back these up to env.bak and venv.bak respectively.

Terrarium docs:
http://terrarium.readthedocs.io/en/latest/quickstart.html?highlight=env.bak