### PR TITLE
add yarn.lock

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -59,3 +59,7 @@ typings/
 
 # next.js build output
 .next
+
+# yarn lock file
+yarn.lock
+


### PR DESCRIPTION
**Reasons for making this change:**

yarn.lock file is auto generated file, we don't need to put it in the git repository

**Links to documentation supporting these rule changes:** 

The comment in the yarn.lock file said it is autogenerated

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
