### PR TITLE
TeX.gitignore modification for Emacs users

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -215,7 +215,7 @@ TSWLatexianTemp*
 *~[0-9]*
 
 # auto folder when using emacs and auctex
-/auto/*
+./auto/*
 
 # expex forward references with \gathertags
 *-tags.tex

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -216,6 +216,7 @@ TSWLatexianTemp*
 
 # auto folder when using emacs and auctex
 ./auto/*
+*.el
 
 # expex forward references with \gathertags
 *-tags.tex


### PR DESCRIPTION
For Emacs users: currently the `auto` directory and Emacs-Lisp files `.el` are still considered for commits.

Two minor modifications have been made.

1. `/auto/*` changed to `./auto/*`: the latter ignores the `auto` directory.
2. additional line `*.el` that ensures all Emacs-Lisp files are ignored.