### PR TITLE
Add .DS_Store to Node .gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# created in any directory accessed by the Finder application in macOs
+.DS_Store


### PR DESCRIPTION
This file often finds itself in git repositories by mistake. Since the file is user-specific, it is safe to assume it won't be needed there.
