### PR TITLE
Added "ServiceFabricBackup/"

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -237,6 +237,7 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
+ServiceFabricBackup/
 
 # SQL Server files
 *.mdf


### PR DESCRIPTION
**Reasons for making this change:**

The latest update of Visual Studio 17 (15.5.5) introduces a new backup folder called "ServiceFabricBackup" before upgrading service fabric applications.
