### PR TITLE
Adds IntelliJ gitignore files

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -10,6 +10,12 @@
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 
+# IntelliJ files
+.idea/
+*.iml
+.DS_Store
+/target/
+
 # Package Files #
 *.jar
 *.war

--- a/Java.gitignore
+++ b/Java.gitignore
@@ -13,6 +13,8 @@
 # IntelliJ files
 .idea/
 *.iml
+*.iws
+*.ipr
 .DS_Store
 /target/
 


### PR DESCRIPTION
Reason for change: 
Constant usage of IntelliJ IDE to build software in Java

Links to documentation supporting these rule changes:
http://gary-rowe.com/agilestack/2012/10/12/a-gitignore-file-for-intellij-and-eclipse-with-maven/
