### PR TITLE
[Gradle] Ignore sub-modules "build" directories

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
Little change to ignore all /build/, in root and in sub-modules directories.

**Reasons for making this change:**

Currently builds directories sub modules are not ignored

**Links to documentation supporting these rule changes:** 

N/A

