### PR TITLE
Remove tfvars files from Terraform.gitignore

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -4,6 +4,3 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
-
-# .tfvars files
-*.tfvars

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -4,3 +4,9 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars


### PR DESCRIPTION
`tfvars` files should not be gitignore-d as they are used to parameterize a Terraform root for multiple environments, e.g.:

```bash
$ tree terraform/roots/vpc
terraform/roots/vpc
├── env
│   ├── production.tfvars
│   ├── qa.tfvars
│   └── staging.tfvars
└── main.tf
```

There may be a use case where a particular `tfvars` file should be ignored, but there's no naming convention I'm aware of to easily designate such a file.

**Reasons for making this change:**

Ignoring tfvars files will, in some cases, ignore files that are critical for TF code to be executed.

**Links to documentation supporting these rule changes:** 

Atlantis, a popular TF build tool, expects tfvars files not to be ignored:

https://github.com/runatlantis/atlantis#project-structure

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
