### PR TITLE
Added default annotation processing directory to Eclipse.gitignore

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -47,6 +47,9 @@ local.properties
 # Code Recommenders
 .recommenders/
 
+# Annotation Processing
+.apt_generated/
+
 # Scala IDE specific (Scala & Java development for Eclipse)
 .cache-main
 .scala_dependencies


### PR DESCRIPTION
**Reasons for making this change:**

The `.apt_generated` folder is the default folder when using annotation processing in Eclipse. Even if this configuration can be customized, just activating annotation processing (e.g. through a third-party tool like Gradle) will automatically create this folder and put generated source files there. Any files generated (and reproducible) from source files should **not** be managed by Git.

**Links to documentation supporting these rule changes:** 

http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Fguide%2Fjdt_apt_getting_started.htm