### PR TITLE
Global/XilinxISE.gitignore: + Commenting *.ngc files to track compiled cores. +adding *.vhi, *.lo…

### DIFF
--- a/Global/XilinxISE.gitignore
+++ b/Global/XilinxISE.gitignore
@@ -9,7 +9,6 @@
 *.msd
 *.msk
 *.ncd
-*.ngc
 *.ngd
 *.ngr
 *.pad
@@ -27,6 +26,8 @@
 *.ut
 *.xpi
 *.xst
+*.log
+*.vhi
 *_bitgen.xwbt
 *_envsettings.html
 *_map.map
@@ -41,6 +42,9 @@
 *_summary.xml
 *_usage.xml
 *_xst.xrpt
+
+# un-comment if you don't use compiled cores 
+#*.ngc
 
 # iMPACT generated files
 _impactbatch.log
@@ -65,3 +69,9 @@ xlnx_auto_0_xdb/
 xst/
 _ngo/
 _xmsgs/
+work/
+
+#ignore OS noise
+
+Thumbs.db
+.DS_Store


### PR DESCRIPTION
…g and work directory, ignoring some OS fies

**Reasons for making this change:**
by ignoring *.ngc files compiled cores are ignored, which they are used in lots of FPGA projects.
*.log and *.vhi files/work directory may also be ignored. 

**Links to documentation supporting these rule changes:** 
-for *.ngc files: [CORE Generator Output Files](https://www.xilinx.com/support/documentation/sw_manuals/xilinx11/cgn_r_core_generator_output_files.htm#styler-id1.1.1.6.6.9.14.34.3.6.1)
- No documentation i can find for *.vhi files, but they exist in some my projects, noting lost by ignoring them in tests.
- Log files always my be ignored. same for OS junk files.

