### PR TITLE
Update OCaml.gitignore

### DIFF
--- a/OCaml.gitignore
+++ b/OCaml.gitignore
@@ -18,3 +18,6 @@ _build/
 # oasis generated files
 setup.data
 setup.log
+
+# Merlin configuring file for Vim and Emacs
+.merlin


### PR DESCRIPTION
Merlin is a code completion for OCaml in Vim and Emacs.

**Reasons for making this change:**

 Such configuraing file is common.

**Links to documentation supporting these rule changes:** 

Referring to, https://github.com/ocaml/merlin

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
