### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -37,6 +37,7 @@ captures/
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml
+.idea/caches
 .idea/dictionaries
 .idea/libraries
 


### PR DESCRIPTION
Ignore .idea/caches/build_file_checksums.ser

**Reasons for making this change:**

I noticed this today after upgrading to Android Studio 3.1. And the file name suggests it's checksums of some cached files and should not be checked in to git.

**Links to documentation supporting these rule changes:** 

https://stackoverflow.com/questions/49557737/should-i-add-idea-caches-build-file-checksums-ser-to-gitignore


