### PR TITLE
[Fastlane] Specify screenshot files only, rather than whole folder (in case the user has frameit config)

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -64,5 +64,5 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/Preview.html
-fastlane/screenshots
+fastlane/screenshots/*/*.png
 fastlane/test_output

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -64,5 +64,5 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/Preview.html
-fastlane/screenshots/*/*.png
+fastlane/screenshots/**/*.png
 fastlane/test_output


### PR DESCRIPTION
**Reasons for making this change:**

The whole screenshots folder shouldn't be ignore since there could be frameit configuration in it (Framefile.json, fonts, background.jpg, *.strings, etc...). It'd be better to just ignore the generated PNG screenshot files.

**Links to documentation supporting these rule changes:** 

https://docs.fastlane.tools/actions/frameit/#usage
