### PR TITLE
Fix link to go to current anchor

### DIFF
--- a/Composer.gitignore
+++ b/Composer.gitignore
@@ -1,6 +1,6 @@
 composer.phar
 /vendor/
 
-# Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
+# Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock


### PR DESCRIPTION
**Reasons for making this change:**

Old link pointed to a non-existent anchor.