### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pytest
+.pytest_cache/


### PR DESCRIPTION
pytest generates a .pytest_cache/ directory in the working directory where it is run. It was generated by a test failure when trying to import a module that didn't exist.

**Links to documentation supporting these rule changes:** 

I couldn't find any documentation about this.
 
 - **Link to application or project’s homepage**:  [pytest home page](https://docs.pytest.org)
 