### PR TITLE
Add default file, README in libraries and translations in Drupal

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -1,10 +1,12 @@
 # Ignore configuration files that may contain sensitive information.
 sites/*/*settings*.php
+sites/example.sites.php
 
 # Ignore paths that contain generated content.
 files/
 sites/*/files
 sites/*/private
+sites/*/translations
 
 # Ignore default text files
 robots.txt
@@ -16,6 +18,7 @@ robots.txt
 /UPGRADE.txt
 /README.txt
 sites/README.txt
+sites/all/libraries/README.txt
 sites/all/modules/README.txt
 sites/all/themes/README.txt
 


### PR DESCRIPTION
- sites/example.sites.php
Configuration file for Drupal's multi-site directory aliasing feature. But its only example. To use this file, copy and rename it to "sites.php"
- sites/*/translations
This folder stores temporarily downloaded translations
- sites/all/libraries/README.txt
README file for libraries