### PR TITLE
Remove typings ignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -259,9 +259,6 @@ FakesAssemblies/
 .ntvs_analysis.dat
 node_modules/
 
-# TypeScript v1 declaration files
-typings/
-
 # Visual Studio 6 build log
 *.plg
 


### PR DESCRIPTION
Nobody is using v1 of typings anymore on new projects and 'typings' is the recommended name for the folders of your custom types.
On the other hand the official Visual Studio ignore is not ignoring this folder.
