### PR TITLE
Added MATLAB/Simulink gitignore

### DIFF
--- a/MathWorks.gitignore
+++ b/MathWorks.gitignore
@@ -1,0 +1,18 @@
+## Autosave files
+# Windows default autosave extension
+*.asv
+
+# OSX / *nix default autosave extension
+*.m~
+
+# MATLAB Version Model Backup
+*.slx.r20*
+*.mdl.r20*
+
+# Simulink autosave extension
+*.autosave
+
+## Compilation
+# Compiled MEX binaries (all platforms)
+slprj/
+*.mex*


### PR DESCRIPTION
**Reasons for making this change:**

MATLAB/Simulink are two highly used packages that many people use to develop things, and also use GitHub for source control, it would be a benefit to have a gitignore that has the temporary/compile/autosave MathWorks files in it and can be chosen up repo creation.

**Links to documentation supporting these rule changes:** 

http://nl.mathworks.com/help/simulink/ug/set-up-git-source-control.html

If this is a new template: 

mathworks.com
