### PR TITLE
Ignore Visual Studio 2017 C++ app generated files.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -29,6 +29,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
**Reasons for making this change:**

A lot of generated files are pushed along with the commit. It clutters the repo unnecessarily.

**Links to documentation supporting these rule changes:** 

Launch Visual Studio 2017 then create either a blank app or DirectX 11 app (both C++) then build it as-is. Go to the project directory, then project name and see the "Generated Files" folder containing a lot of auto generated code.
