### PR TITLE
Dart.gitignore: Fix URL in comments

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,4 +1,4 @@
-# See https://www.dartlang.org/tools/private-files.html
+# See https://www.dartlang.org/guides/libraries/private-files
 
 # Files and directories created by pub
 .dart_tool/


### PR DESCRIPTION
Points to valid URI

**Reasons for making this change:**

The URL has been updated – pointing to latest

**Links to documentation supporting these rule changes:** 

See that the old URI redirects to the new one