### PR TITLE
Use desktop.ini instead of Desktop.ini

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -8,6 +8,7 @@ ehthumbs_vista.db
 
 # Folder config file
 Desktop.ini
+desktop.ini
 
 # Recycle Bin used on file shares
 $RECYCLE.BIN/


### PR DESCRIPTION
**Reasons for making this change:**

Some Windowses uses desktop.ini instead of Desktop.ini .

**Links to documentation supporting these rule changes:** 

https://ru.wikipedia.org/wiki/Desktop.ini

Translation:
> **d**esktop.ini is a configuration file that contains data on external systems of the system folder in Microsoft Windows operating system: icon, text color, wallpaper, etc.

If you visit it on English wiki you will be redirected to .INI page.