### PR TITLE
maven-wrapper.jar can be removed from the source

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,6 +7,3 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-
-# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
-!/.mvn/wrapper/maven-wrapper.jar

--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,3 +7,4 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
**Reasons for making this change:**

remove the exceptions for maven-wrapper.jar

**Links to documentation supporting these rule changes:** 

https://github.com/takari/maven-wrapper#usage-without-binary-jar