### PR TITLE
ignore MSBuild Binary and Structured Log

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -313,3 +313,7 @@ OpenCover/
 
 # Azure Stream Analytics local run output 
 ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+


### PR DESCRIPTION
msbuild 15 added a `/bl` argument to generate a binary log.
these can be viewed with http://msbuildlog.com/ or inside visual studio 2017
