### PR TITLE
Add shelf to JetBrains.gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -4,7 +4,8 @@
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml
-.idea/dictionaries
+.idea/**/dictionaries
+.idea/**/shelf
 
 # Sensitive or high-churn files
 .idea/**/dataSources/


### PR DESCRIPTION
**Reasons for making this change:**

.idea/shelf is a directory of user-specific stuff, should not be committed.

**Links to documentation supporting these rule changes:** 

Can't find any, but these files are obviously personal files