### PR TITLE
Added .gitignore for 1C external data processors on unmanaged formes

### DIFF
--- a/1C.gitignore
+++ b/1C.gitignore
@@ -1,0 +1,6 @@
+# 1C external data processors on unmanaged formes
+
+**/Form/**/form
+src/**/und/*
+src/**/maps.txt
+src/**/renames.txt


### PR DESCRIPTION

This is a gitignore file for 1C external data processors on unmanaged formes versioned with [precommit1c](https://github.com/xDrivenDevelopment/precommit1c) git hook 