### PR TITLE
Add a new .msix extension

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -15,6 +15,7 @@ $RECYCLE.BIN/
 # Windows Installer files
 *.cab
 *.msi
+*.msix
 *.msm
 *.msp
 


### PR DESCRIPTION
Microsoft was announced a new extension of installer for Windows. I just added that one to be ignored as default, like others installers files.

**Reasons for making this change:**

I made these changes, because it is not common to version installer files, and Microsoft was just announced these new type of installer.

**Links to documentation supporting these rule changes:** 

* <https://mspoweruser.com/microsoft-announces-new-msix-app-packaging-format/>
* <https://blogs.windows.com/buildingapps/2018/03/07/three-things-need-know-windows-developer-day/>

If this is a new template: 

 - **Link to application or project’s homepage**: <https://github.com/Microsoft/msix-packaging>
