### PR TITLE
Remove TODO from VS.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -151,7 +151,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings
+# Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -151,7 +151,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# Comment the next line if you want to checkin your web deploy settings
+# Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj


### PR DESCRIPTION
**Reasons for making this change:**

I search my GitHub repo regularly for the string "TODO" and this always shows up. Please consider removing the todo; I'm also open to changing it to something else like `Note: `.
