### PR TITLE
Create JupyterNotebook.gitignore

### DIFF
--- a/JupyterNotebook.gitignore
+++ b/JupyterNotebook.gitignore
@@ -3,3 +3,4 @@
 
 # Remove previous ipynb_checkpoints
 #   git rm -r .ipynb_checkpoints/
+ 

--- a/JupyterNotebook.gitignore
+++ b/JupyterNotebook.gitignore
@@ -1,0 +1,5 @@
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/

--- a/JupyterNotebook.gitignore
+++ b/JupyterNotebook.gitignore
@@ -3,4 +3,4 @@
 
 # Remove previous ipynb_checkpoints
 #   git rm -r .ipynb_checkpoints/
- 
+#


### PR DESCRIPTION
**Reasons for making this change:**

Make Jupyter Notebook repository clean.

**Links to documentation supporting these rule changes:** 

https://stackoverflow.com/questions/36306017/should-ipynb-checkpoints-be-stored-in-git

If this is a new template: 

 - **Link to application or project’s homepage**: http://jupyter.org/
