### PR TITLE
Add extended DVI (XDV) to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -13,6 +13,7 @@
 
 ## Intermediate documents:
 *.dvi
+*.xdv
 *-converted-to.*
 # these rules might exclude image files for figures etc.
 # *.ps


### PR DESCRIPTION
**Reasons for making this change:**

* XDV is the XeTeX-equivalent of DVI, an intermediary format that has to be converted before reading.

**Links to documentation supporting these rule changes:** 

* https://www.ctan.org/pkg/xetex
