### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -173,7 +173,7 @@ publish/
 # Microsoft Azure Web App publish settings. Comment the next line if you want to
 # checkin your Azure Web App publish settings, but sensitive information contained
 # in these scripts will be unencrypted
-PublishScripts/
+PublishProfiles/
 
 # NuGet Packages
 *.nupkg


### PR DESCRIPTION
**Reasons for making this change:**

The actual name of the folder which contains publish profiles is "PublishProfiles"

**Links to documentation supporting these rule changes:** 

I don't have any documentation to link to, but I've confirmed this is the case with Visual Studio 2017
