### PR TITLE
Updating Swift.gitignore with Package.resolved

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -37,6 +37,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
+# Package.resolved
 .build/
 
 # CocoaPods


### PR DESCRIPTION
**Reasons for making this change:**

As they say in in that implemented proposal: 

> This proposal makes the package manager's dependency resolution behavior clearer and more intuitive. It removes the pinning commands (swift package pin & swift package unpin), replaces the swift package fetch command with a new swift package resolve command with improved behavior, and replaces the optional Package.pins file with a Package.resolved file which is always created during dependency resolution.

`Package.resolved` is a new file that replaces the old `Package.pins` and will be added in Swift 4.0 release, but is already available for those that use Swift snapshots or Xcode 9 beta.

**Links to documentation supporting these rule changes:** 

- https://github.com/apple/swift-evolution/blob/master/proposals/0175-package-manager-revised-dependency-resolution.md#introduction
- https://github.com/apple/swift-evolution/blob/master/proposals/0175-package-manager-revised-dependency-resolution.md#proposed-solution
