### PR TITLE
'*.tfstate.*.backup' added to Terraform.gitignore

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -1,5 +1,6 @@
 # Compiled files
 *.tfstate
+*.tfstate.*.backup
 *.tfstate.backup
 
 # Module directory


### PR DESCRIPTION
**Reasons for making this change:**

To ignore backup files with UNIX timestamp, e.g., `terraform.tfstate.1502674938.backup`.

**Links to documentation supporting these rule changes:** 

* [Command: state mv - Terraform by HashiCorp](https://www.terraform.io/docs/commands/state/mv.html)
* [Command: state rm - Terraform by HashiCorp](https://www.terraform.io/docs/commands/state/rm.html)