### PR TITLE
Exclude secret deployment key in rsconnect/

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -31,3 +31,6 @@ vignettes/*.pdf
 # Temporary files created by R markdown
 *.utf8.md
 *.knit.md
+
+# Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
+rsconnect/


### PR DESCRIPTION
Exclude secret deployment key in rsconnect/, see https://shiny.rstudio.com/articles/shinyapps.html for details.

**Reasons for making this change:**

Shiny deployment keys are specific to each user.  Sharing your key will allow others to alter or delete your Shiny application(s) on the Shiny server associated w/your project.

**Links to documentation supporting these rule changes:** 

https://shiny.rstudio.com/articles/shinyapps.html for details.

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
