### PR TITLE
ignore the vendor folder created by dep

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# Vendor directory created by the official go dependency management tool
+vendor/


### PR DESCRIPTION
**Reasons for making this change:**

dep is the the official go dependency management tool and is becoming more and more popular. As it is generally not recommended to commit your vendor folder to git I though to add it here.

**Links to documentation supporting these rule changes:** 

https://github.com/golang/dep

