### PR TITLE
Update Eclipse.gitignore

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -10,6 +10,7 @@ local.properties
 .settings/
 .loadpath
 .recommenders
+.project
 
 # External tool builders
 .externalToolBuilders/
@@ -22,6 +23,9 @@ local.properties
 
 # CDT-specific (C/C++ Development Tooling)
 .cproject
+
+# CDT- autotools 
+.autotools
 
 # Java annotation processor (APT)
 .factorypath

--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -10,7 +10,6 @@ local.properties
 .settings/
 .loadpath
 .recommenders
-.project
 
 # External tool builders
 .externalToolBuilders/


### PR DESCRIPTION
**Reasons for making this change:**

adding more eclipse files to ignore list, i have those files in many projects

**Links to documentation supporting these rule changes:** 
search for .autotools in https://wiki.eclipse.org/Linux_Tools_Project/Autotools/User_Guide

If this is a new template: 

no
