### PR TITLE
Feat: Ignore eslint cache file

### DIFF
--- a/Eslint.gitignore
+++ b/Eslint.gitignore
@@ -1,0 +1,1 @@
+.eslintcache


### PR DESCRIPTION
**Reasons for making this change:**

The JS linter tool `Eslint` creates a cache file that should be ignored when the `--cache`is added to the command.

**Links to documentation supporting these rule changes:** 

https://eslint.org/docs/user-guide/command-line-interface#caching
