### PR TITLE
Visual Studio 2017 puts the name of the project after Release and Debug

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -13,16 +13,18 @@
 *.userprefs
 
 # Build results
-[Dd]ebug/
-[Dd]ebugPublic/
-[Rr]elease/
-[Rr]eleases/
+[Dd]ebug*/
+[Dd]ebugPublic*/
+[Rr]elease*/
+[Rr]eleases*/
 x64/
 x86/
 bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+*.lib
+*.exp
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
Ran into this while building the Darkplaces Quake engine in Visual Studio 2017 Community.