### PR TITLE
Adding helm gitignore to ignore compressed packages

### DIFF
--- a/Helm.gitignore
+++ b/Helm.gitignore
@@ -1,0 +1,2 @@
+#ignore packages
+**/.tgz


### PR DESCRIPTION
**Reasons for making this change:**

Added helm gitignore to ignore compressed packages after dependency build or dependency update

**Links to documentation supporting these rule changes:** 

https://docs.helm.sh/developing_charts/#syncing-your-chart-repository contains working of charts. When we do depency build or dependency update it will download charts as packages in format .tgz which are not needed to be included in source code.


If this is a new template: 

 - https://helm.sh/
