### PR TITLE
Add exclusion of Visual Studio trace files (*.e2e)

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -96,6 +96,9 @@ ipch/
 *.vspx
 *.sap
 
+# Visual Studio Trace Files
+*.e2e
+
 # TFS 2012 Local Workspace
 $tf/
 


### PR DESCRIPTION
Reason for change:
Exclude Visual Studio Trace files (*.e2e) as these are runtime generated files and not candidates for source control inclusion

Links to documentation supporting these rule changes:
https://docs.microsoft.com/en-us/dotnet/framework/wcf/service-trace-viewer-tool-svctraceviewer-exe

