### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -1,8 +1,8 @@
-[Ll]ibrary/
-[Tt]emp/
-[Oo]bj/
-[Bb]uild/
-[Bb]uilds/
+/[Ll]ibrary/
+/[Tt]emp/
+/[Oo]bj/
+/[Bb]uild/
+/[Bb]uilds/
 Assets/AssetStoreTools*
 
 # Visual Studio 2015 cache directory


### PR DESCRIPTION
"Unity3D is a powerful cross-platform 3D engine and a user friendly development environment. Easy enough for the beginner and powerful enough for the expert;" 

"user friendly",  "beginner" case in point; having files not be committed because they have no knowledge that they are not supposed to name their folders  "library" or "build"  inside unity is not cool. There are plenty of example libraries that break for this reason and give needless headaches.

The point of a default should be to only care about the important case, ie the magic folders that Unity creates and leave all other folders alone.
