### PR TITLE
Added Godot gitignore (https://godotengine.org/)

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,0 +1,3 @@
+.import/
+.mono/
+export_presets.cfg


### PR DESCRIPTION
**Reasons for making this change:**

Godot Engine is becoming a major game engine in game development industry, and in preparation for the next major release, Godot Engine 3.0, I've prepared this .gitignore in order to make it easy for new projects to start with a template that will ignore automatic generated files, such as `.import` ones which will be generated as soon as a compatible file, such as a `.png`, is added to the project. 

Also since Godot now supports C# by using Mono, I added the `.mono` directory.

**Links to documentation supporting these rule changes:** 

You can check how Godot Engine handles the import process in the [official documentation](http://docs.godotengine.org/en/latest/learning/workflow/assets/import_process.html?highlight=import).

If this is a new template: 

 Godot has a [github repository](https://github.com/godotengine/godot) with more than 10.000 stars and over 2.500 forks and an [official homepage](https://godotengine.org/) with contents being updated frequently.
