### PR TITLE
Added *.nlo and *.nls extensions to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -153,7 +153,9 @@ _minted*
 *.mw
 
 # nomencl
+*.nlg
 *.nlo
+*.nls
 
 # pax
 *.pax


### PR DESCRIPTION
The LaTeX nomeclature package produces files with the following extensions, which are not yet listed in the TeX.gitignore file:
- *.nlo nomenclature file
- *.nls nomenclature list file

### Reasons for making this change
Because these files are generated automatically when compiling a LaTeX project using the nomencl package, it is not necessary to version them.

See documentation at https://ctan.org/pkg/nomencl?lang=en