### PR TITLE
Ignore .ghc.environment.*

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -18,3 +18,4 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 .HTF/
+.ghc.environment.*


### PR DESCRIPTION
**Reasons for making this change:**

`cabal new-build` generates a file `.ghc.environment.*` (where `*` depends on your GHC version / operating system / architecture) that captures the exact environment (including dependency versions) in which a project was built. This information is machine-specific by design, so it makes little sense to version-control it.

**Links to documentation supporting these rule changes:** 

`.ghc.environment.*` files were introduced [here](https://ghc.haskell.org/trac/ghc/ticket/11268). Several projects (including `cabal`) itself recommend putting this file into `.gitignore`, as seen [here](https://github.com/haskell/cabal/blob/bc8daa7492f92f33c88b24aa77d062082be0efe3/.gitignore#L5).
