### PR TITLE
*.pyc files are ignored

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.pyc
 
 # C extensions
 *.so


### PR DESCRIPTION
By default, the .pyc files are ignored and are not visible in the Project Window (IDE).

**Reasons for making this change:**

 "*.pyc" files are ignored by Python interpreter

**Links to documentation supporting these rule changes:** 

https://www.jetbrains.com/help/pycharm/cleaning-pyc-files.html

If this is a new template: 

 - **Link to application or project’s homepage**: No Support
