### PR TITLE
Update .gitignore with .cpcache

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .lein-plugins/
 .lein-failures
 .nrepl-port
+.cpcache/


### PR DESCRIPTION
**Reasons for making this change:**

The current clojure deps tool creates .cpcache directory in the project directory while using .deps.edn

**Links to documentation supporting these rule changes:** 

https://clojure.org/reference/deps_and_cli

> Project directory
>     The current directory
>     Contents:
>           deps.edn - optional project deps
>           .cpcache - project cache directory, same as the user-level cache directory, created if there is a deps.edn

If this is a new template: 

* None
