### PR TITLE
Remove unreasonable ignores for Python/Django

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -52,8 +52,6 @@ coverage.xml
 
 # Django stuff:
 *.log
-.static_storage/
-.media/
 local_settings.py
 
 # Flask stuff:


### PR DESCRIPTION
This is a pull request to revert #2464 . Two ignores that are neither Python-specific nor Django-specific are removed:
- .static_storage
- .media

**Reasons for making this change:**

The paths of [static folder](https://docs.djangoproject.com/en/2.0/ref/settings/#std:setting-STATIC_ROOT) and [media folder](https://docs.djangoproject.com/en/2.0/ref/settings/#std:setting-MEDIA_ROOT) are actually personal preferences and the ones added in #2464 are neither Django's default nor something suggested/illustrated in Django's documentation/[tutorial](https://docs.djangoproject.com/en/2.0/howto/static-files/). In fact, Django does not provide default values for these two paths.

There are other reasons these two paths shall not be included in the gitignore:
1. Both folders are not necessary to be included in the project folder since files in both folders are not served by Django itself but instead a web server.
2. Depending on deployment environment, Django may have permission problems in automatically creating these two folders. In case these folders are decided to be located in the project folder, include both folders in git repository, with ideal permission modes set, is often a simple way to prevent the folder creation problem.

**Links to documentation supporting these rule changes:** 

Django's documentation about settings of static folder and media folder:
- [static folder](https://docs.djangoproject.com/en/2.0/ref/settings/#std:setting-STATIC_ROOT)
- [media folder](https://docs.djangoproject.com/en/2.0/ref/settings/#std:setting-MEDIA_ROOT)