### PR TITLE
(Unity) Ignore /Library, /Temp, /Build, or /Builds not any directory

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -3,8 +3,6 @@
 /[Oo]bj/
 /[Bb]uild/
 /[Bb]uilds/
-/Assets/AssetStoreTools*
-/Assets/Temp.meta
 
 # Visual Studio 2015 cache directory
 /.vs/

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -1,9 +1,10 @@
-[Ll]ibrary/
-[Tt]emp/
-[Oo]bj/
-[Bb]uild/
-[Bb]uilds/
-Assets/AssetStoreTools*
+/[Ll]ibrary/
+/[Tt]emp/
+/[Oo]bj/
+/[Bb]uild/
+/[Bb]uilds/
+/Assets/AssetStoreTools*
+/Assets/Temp.meta
 
 # Visual Studio 2015 cache directory
 /.vs/


### PR DESCRIPTION
Some assets from Unity Asset Store use "Library" as the name of a subdirectory under `/Assets`. As for the other names, there's no reason to ignore all the subdirectory as well as the said directories under the root.
