### PR TITLE
Add Unity generated meta file for an already ignored debugging file

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -25,6 +25,7 @@ ExportedObj/
 
 # Unity3D generated meta files
 *.pidb.meta
+*.pdb.meta
 
 # Unity3D Generated File On Crash Reports
 sysinfo.txt


### PR DESCRIPTION
**Reasons for making this change:**

Unity generates and manages it's own `*.*.meta` metatdata files for every file and directory in a Unity project. These files must be added/removed/renamed along with their respective file/directory.

`*.pdb` files (generated by Visual Studio for debugging in Windows) were ignored in https://github.com/github/gitignore/pull/2240, but this did _not_ include their corresponding `*.pdb.meta` files.
    
Similarly, `*.pidb` _and_ their corresponding `*.pidb.meta` files were ignored in https://github.com/github/gitignore/pull/1319.

Without this, Unity will complain that `*.pdb.meta` files exist when a corresponding `*.pdb` does not exist and remove the offending `*.pdb.meta` files anyways. Committing these removals will cause them to be re-generated on the developers machine who has the `*.pdb` files. This causes unnecessary add/remove fighting in the codebase.

**Links to documentation supporting these rule changes:** 

[Visual Studio `*.pdb` debugging files](https://docs.unity3d.com/Manual/WindowsDebugging.html) 
[Unity `*.*.meta` metadata files](https://docs.unity3d.com/Manual/BehindtheScenes.html)
[Unity `*.*.meta` metadata files with respect to Version Control](https://docs.unity3d.com/Manual/ExternalVersionControlSystemSupport.html) 
