### PR TITLE
Update Jekyll.gitignore

### DIFF
--- a/Jekyll.gitignore
+++ b/Jekyll.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
+.jekyll-cache/
 .jekyll-metadata


### PR DESCRIPTION
**Reasons for making this change:**

Add .jekyll-cache/ as per https://github.com/envygeeks/jekyll-assets

**Links to documentation supporting these rule changes:** 