### PR TITLE
JetBrains: add .idea/httpRequests

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -45,3 +45,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests


### PR DESCRIPTION
**Reasons for making this change:**

This directory used by HTTP Client in IntelliJ IDEA (and other product), contains only requests history.

**Links to documentation supporting these rule changes:** 

https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#viewingResponse
