### PR TITLE
Create StandardML.git

### DIFF
--- a/StandardML.git
+++ b/StandardML.git
@@ -1,0 +1,2 @@
+## Ignore all SML/NJ Compiler Manager build directories
+.cm/


### PR DESCRIPTION
**Reasons for making this change:**

Add a gitignore for Standard ML

**Links to documentation supporting these rule changes:** 

https://www.smlnj.org/doc/CM/index.html

The documentation doesn't explicitly mention this as most SML/NJ developers have been using Subversion. But this can be found in most SML projects on GitHub, e.g. https://github.com/MLton/mlton/blob/master/lib/.gitignore

If this is a new template: 

 - **Link to application or project’s homepage**: http://smlnj.org/
