### PR TITLE
[TeX] Ignore generated *.xmpi files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -198,6 +198,9 @@ pythontex-files-*/
 # easy-todo
 *.lod
 
+# xmpincl
+*.xmpi
+
 # xindy
 *.xdy
 


### PR DESCRIPTION
**Reasons for making this change:**

Package [xmpincl](https://www.ctan.org/pkg/xmpincl) generates `*.xmpi` files out of `*.xmp` files during the inclusion process.

**Links to documentation supporting these rule changes:** 

https://texdoc.net/pkg/xmpincl -> page 3:

> basically create a new file .xmpi
