### PR TITLE
Ignore node_modules

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -42,3 +42,7 @@ bower.json
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Ignore node_modules
+node_modules/
+


### PR DESCRIPTION
Rails 5 uses npm to handle javascript dependancies, node_modules should not be checked in to git.


http://guides.rubyonrails.org/5_1_release_notes.html#yarn-support

