### PR TITLE
Update Terraform.gitignore

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -1,10 +1,9 @@
-# Compiled files
+#  Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
 *.tfstate
-*.tfstate.*.backup
-*.tfstate.backup
+*.tfstate.*
 
-# Module directory
-.terraform/
-
-# Variable values for development
-terraform.tfvars
+# .tfvars files
+*.tfvars


### PR DESCRIPTION
Improvements: 

 * `.terraform` directories could be created in any subdirectory when user runs `terraform init`.
 * Quite an interesting variations of`.tfstate` files are created by Terraform such as `.*.tfstate.d` or  `.*.tfstate.lock.info`. It's best not to name any file with `*.tfstate.*` pattern.
 * `*.tfvars` files often contain private data and not supposed to be committed.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
