### PR TITLE
Kicad: Add more formats and documentation link

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -1,4 +1,5 @@
 # For PCBs designed using KiCad: http://www.kicad-pcb.org/
+# Format documentation: http://kicad-pcb.org/help/file-formats/
 
 # Temporary files
 *.000

--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -9,6 +9,10 @@
 *~
 _autosave-*
 *.tmp
+*-cache.lib
+*-rescue.lib
+*-save.pro
+*-save.kicad_pcb
 
 # Netlist files (exported from Eeschema)
 *.net


### PR DESCRIPTION
**Reasons for making this change:**

KiCad have more formats

**Links to documentation supporting these rule changes:** 

[Link to documentation that support my insane changes.](http://kicad-pcb.org/help/file-formats/)
