### PR TITLE
Added Must Use Plugins to gitignore

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -7,6 +7,7 @@ wp-content/blogs.dir/
 wp-content/cache/
 wp-content/upgrade/
 wp-content/uploads/
+wp-content/mu-plugins/
 wp-content/wp-cache-config.php
 wp-content/plugins/hello.php
 


### PR DESCRIPTION
https://codex.wordpress.org/Must_Use_Plugins

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
