### PR TITLE
Create MATLAB.gitignore

### DIFF
--- a/MATLAB.gitignore
+++ b/MATLAB.gitignore
@@ -1,0 +1,13 @@
+# Ignore MATLAB autosave files.
+*.asv
+*.m~
+ 
+# Ignore prebuilt MEX files.
+*.mex*
+ 
+# Ignore prepackaged MATLAB app and toolbox files.
+*.mlappinstall
+*.mltbx
+ 
+# Ignore pregenerated helpsearch folders.
+*helpsearch*


### PR DESCRIPTION
Added a gitignore file for MATLAB, ignoring MATLAB autosave files, prebuilt MEX files, prepackaged MATLAB app and toolbox files, and pregenerated helpsearch folders.

**Reasons for making this change:**

Ignore files that are commonly associated with MATLAB projects, but that are typically not intended to be committed as source code; either because they are temporary files, or because they are the output of a build process.

**Links to documentation supporting these rule changes:** 

MATLAB autosave files:
https://uk.mathworks.com/help/matlab/matlab_env/about-editor-debugger-preferences.html#bs237bq-13

MATLAB autosave files are by default saved by MATLAB every 5 minutes. By default they have an extension either `.asv` or `.m~`. Typically a developer will want to exclude these from being committed along with the main source code of their project.

MEX files:
https://uk.mathworks.com/help/matlab/matlab_external/using-mex-files.html

MEX files are files produced from C/C++ or FORTRAN source code, that can be called directly from MATLAB. Typically a developer will want to commit the C/C++/FORTRAN source code, but not the produced MEX artefact. MEX files have an extension `.mexa64`, `.mexmaci64` or `.mexw64` depending on the platform.

MATLAB app and toolbox files:
https://uk.mathworks.com/help/matlab/creating_guis/what-is-an-app.html
https://uk.mathworks.com/help/matlab/matlab_prog/create-and-share-custom-matlab-toolboxes.html

It is possible to package MATLAB UI application source code into an "app" file, and MATLAB source code into a "toolbox" file. These files are produced using a build process from within MATLAB. Typically a developer will want to commit the source code, but not the packaged app/toolbox file. These files have extension `.mlappinstall` and `.mltbx`.

helpsearch folders:
https://uk.mathworks.com/help/matlab/ref/builddocsearchdb.html?s_tid=doc_ta

Before packaging source code that has documentation, it is possible for MATLAB to produce a "helpsearch" folder, containing information that enables the documentation to be searched from within the MATLAB help system. Typically a developer will want to commit the documentation files themselves, but will regard the search folder as a build artefact that is generated immediately before packaging.

**Link to application or project’s homepage**: 
https://uk.mathworks.com/products/matlab.html