### PR TITLE
Solidity/Truffle .gitignore

### DIFF
--- a/SolidityTruffle.gitignore
+++ b/SolidityTruffle.gitignore
@@ -1,0 +1,24 @@
+# depedencies
+node_modules
+
+# testing
+coverage
+
+# production
+build
+build_webpack
+
+# misc
+.DS_Store
+.env
+npm-debug.log
+.truffle-solidity-loader
+.vagrant/**
+blockchain/geth/**
+blockchain/keystore/**
+blockchain/history
+
+#truffle
+.tern-port
+yarn.lock
+package-lock.json


### PR DESCRIPTION
**Reasons for making this change:**
There was no suggested file for either Truffle or Solidity. The added file is a standart .gitignore that helps a lot.

**Links to documentation supporting these rule changes:** 

There is no official documentation supporting these gitignore files, they are what I've been using, based on official projects that use the same technology:

https://github.com/ethereum/go-ethereum/blob/master/.gitignore
https://github.com/ethereum/node-ethereum/blob/master/.gitignore

If this is a new template: 

 - **Link to application or project’s homepage**: 
https://github.com/trufflesuite/truffle
https://github.com/ethereum
