### PR TITLE
Ignored default sqlite database of Django

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -56,6 +56,7 @@ coverage.xml
 .static_storage/
 .media/
 local_settings.py
+db.sqlite3
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
**Reasons for making this change:**
Ignore default SQLite database created by Django framework for development and test purposes.

**Links to documentation supporting these rule changes:** 
* Supporting that file name is correct: https://docs.djangoproject.com/en/2.0/intro/tutorial02/#database-setup
* Supporting that this file should be ignored: https://devcenter.heroku.com/articles/gitignore

If this is a new template: 

 - **Link to application or project’s homepage**: _Not a new template_
