### PR TITLE
Create Kotlin.gitignore

### DIFF
--- a/Kotlin.gitignore
+++ b/Kotlin.gitignore
@@ -1,0 +1,47 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+lib/
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties

--- a/Kotlin.gitignore
+++ b/Kotlin.gitignore
@@ -45,3 +45,10 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
+
+# Additional Files
+/local.properties
+.DS_Store
+/build
+/captures
+.gradle


### PR DESCRIPTION
Files to ignore while using Kotlin

**Reasons for making this change:** I am new to Kotlin and I was having difficulty finding the files to be included in .gitgnore for Kotlin. I collected some list of files and put them together in a single file to be used easily.

If this is a new template: 

 - **Link to application or project’s homepage**: https://github.com/JetBrains/kotlin
