### PR TITLE
updated static and media files in django section

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -51,6 +51,8 @@ coverage.xml
 
 # Django stuff:
 *.log
+.static_storage/
+.media/
 local_settings.py
 
 # Flask stuff:


### PR DESCRIPTION
the media, and static_storage files is not needed while pushed the items in the git, it will increase the memory usage.