### PR TITLE
New Template file for Iconic3

### DIFF
--- a/Ionic3.gitignore
+++ b/Ionic3.gitignore
@@ -1,0 +1,58 @@
+# Log and tmp data
+*~
+*.sw[mnpcod]
+*.log
+*.lock
+*.tmp
+*.tmp.*
+log.txt
+
+# NPM (Node Package Manager) files
+npm-debug.log*
+node_modules/
+tmp/
+temp/
+.package.tmp.json
+
+# Preprocessors cache files
+.idea/
+.sourcemaps/
+.vscode/
+.sass-cache/
+.versions/
+coverage/
+dist/
+.tmp/
+hooks/
+
+# Ionic 3 plugins files
+platforms/
+plugins/
+plugins/android.json
+plugins/ios.json
+www/
+
+# Trash data
+$RECYCLE.BIN/
+.DS_Store
+Thumbs.db
+.env
+UserInterfaceState.xcuserstate
+
+# source files
+src/themes/version.scss
+scripts/e2e/webpackEntryPoints.json
+scripts/build/e2e-generated-tsconfig.json
+*.css.ts
+
+# demo files
+demos/node_modules
+demos/polyfills
+demos/css
+demos/fonts
+demos/src/**/*.js
+demos/src/**/*.map
+demos/src/**/*.ngfactory.ts
+demos/src/**/*.d.ts
+demos/src/**/*.metadata.json
+demos/src/**/*.css.shim.ts


### PR DESCRIPTION
**Reasons for making this change:**
There is currently no template file for Iconic3 and this file aims to change that.

**Links to documentation supporting these rule changes:** 
Ionic have a pre-defined `.gitignore` file which formed the basis for this template. You can view the file [over here][2]. I have added extra items to the default Ionic3 files.

If this is a new template:  
- **Link to application or project's homepage**: [Iconic3 Framework][1]

[1]: https://ionicframework.com
[2]: https://github.com/ionic-team/ionic/blob/master/.gitignore