### PR TITLE
added kirby.gitignore

### DIFF
--- a/kirby.gitignore
+++ b/kirby.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+/scripts
+/site/accounts
+/site/cache
+/thumbs
+/site/config/config.dev.getkirby.com.php
+/site/config/config.algolia.php
+/update
+/node_modules
+/kits


### PR DESCRIPTION
gitignore file for kirby cms (https://github.com/getkirby/getkirby.com)

**Reasons for making this change:**

it would be nice to have kirby in this list


