### PR TITLE
[Python gitignore] add .idea to gitignore;

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm IDE settings
+.idea


### PR DESCRIPTION
**Reasons for making this change:**

PyCharm IDE stores the project settings in set  of the xml files stored under the .idea directory;
As I am working - and probably not only me :) with PyCharm (which is one of the most popular IDE for python), adding this each time to the gitgnore file created from template is little bit irritating. 

**Links to documentation supporting these rule changes:** 

* [Official PyCharm IDE documentation](https://www.jetbrains.com/help/pycharm/project-and-ide-settings.html)

