### PR TITLE
Update Autotools.gitignore

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -31,3 +31,12 @@ Makefile.in
 # http://www.gnu.org/software/texinfo
 
 /texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+autom4te.cache


### PR DESCRIPTION
**Reasons for making this change:**

add files generated by the autotool m4. It is common in open source projects, like google protobuf.

**Links to documentation supporting these rule changes:** 

http://www.gnu.org/software/m4/m4.html

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
