### PR TITLE
Add VSCode in python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -100,3 +100,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**
IDE related files and folders are not part of a software repository

**Links to documentation supporting these rule changes:**
Visual Studio Code doc states that it makes a .vscode file on the workspace 
https://code.visualstudio.com/docs/getstarted/settings
