### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# next.js build output
+.next


### PR DESCRIPTION
**Reasons for making this change:**

`.next` directories contain the build artifacts for a next.js deployment and should not be placed in version control

**Links to documentation supporting these rule changes:** 

[next.js `.next` build for production](https://github.com/zeit/next.js#production-deployment)
