### PR TITLE
added: intellij ide generated file and target folder

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -18,5 +18,12 @@
 *.tar.gz
 *.rar
 
+#IntelliJ Files
+.iml
+
+#Folders
+target
+
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/Java.gitignore
+++ b/Java.gitignore
@@ -19,7 +19,8 @@
 *.rar
 
 #IntelliJ Files
-.iml
+*.iml
+.idea
 
 #Folders
 target


### PR DESCRIPTION
.iml generated by intellij, also target folder is created after build and all its contents should be omitted.

**Reasons for making this change:**

When I created a java web Project on intellij, I have realised some files are not covered current java.gitignore file

**Links to documentation supporting these rule changes:** 

https://www.jetbrains.org/intellij/sdk/docs/basics/project_structure.html

