### PR TITLE
Add node_modules and yarn-error.log to Rails.gitignore

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -11,6 +11,7 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+node_modules/
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -12,6 +12,7 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 node_modules/
+yarn-error.log
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb


### PR DESCRIPTION
**Reasons for making this change:**

Rails 5.1 allows managing JavaScript dependencies from NPM via Yarn

**Links to documentation supporting these rule changes:** 

http://edgeguides.rubyonrails.org/5_1_release_notes.html