### PR TITLE
Commenting out Android keystore files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -41,7 +41,8 @@ captures/
 .idea/libraries
 
 # Keystore files
-*.jks
+# Uncomment the following line if you do not want to check your keystore files in.
+#*.jks
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild


### PR DESCRIPTION
**Reasons for making this change:**

Android keystore files are critical and losing them is destructive.

They should be commented out by default, the user should explicitly uncomment their line if they intend not to include them into their repository.