### PR TITLE
Updated Smalltalk.gitignore

### DIFF
--- a/Smalltalk.gitignore
+++ b/Smalltalk.gitignore
@@ -13,6 +13,10 @@ SqueakDebug.log
 # Monticello package cache
 /package-cache
 
+# playground cache
+/play-cache
+/play-stash
+
 # Metacello-github cache
 /github-cache
 github-*.zip


### PR DESCRIPTION
**Reasons for making this change:**

Added Playground cache directory.
Playground are new moldable development tools for inspecting, coding and searching objects.

>Pharo Smalltalk
>Pharo emerged as a fork of Squeak Smalltalk. It focuses on modern software engineering and development techniques.

**Links to documentation supporting these rule changes:** 

[Pharo environment overview](https://ci.inria.fr/pharo-contribution/job/UpdatedPharoByExample/lastSuccessfulBuild/artifact/book-result/Environment/Environment.html)

