### PR TITLE
Node - update Compiled binary addons link to https

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -29,7 +29,7 @@ bower_components
 # node-waf configuration
 .lock-wscript
 
-# Compiled binary addons (http://nodejs.org/api/addons.html)
+# Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
 # Dependency directories


### PR DESCRIPTION
**Reasons for making this change:**

Save a redirect in Node.gitignore build/Release Compiled binary addons: http to https

**Links to documentation supporting these rule changes:** 

https://nodejs.org/api/addons.html

