### PR TITLE
update java.gitignore

### DIFF
--- a/java.gitignore
+++ b/java.gitignore
@@ -1,0 +1,16 @@
+
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+#maven
+/target/


### PR DESCRIPTION
Add the support for maven.

**Reasons for making this change:**

_Because Java web projects often use maven tools._


