### PR TITLE
added vendor to Go.gitignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Vendor directory containing dependencies, specifically when using dep or govendor.
+vendor/


### PR DESCRIPTION
When the project is not  a library, it's not necessary to push the `vendor` directory containing the dependencies along with the code. In such cases, dependency management tools like [dep](https://github.com/golang/dep) can be used which will create a `.toml` file containing all the dependencies required by the project.

This will significantly reduce the size of the project if the project is big and if it uses a lot of external libraries.

https://golang.github.io/dep/docs/FAQ.html#should-i-commit-my-vendor-directory

