### PR TITLE
Update TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -10,6 +10,7 @@
 *.fot
 *.cb
 *.cb2
+.*.lb
 
 ## Intermediate documents:
 *.dvi


### PR DESCRIPTION
Added a temporary file used in MacTeX

**Reasons for making this change:**

This is a temp file that always gets created when compiling tex files using in my installation of MacTeX (for a while now). I have checked and the same temp file does not appear in Windows or Linux.

**Links to documentation supporting these rule changes:** 

I have not found any documentation describing this file, but it does get created in my installation.

If this is a new template: 

 - **Link to application or project’s homepage**:  https://www.tug.org/mactex/