### PR TITLE
Fix comments on same line causing ignore to break

### DIFF
--- a/Actionscript.gitignore
+++ b/Actionscript.gitignore
@@ -1,9 +1,8 @@
 # Build and Release Folders
-bin/
 bin-debug/
 bin-release/
-[Oo]bj/ # FlashDevelop obj
-[Bb]in/ # FlashDevelop bin
+[Oo]bj/
+[Bb]in/
 
 # Other files and folders
 .settings/


### PR DESCRIPTION
**Reasons for making this change:**

The current ActionScript ignore file doesn't work. bin and obj directories are not ignored because of the comment on the same line following the pattern.

Also removed redundant declaration of "bin/"