### PR TITLE
Keep `.vscode` from appearing in untracked files

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,3 +1,4 @@
+.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json


### PR DESCRIPTION
**Reasons for making this change:**

Whenever I ran `git status` in my project directory the `.vscode` subdirectory would erroneously show up in the untracked files list.
