### PR TITLE
Add "cmake-build-release/" to Jetbrains.gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -21,6 +21,7 @@
 
 # CMake
 cmake-build-debug/
+cmake-build-release/
 
 # Mongo Explorer plugin:
 .idea/**/mongoSettings.xml


### PR DESCRIPTION
**Reasons for making this change:**

Release build should also be ignored

**Links to documentation supporting these rule changes:** 

https://intellij-support.jetbrains.com/hc/en-us/community/posts/205976564--2016-3-CLion-multiple-configurations
