### PR TITLE
Add cabal.project.local~ to Haskell.gitignore

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -17,5 +17,6 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
+cabal.project.local~
 .HTF/
 .ghc.environment.*


### PR DESCRIPTION
**Reasons for making this change:**

When using the `cabal` build tool, if one calls `cabal new-configure` and an existing `cabal.project.local` file exists in the current directory, it will be moved to `cabal.project.local~` as a backup before creating a fresh `cabal.project.local` to take its place. Just as we currently ignore `cabal.project.local`, we ought to ignore `cabal.project.local~`.

**Links to documentation supporting these rule changes:** 

[Documentation about `cabal.project.local`](https://github.com/haskell/cabal/blob/282eb213e6ce1ce8740b8120a422be4f3228c7bc/Cabal/doc/nix-local-build.rst#developing-multiple-packages)
