### PR TITLE
Go: Add '*.exe~' to .gitignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -1,5 +1,6 @@
 # Binaries for programs and plugins
 *.exe
+*.exe~
 *.dll
 *.so
 *.dylib


### PR DESCRIPTION
**Reasons for making this change:**

When you build a Go executable, which does already exists and is in use on Windows (e.g. running) then the output binary name will be extended by a '~' prefix.

**Links to documentation supporting these rule changes:** 

https://github.com/golang/go/blob/558eeb2d850d064b0b02b65a7bf3af6c108c248d/src/cmd/go/internal/work/exec.go#L1165-L1170