### PR TITLE
Ignore Nuget package directory name casing

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -171,11 +171,11 @@ PublishScripts/
 # NuGet Packages
 *.nupkg
 # The packages folder can be ignored because of Package Restore
-**/packages/*
+**/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.
-!**/packages/build/
+!**/[Pp]ackages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
-#!**/packages/repositories.config
+#!**/[Pp]ackages/repositories.config
 # NuGet v3's project.json files produces more ignorable files
 *.nuget.props
 *.nuget.targets


### PR DESCRIPTION
It looks like VS2017 changed it's nuget package directory name to be capitalized.

If you are using Ubuntu for Windows as your git shell, directory names are case sensitive, and will be seen as changes by git.

Since it doesn't matter for Windows users, perhaps we can add this case ignoring to .gitignore.



