### PR TITLE
Added missing entries included by the dotnet/core project as well as …

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -53,6 +53,13 @@ project.lock.json
 project.fragment.lock.json
 artifacts/
 **/Properties/launchSettings.json
+.DS_Store
+*.swp
+*.*~
+
+
+# Visual Studio Code
+.vscode
 
 # StyleCop
 StyleCopReport.xml


### PR DESCRIPTION
….DS_Store for Mac development.

**Reasons for making this change:**

dotnet/core includes a few extra entries. Include this as well.

Visual Studio development on a Mac is becoming more popular. Ignore .DS_Store.

**Links to documentation supporting these rule changes:** 

https://github.com/dotnet/core/blob/master/.gitignore
