### PR TITLE
added: *.iobj, *.ipdb

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -64,8 +64,10 @@ StyleCopReport.xml
 *.ilk
 *.meta
 *.obj
+*.iobj
 *.pch
 *.pdb
+*.ipdb
 *.pgc
 *.pgd
 *.rsp


### PR DESCRIPTION
"These files are produced when Incremental Link-Time Code Generation (LTCG) is enabled."
https://stackoverflow.com/questions/31554559/possible-to-stop-generating-ipdb-iobj-files-by-visual-studio-2015