### PR TITLE
allow .ssh directory

### DIFF
--- a/Global/Vim.gitignore
+++ b/Global/Vim.gitignore
@@ -1,7 +1,8 @@
 # Swap
 [._]*.s[a-v][a-z]
 [._]*.sw[a-p]
-[._]s[a-v][a-z]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
 [._]sw[a-p]
 
 # Session


### PR DESCRIPTION
**Reasons for making this change:**

My .ssh directory missed in my git repository as the vi-swapfile exclude was to greedy