### PR TITLE
Added a few common CAM file extensions

### DIFF
--- a/Eagle.gitignore
+++ b/Eagle.gitignore
@@ -4,6 +4,9 @@
 *.s#?
 *.b#?
 *.l#?
+*.b$?
+*.s$?
+*.l$?
 
 # Eagle project file
 # It contains a serial number and references to the file structure
@@ -31,9 +34,15 @@ eagle.epf
 *.drl
 *.gpi
 *.pls
+*.ger
+*.gpi
+*.xln
 
 *.drd
 *.drd.*
+
+*.s#*
+*.b#*
 
 *.info
 
@@ -41,4 +50,3 @@ eagle.epf
 
 # file locks introduced since 7.x
 *.lck
-


### PR DESCRIPTION
**Reasons for making this change:**

These are common gerber file extensions that should be covered by this gitignore as it already ignores other gerber extensions.

**Links to documentation supporting these rule changes:** 

https://github.com/OSHPark/OSHPark-Eagle-Tools/blob/master/cam/oshpark-2layer.cam
