### PR TITLE
ignore xcuserdata

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -3,7 +3,7 @@
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
 ## User settings
-xcuserdata/
+xcuserdata/*
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint


### PR DESCRIPTION
Now it ignores xcuserdata

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
