### PR TITLE
FIRST Robotics Competition .gitignore

### DIFF
--- a/FRC.gitignore
+++ b/FRC.gitignore
@@ -1,0 +1,40 @@
+# WPILib
+bin/
+build/
+dist/
+sysProps.xml
+workbench.xmi
+
+# IDE
+*.ipr
+*.iml
+*.iws
+out/
+tmp/
+.settings/
+.loadpath
+.project
+/.idea
+.classpath
+
+# Toast/GradleRIO
+run/
+.gradle/
+gradle/.launch/
+
+# OS Files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.AppleDouble
+.LSOverride
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# backup files
+*~
+
+# directory for XML generated after running junit tests through ant
+junit/


### PR DESCRIPTION


**Reasons for making this change:**

Support FIRST Robotics Competition Teams that use GitHub for version control. (Java and CPP - LabVIEW already has a supported GitIgnore - https://github.com/github/gitignore/blob/master/LabVIEW.gitignore)

Teams need a fast way to create a gitignore that is project agnostic and a quick reference during project creation.

**Links to documentation supporting these rule changes:** 
https://github.com/github/gitignore/blob/master/Java.gitignore - Includes the contents of the /bin folder


If this is a new template: 

 - **Link to application or project’s homepage**: https://www.firstinspires.org/robotics/frc/ 
