### PR TITLE
JetBrains: out/ ignored recursively

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -31,7 +31,7 @@ cmake-build-debug/
 ## Plugin-specific files:
 
 # IntelliJ
-/out/
+out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/


### PR DESCRIPTION
**Reasons for making this change:**

`.gitignore` may be used to in a projects containing multiple Java projects. Therefore, in other settings, directories are ignored recursively (e.g., `.idea_modules`).

**Links to documentation supporting these rule changes:** 

`/out/` was already in, so I think it is agreed that IntelliJ creates the `out` folder.