### PR TITLE
Add {prod, dev, whatever_enviroment}.secret.exs in Elixir/Phoenix

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -6,3 +6,4 @@
 erl_crash.dump
 *.ez
 *.beam
+/config/*.secret.exs


### PR DESCRIPTION
**Reasons for making this change:**

The config/prod.secret.exs file by default contains sensitive data and you should not commit it into version control. But can exist other configurations in the development environment that should not be shared like every developer database configuration because could be annoying to the rest of the team

**Links to documentation supporting these rule changes:** 

Phoenix documentation site [Link](https://hexdocs.pm/phoenix/deployment.html#handling-of-your-application-secrets)