### PR TITLE
Create Red.gitignore for Red Programming Language

### DIFF
--- a/Red.ignore
+++ b/Red.ignore
@@ -1,0 +1,17 @@
+# This is a minimal set of files to be ignored for the red git repository.
+# (The files listed are those that are generated when running the automated tests.)
+#
+# It is not tracked in the repository.
+#
+# Copyright © 2018 Red Foundation
+# Licensed under the Boost Software licence 
+# (see https://github.com/red/red/blob/master/BSL-License.txt)
+
+.gitignore
+quick-test/quick-test.log
+quick-test/runnable/
+system/tests/source/units/auto-tests/
+tests/source/units/auto-tests/
+crush.dll
+crush.so
+crush.dylib


### PR DESCRIPTION
**Reasons for making this change:**

This is a .gitignore file for the Red Programming Language.

**Links to documentation supporting these rule changes:** 

There is a note in the project [README](https://github.com/red/red/blob/master/README.md) in the section Compiling from Sources that explains the need for this file.

If this is a new template: 

[The Red Programming Language](http://www.red-lang.org)