### PR TITLE
use .DS_Store instead of *.DS_Store

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -1,5 +1,5 @@
 # General
-*.DS_Store
+.DS_Store
 .AppleDouble
 .LSOverride
 


### PR DESCRIPTION
the .DS_Store is the name of a file generated by macOS, not a file extension

https://en.wikipedia.org/wiki/.DS_Store
https://git-scm.com/docs/gitignore
http://man7.org/linux/man-pages/man3/fnmatch.3.html
https://stackoverflow.com/questions/107701/how-can-i-remove-ds-store-files-from-a-git-repository
http://www.filetypehelp.com/dsstore-file-extension/

