### PR TITLE
.DS_Store is a file name, not an extension

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -1,5 +1,5 @@
 # General
-*.DS_Store
+.DS_Store
 .AppleDouble
 .LSOverride
 


### PR DESCRIPTION
I changed `*.DS_Store` to `.DS_Store`, because it is a filename: https://en.wikipedia.org/wiki/.DS_Store

