### PR TITLE
Create Godot.gitignore

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,0 +1,12 @@
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Mono-specific ignores
+.mono/
+
+# System/tool-specific ignores
+.directory
+*~

--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -6,7 +6,3 @@ export_presets.cfg
 
 # Mono-specific ignores
 .mono/
-
-# System/tool-specific ignores
-.directory
-*~


### PR DESCRIPTION
A simple .gitignore for the Godot game engine.


 - **Project’s homepage**: [The Godot Engine](www.godotengine.org)
 - **Template**: [.gitignore example from godot demo project.](https://github.com/godotengine/godot-demo-projects/blob/master/.gitignore)
