### PR TITLE
Create Pawn.gitignore

### DIFF
--- a/Pawn.gitignore
+++ b/Pawn.gitignore
@@ -1,0 +1,8 @@
+# Compiled Bytecode
+*.amx
+
+# Vendor directory for dependencies
+dependencies/
+
+# Dependency versions lockfile
+pawn.lock

--- a/Pawn.gitignore
+++ b/Pawn.gitignore
@@ -1,5 +1,11 @@
-# Compiled Bytecode
+#
+# Pawn Package Files
+#
+
+# Compiled Bytecode, precompiled output and assembly
 *.amx
+*.lst
+*.asm
 
 # Vendor directory for dependencies
 dependencies/


### PR DESCRIPTION
**Reasons for making this change:**

Rules for the popular scripting language, Pawn which is in use by the San Andreas Multiplayer open source community. This language also has a package manager called sampctl which also has a few non-repo metadata files.

This contains rules for:

- compiled `.amx` files
- `dependencies/` directory - where vendored dependencies are stored for package management
- `pawn.lock` file which contains a cache of a flattened dependency tree

**Links to documentation supporting these rule changes:** 

- The original compiler: https://www.compuphase.com/pawn/pawn.htm
- SA:MP community compiler: https://github.com/Zeex/pawn
- sampctl documentation: https://github.com/Southclaws/sampctl/wiki

If this is a new template: 

 - **Link to application or project’s homepage**:

- SA:MP: http://sa-mp.com and http://wiki.sa-mp.com
- Current community compiler docs: https://github.com/Zeex/pawn/wiki
