### PR TITLE
Visual Studio: ignore 'ncrunchproject' and 'ncrunchsolution' files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -121,9 +121,8 @@ _TeamCity*
 *.coveragexml
 
 # NCrunch
-_NCrunch_*
+*ncrunch*
 .*crunch*.local.xml
-nCrunchTemp_*
 
 # MightyMoose
 *.mm.*


### PR DESCRIPTION
**Reasons for making this change:**

When using the gitignore template prior to this commit and when NCrunch is added to a solution, 'ncrunchproject' and 'ncrunchsolution' files are tracked - I don't believe these files should be in source.

This commit fixes the issue by using the following pattern:

> `*ncrunch*` 

**Note:** Using the pattern above means that `_NCrunch_*` and `nCrunchTemp_*` were no longer required, hence me removing them in this commit.