### PR TITLE
Update JetBrains.gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -4,6 +4,7 @@
 # User-specific stuff:
 .idea/**/workspace.xml
 .idea/**/tasks.xml
+.idea/**/preferred-vcs.xml
 .idea/dictionaries
 
 # Sensitive or high-churn files:


### PR DESCRIPTION
Adds .idea/**/preferred-vcs.xml

**Reasons for making this change:**

The preferred-vcs.xml file isn't ignored by the pre-existing JetBrains.gitignore, has recently begun showing up after updating to 2017.1.5 / 2017.2 versions of JetBrains IDEs, and seems irrelevant/useless in a repository already under Git.
The file lists 'ApexVCS' as the preferred VCS despite the IDE already recognizing the project is under Git, and the file is re-created after deletion each time the IDE is run.