### PR TITLE
Feat: Ignore stylelint cache file

### DIFF
--- a/Stylelint.gitignore
+++ b/Stylelint.gitignore
@@ -1,0 +1,1 @@
+.stylelintcache


### PR DESCRIPTION
**Reasons for making this change:**

The CSS linter tool `Stylelint` creates a cache file that should be ignored when the `--cache`is added to the command.

**Links to documentation supporting these rule changes:** 

https://stylelint.io/user-guide/cli/
