### PR TITLE
.idea/**/datasources.xml is now safe to store

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -9,7 +9,6 @@
 # Sensitive or high-churn files:
 .idea/**/dataSources/
 .idea/**/dataSources.ids
-.idea/**/dataSources.xml
 .idea/**/dataSources.local.xml
 .idea/**/sqlDataSources.xml
 .idea/**/dynamic.xml


### PR DESCRIPTION
**Reasons for making this change:**

Since IDEA 14 (2014), IDEA and other contemporaneous JebBrains IDEs don't store sensitive info in `datasources.xml` and it makes sense to version control `datasources.xml` for sharing project data sources among a team. `dataSources.local.xml` is user-specific: contain usernames and could be sensitive from a security perspective, albeit passwords could be externalized to e.g. Mac Keychain.

**Links to documentation supporting these rule changes:** 

References: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839, https://youtrack.jetbrains.com/issue/IDEA-127105