### PR TITLE
[Visual Studio] Add ignore for Azure Stream Analytics local run output folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -303,3 +303,6 @@ __pycache__/
 
 # OpenCover UI analysis results
 OpenCover/
+
+# Azure Stream Analytics local run output 
+ASALocalRun/


### PR DESCRIPTION
**Reasons for making this change:**

When using visual studio with stream analytics facet, output folder was not ignored. 

**Links to documentation supporting these rule changes:** 

https://docs.microsoft.com/en-us/azure/stream-analytics/stream-analytics-tools-for-visual-studio
