### PR TITLE
New template file for Backup file formats

### DIFF
--- a/Global/Backup.gitignore
+++ b/Global/Backup.gitignore
@@ -1,0 +1,4 @@
+*.bak
+*.gho
+*.ori
+*.tmp


### PR DESCRIPTION
**Reasons for making this change:**
There is no template to exclude backup files from a project. The closest I have seen
is the `Archives.gitignore` file but this does not cover backup file formats. 

**Links to documentation supporting these rule changes:** 
In this file I have included four backup formats. You can click on each format to
view the supporting documentation for each file format and why I believe they
should be included in this file.

- [.ori][1]
- [.tmp][2]
- [.gho][3]
- [.bak][4]

[1]: https://fileinfo.com/extension/ori
[2]: https://fileinfo.com/extension/tmp
[3]: https://fileinfo.com/extension/gho
[4]: https://fileinfo.com/extension/bak