### PR TITLE
Add ignore '.pytest_cache' directory in Unit test section

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
**Reasons for making this change:**

It added support to the specifications of the modified cache directory in the unit test tool pytest 3.4.0.

And I also saw #2591 discussion.

**Links to documentation supporting these rule changes:** 

See also: [Pytest Changelog history](https://docs.pytest.org/en/latest/changelog.html)

> The default cache directory has been renamed from `.cache` to `.pytest_cache` after community feedback that the name `.cache` did not make it clear that it was used by pytest.
