### PR TITLE
Add @std/esm ESM module cache

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# Standard Things ESM modules cache (https://github.com/standard-things/esm)
+.esm-cache


### PR DESCRIPTION
**Reasons for making this change:**

`@std/esm` is starting to be widely adopted to support ESM Modules, it creates a `.esm-cache` folder with the compiled Javscript files. 

**Links to documentation supporting these rule changes:** 

https://github.com/standard-things/esm

CC: @jdalton Author of `@std/esm`