### PR TITLE
Updates Elixir gitignore file

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -1,6 +1,8 @@
 /_build
 /cover
 /deps
+/doc
+/.fetch
 erl_crash.dump
 *.ez
 *.beam


### PR DESCRIPTION
**Reasons for making this change:**

Official `elixir`'s `gitignore` after running `mix new` contains these two lines:

> Where 3rd-party dependencies like ExDoc output generated docs.
> /doc
> Ignore .fetch files in case you like to edit your project deps locally.
> /.fetch

They are missing at the moment.

**Links to documentation supporting these rule changes:** 

https://github.com/elixir-lang/elixir/blob/55c40b465f41d14d94842b01fcdab0e49a38aaea/lib/mix/lib/mix/tasks/new.ex#L233