### PR TITLE
update gitignore for submodule inside assetfolder

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -32,3 +32,6 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
+
+#submodule
+/*.meta


### PR DESCRIPTION



**Reasons for making this change:**

im having problem when submodule - ing  another unity project on my project since i usually add it inside my asset folder
and with this addition it could ignore readme and license metas that unity autimatically create

**Links to documentation supporting these rule changes:** 

https://stackoverflow.com/questions/28853177/gitignore-files-in-parent-folder#28853251
