### PR TITLE
ROS_gitignore - added logs and devel directories to .gitignore

### DIFF
--- a/ROS.gitignore
+++ b/ROS.gitignore
@@ -1,3 +1,5 @@
+devel/
+logs/
 build/
 bin/
 lib/


### PR DESCRIPTION
**Reasons for making this change:**

The **devel/** and **logs/** directories contain system specific paths and details, which can't be shared over github for the sake of security as well as code portability

**Links to documentation supporting these rule changes:** 

[Building and using catkin packages in a workspace](http://wiki.ros.org/catkin/Tutorials/using_a_workspace)

If this is a new template: 

 - **Link to application or project’s homepage**: [ROS wiki](http://wiki.ros.org/)
