### PR TITLE
Added htlatex for TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -110,6 +110,14 @@ acs-*.bib
 *.gaux
 *.gtex
 
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
 # hyperref
 *.brf
 


### PR DESCRIPTION
**Reasons for making this change:**

I needed these temporary files ignored on one of my personal repos, and others might need it as well.  htlatex (the command from the program [TeX4ht](https://en.wikipedia.org/wiki/TeX4ht) is rather common.

**Links to documentation supporting these rule changes:** 

These temporary files are undocumented by TeX4ht and do not serve any purpose once complete.  An [issue from 2011](http://tug.org/pipermail/tex4ht/2011q1/000274.html) was raised with the maintainers, but not implemented.  These files can be safely removed after the work is done.

If this is a new template: 

n/a - not a new template
