### PR TITLE
vendor/ folder added

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# Ignores the vendor directory provided by some applications such as: Glide, Godep, etc...
+vendor/


### PR DESCRIPTION
**Reasons for making this change:**

Added vendor folder to be ignored by git, in order to work well with glide, godep and etc ...

**Links to documentation supporting these rule changes:** 

https://github.com/golang/dep,
http://glide.sh/
