### PR TITLE
Added IAR EmbeddedWoekBench .gitignore file

### DIFF
--- a/IAREmbeddedWorkBench.gitignore
+++ b/IAREmbeddedWorkBench.gitignore
@@ -1,0 +1,49 @@
+# IAR C-STAT and C-RUN
+# Comment this out if you use C-Stat or C-Run to compile/analyze your project
+*.ewt
+
+# IAR Debugger files
+*.ewd
+
+# IAR Workspace files
+*.eww
+
+# IAR Settings  
+**/settings/*.crun  
+**/settings/*.dbgdt  
+**/settings/*.cspy  
+**/settings/*.cspy.*  
+**/settings/*.xcl  
+**/settings/*.dni  
+**/settings/*.wsdt  
+**/settings/*.wspos  
+
+# IAR Debug Exe  
+**/Debug/Exe/
+
+# IAR Debug List
+**/Debug/List
+
+# IAR Debug Obj  
+**/Obj/*.pbd  
+**/Obj/*.pbd.*  
+**/Obj/*.pbi  
+**/Obj/*.pbi.*
+
+# Log files
+**.log 
+
+# IAR backup files
+Backup*
+
+# IAR .dep files
+*.dep
+
+# Compiled Binaries
+*.bin
+*.elf
+*.hex
+*.map
+
+# Trash files
+*.bak


### PR DESCRIPTION
**Reasons for making this change:**

IAR Embedded Work Bench is commonly used IDE for ARM-based devices. They now support ~11500 devices. Although IAR incorporates an in-built version control, I would not be surprised if people preferred git.

**Links to documentation supporting these rule changes:** 

Files to be used for [Version Control](https://www.iar.com/support/tech-notes/ide/which-files-should-be-version-controlled/)

If this is a new template: 

IAR Embedded WorkBench [Homepage](https://www.iar.com/iar-embedded-workbench/)
