### PR TITLE
Qt: typo fix and extra empty lines removal

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -35,9 +35,9 @@ target_wrapper.*
 # QtCreator
 *.autosave
 
-# QtCtreator Qml
+# QtCreator Qml
 *.qmlproject.user
 *.qmlproject.user.*
 
-# QtCtreator CMake
+# QtCreator CMake
 CMakeLists.txt.user*

--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -1,5 +1,4 @@
 # C++ objects and libs
-
 *.slo
 *.lo
 *.o
@@ -11,7 +10,6 @@
 *.dylib
 
 # Qt-es
-
 object_script.*.Release
 object_script.*.Debug
 *_plugin_import.cpp
@@ -35,7 +33,6 @@ Makefile*
 target_wrapper.*
 
 # QtCreator
-
 *.autosave
 
 # QtCtreator Qml
@@ -44,4 +41,3 @@ target_wrapper.*
 
 # QtCtreator CMake
 CMakeLists.txt.user*
-


### PR DESCRIPTION
**Reasons for making this change:**

6d6dce75f8ec06bcd18e6fbceb9c2278a32f23a8: To keep consistency with other files in the repository, which all appear to have a single empty line at the end of them and no empty lines under comments.

1bee1a16dcfa60097115eac1dfce82b22fbd0645: The name of the program is **Qt Creator**.