### PR TITLE
Nanoc: Ignore tmp/nanoc/, not tmp/

### DIFF
--- a/Nanoc.gitignore
+++ b/Nanoc.gitignore
@@ -4,7 +4,7 @@
 output/
 
 # Temporary file directory
-tmp/
+tmp/nanoc/
 
 # Crash Log
 crash.log


### PR DESCRIPTION
**Reasons for making this change:**

Nanoc stores its temporary data in `tmp/nanoc/` now, rather than `tmp/` as before.

**Links to documentation supporting these rule changes:** 

https://github.com/nanoc/nanoc/pull/1071:

> Temporary data is now stored in tmp/nanoc/ rather than tmp/, so that Nanoc can ± safely assume that anything in tmp/nanoc/ is 100% under control of Nanoc.