### PR TITLE
Fix failure to ignore Simulink autosave files

### DIFF
--- a/Global/Matlab.gitignore
+++ b/Global/Matlab.gitignore
@@ -19,4 +19,4 @@ slprj/
 octave-workspace
 
 # Simulink autosave extension
-.autosave
+*.autosave


### PR DESCRIPTION
**Reasons for making this change:**

Name of autosave file generated by Simulink is formatted as `model_file_name.autosave`.  Therefore, an asterisk is needed to ignore such files.  `.autosave` is not enough.

**Links to documentation supporting these rule changes:** 
[Autosave Options](https://cn.mathworks.com/help/simulink/gui/simulink-preferences-model-file-pane.html#brtjhn8)

