### PR TITLE
ignore vscode filefolder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**
VSCODE is becoming a major editor in python development.

**Links to documentation supporting these rule changes:** 

[https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore](https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore)

If this is a new template: 

 - **Link to application or project’s homepage**: [https://code.visualstudio.com/](https://code.visualstudio.com/)
