### PR TITLE
Windows.gitignore - Change desktop.ini to [Dd]esktop.ini

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -7,7 +7,7 @@ ehthumbs_vista.db
 *.stackdump
 
 # Folder config file
-Desktop.ini
+[Dd]esktop.ini
 
 # Recycle Bin used on file shares
 $RECYCLE.BIN/


### PR DESCRIPTION
**Reasons for making this change:**

Some Windowses uses **desktop.ini** instead of **Desktop.ini**.
This commit can close PR #2460 by @NeverMine17

**Links to documentation supporting these rule changes:** 

https://ru.wikipedia.org/wiki/Desktop.ini