### PR TITLE
Update Eclipse.gitignore

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -51,3 +51,6 @@ local.properties
 .cache-main
 .scala_dependencies
 .worksheet
+
+# Checkstyle Plug-in
+.checkstyle


### PR DESCRIPTION
added support for "Checkstyle Plug-in"

**Reasons for making this change:**

".checkstyle" file is not ignored