### PR TITLE
Adds .gitignore rules for AxoCover

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -116,6 +116,10 @@ _TeamCity*
 # DotCover is a Code Coverage Tool
 *.dotCover
 
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
 # Visual Studio code coverage results
 *.coverage
 *.coveragexml


### PR DESCRIPTION
**Reasons for making this change:**
AxoCover is a Code Coverage Tool. It creates a **.axoCover** folder where are created:
- settings in settings.json
- sub-folders into **run** folder which contain code coverage results.

All content into **.axoCover** folder must be ignored except the **settings.json** file.

**Links to documentation supporting these rule changes:** 

https://github.com/axodox/AxoTools

If this is a new template: 

 - **Link to application or project’s homepage**: https://github.com/axodox/AxoTools
