### PR TITLE
Add the idea caches to gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -39,6 +39,7 @@ captures/
 .idea/gradle.xml
 .idea/dictionaries
 .idea/libraries
+.idea/caches
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.


### PR DESCRIPTION
**Reasons for making this change:**

After updating to a new android studio, projects began to store some cache in the folder .idea/caches/
For example:

```
~/ExampleAndroidProject/.idea/caches
$ ls
build_file_checksums.ser
```
