### PR TITLE
Joomla: don't ignore .gitignore

### DIFF
--- a/Joomla.gitignore
+++ b/Joomla.gitignore
@@ -1,4 +1,3 @@
-/.gitignore
 /.htaccess
 /administrator/cache/*
 /administrator/components/com_admin/*


### PR DESCRIPTION
Root .gitignore files should generally be checked in.
