### PR TITLE
Add rptproj.rptuser

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -247,6 +247,7 @@ UpgradeLog*.htm
 *.rdl.data
 *.bim.layout
 *.bim_*.settings
+*.rptproj.rsuser
 
 # Microsoft Fakes
 FakesAssemblies/


### PR DESCRIPTION
**Reasons for making this change:**

The VS 2017 version of the Business Intelligence project contains a user file (*.rptproj.rptuser) that should be ignored as well.  This file is generated by the "Microsoft Reporting Services Projects" extension for visual studio.  https://marketplace.visualstudio.com/items?itemName=ProBITools.MicrosoftReportProjectsforVisualStudio

This was discussed on Stack Overflow (I wasn't involved), but this change was never requested.  https://stackoverflow.com/questions/47076716/which-reporting-services-file-types-are-safe-to-ignore-on-git


