### PR TITLE
Ignore PyCharm files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea/


### PR DESCRIPTION


**Reasons for making this change:**

PyCharm is an JetBrains IDE for Python and creates an `.idea` folder that contains a bunch of XML files for the project. I don't want to upload these to GitHub so I'm proposing that this folder get added to the GitHub-wide Python `.gitignore`. It's possible that the `.idea/` folder shouldn't get bulk-ignored as JetBrains has their own [.gitignore](https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore) so that could be used instead.


**Links to documentation supporting these rule changes:** 

JetBrains also has their own [discussion](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems) about what should be ignored in JetBrains projects.
