### PR TITLE
Added an item in TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -210,6 +210,9 @@ pythontex-files-*/
 TSWLatexianTemp*
 
 ## Editors:
+# vim
+*~
+
 # WinEdt
 *.bak
 *.sav


### PR DESCRIPTION
To ignore backup files generated by vim <https://www.vim.org>.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:** 

_TODO_

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
