### PR TITLE
Symfony.gitignore: add web server pid file

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -39,3 +39,6 @@
 
 # Backup entities generated with doctrine:generate:entities command
 **/Entity/*~
+
+# Embedded web-server pid file
+/.web-server-pid


### PR DESCRIPTION
**Reasons for making this change:**

Since Symfony 3.3, WebServerBundle creates a `.web-server-pid` file when embedded server is running.

**Links to documentation supporting these rule changes:** 

http://symfony.com/blog/new-in-symfony-3-3-webserverbundle

If this is a new template: 

 - no