### PR TITLE
Fixes  WebStorm capitalization in comment

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,4 +1,4 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff:


### PR DESCRIPTION
On line 1, WebStorm is capitalized the same way as the other IDE names.

**Reasons for making this change:**

Consistent capitalization in comment

**Links to documentation supporting these rule changes:** 



If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
