### PR TITLE
Update Swift.gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -21,6 +21,7 @@ xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
add .DS_Store to swift gitignore

**Reasons for making this change:**

sometimes macOS make .DS_Store file in a directory and cause conflicts. It's better to ignore this file.

**Links to documentation supporting these rule changes:** 

[http://osxdaily.com/2009/12/31/what-is-a-ds_store-file/](http://osxdaily.com/2009/12/31/what-is-a-ds_store-file/)

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_