### PR TITLE
Revert "Remove Composer's file and directory."

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -25,6 +25,7 @@
 /bin/*
 !bin/console
 !bin/symfony_requirements
+/vendor/
 
 # Assets and user uploads
 /web/bundles/
@@ -36,6 +37,9 @@
 
 # Build data
 /build/
+
+# Composer PHAR
+/composer.phar
 
 # Backup entities generated with doctrine:generate:entities command
 **/Entity/*~


### PR DESCRIPTION
This reverts commit 5b83681411d95d9302a3e0414efe82c6b4549d26.

**Reasons for making this change:**

Symfony is installed with Composer [1], ignores vendors in the standard distribution's gitignore [2], and it's generally recommended to avoid committing the vendor directory [3]. Although #2312 states the reason for removal (duplicate rules), in my opinion, it's better to include them here also since users pushing a new Symfony project are far more likely to select this gitignore over the Composer one, given the fact it has more relevant rules and that you cannot choose multiple gitignores in the UI when creating a new repo. Additionally, users new to Symfony and/or Composer might not even be aware that you shouldn't be committing vendor files (which can grow into 100s of MB in size).

**Links to documentation supporting these rule changes:** 

1. http://symfony.com/doc/master/setup.html
2. https://github.com/symfony/symfony-standard/blob/3.3/.gitignore#L16
3. https://getcomposer.org/doc/faqs/should-i-commit-the-dependencies-in-my-vendor-directory.md
