### PR TITLE
Add QML and JS cache files to Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -26,6 +26,8 @@ moc_*.cpp
 moc_*.h
 qrc_*.cpp
 ui_*.h
+*.qmlc
+*.jsc
 Makefile*
 *build-*
 


### PR DESCRIPTION
**Reasons for making this change:**

Since Qt 5.8, code and data structures generated from `.qml` and `.js` files are cached in `.qmlc` and `.jsc` files. 

**Links to documentation supporting these rule changes:** 

Please refer to [the Qt 5.8 release notes](https://doc.qt.io/qt-5/whatsnew58.html) for more information.
