### PR TITLE
Update Unity.gitignore - expanded functionality.

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -1,9 +1,9 @@
-/[Ll]ibrary/
-/[Tt]emp/
-/[Oo]bj/
-/[Bb]uild/
-/[Bb]uilds/
-/Assets/AssetStoreTools*
+*/[Ll]ibrary/
+*/[Tt]emp/
+*/[Oo]bj/
+*/[Bb]uild/
+*/[Bb]uilds/
+*/Assets/AssetStoreTools*
 
 # Visual Studio 2015 cache directory
 /.vs/


### PR DESCRIPTION
**Reasons for making this change:**

Prevents directories: 
`Library`
`Temp`
`Obj`
`Build`
`Builds`
`Assets/AssetStoreTools`
from being included in the remote if the project sits in the `Assets` folder.
The change doesn't change the current functionality.

**Links to documentation supporting these rule changes:** 
The issue came up in my recent professional project. https://github.com/matt360/TrashKittens

