### PR TITLE
Add exclude credential master key of Rails 5.2

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -14,6 +14,7 @@ pickle-email-*.html
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
+config/master.key
 
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml


### PR DESCRIPTION
**Reasons for making this change:**

From Rails 5.2, the function to handle confidentiality is added.
A master key for restoring confidentiality is created, but it is better not to manage git.

**Links to documentation supporting these rule changes:** 
- https://github.com/rails/rails/commit/69f976b859cae7f9d050152103da018b7f5dda6d
- https://github.com/rails/rails/commit/f27319a72a4ccfbffc575b752e4d91136f23725e#diff-24ae9dbe3383b08f36a08bfac6cf5fc7
