### PR TITLE
Add .gitignore for FreePascal (http://www.freepascal.org) and Lazarus…

### DIFF
--- a/FPCLazarus.gitignore
+++ b/FPCLazarus.gitignore
@@ -1,0 +1,12 @@
+# Binary and generated files and directories.
+backup
+lib
+# Standard unneeded file types.
+# See http://wiki.freepascal.org/file_types
+*.lps
+*.compiled
+*.o
+*.or
+*.ppu
+*.res
+*.exe


### PR DESCRIPTION
**Reasons for making this change:**

Currently missing.

**Links to documentation supporting these rule changes:** 

http://wiki.freepascal.org/file_types

**Link to application or project’s homepage**: 

http://www.freepascal.org
http://www.lazarus-ide.org
