### PR TITLE
Update Terraform.gitignore - ignore terraform.tfvars

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -4,3 +4,6 @@
 
 # Module directory
 .terraform/
+
+# Variable values for development
+terraform.tfvars


### PR DESCRIPTION
Added .tfvars file so for example AWS credentials aren't committed.

**Reasons for making this change:**

terraform.tfvars isn't currently included, so credentials can get committed if you expected this to be in the gitignore file.

**Links to documentation supporting these rule changes:** 

> If a file named terraform.tfvars is present in the current directory, Terraform automatically loads it to populate variables. If the file is named something else, you can pass the path to the file using the -var-file flag.

https://www.terraform.io/docs/configuration/variables.html