### PR TITLE
Added MFractor's working folder to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -324,3 +324,6 @@ ASALocalRun/
 
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
+
+# MFractors (Xamarin productivity tool) working folder 
+.mfractor/


### PR DESCRIPTION
MFractor is a Xamarin/Visual Studio Mac productivity tool used by 1000's of Xamarin developers.

The `.mfractor/` folder should not be included in source control (but often is).

**Reasons for making this change:**

People are starting to include this folder inside their GitHub repositories. See [here](https://www.google.com.au/search?q=.mfractor&rlz=1C5CHFA_enAU723AU723&oq=.mfractor&aqs=chrome..69i57j69i60l5.4941j0j7&sourceid=chrome&ie=UTF-8).

This folder contains SQLite databases that are frequently regenerated and can grow large based on the complexity of the solution.

