### PR TITLE
Add vendor to Golang git ignore list

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# Golang project vendor packages which should be ignored
+vendor/


### PR DESCRIPTION
Golang Dependency Management == Vendoring

Vendoring is the only method for golang dependency management. In this, you save a local copy of the dependent libraries that your application shall use. Each library is for a vender which its source codes should not be added to main project and only name of those dependencies should be tracked by tools like glide or ... .

So I think we should ignore vendor directory.