### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -37,6 +37,7 @@ captures/
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml
+.idea/assetWizardSettings.xml
 .idea/dictionaries
 .idea/libraries
 


### PR DESCRIPTION
Ignore .idea/assetWizardSettings.xml for Android Studio 3.1

**Reasons for making this change:**

This file was created when I create Image Asset or Vector Asset. It contains the full path to where my Android Studio is installed.

See [here](https://github.com/leesah/nirvana/blob/3c1204ab20a058b524f7e1bf81b7bc9e3046a865/.idea/assetWizardSettings.xml#L38).

**Links to documentation supporting these rule changes:** 

I haven't found any.

