### PR TITLE
Adds ignore for Pycharm (JetBrains IDE) projects

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -90,6 +90,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Pycharm (JetBrains IDE) project settings
+.idea/
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
**Reasons for making this change:**

JetBrains IDE products store project settings in the ".idea/" directory and this should be ignored.

**Links to documentation supporting these rule changes:** 

Under the "Project Settings" section located at: https://www.jetbrains.com/help/idea/project-and-ide-settings.html

If this is a new template: 

No new template, uses the existing Python gitignore file.
