### PR TITLE
[Fastlane] Specify screenshot files only, rather than whole folder (i…

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -52,7 +52,7 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/Preview.html
-fastlane/screenshots
+fastlane/screenshots/**/*.png
 fastlane/test_output
 
 # Code Injection


### PR DESCRIPTION
**Reasons for making this change:**

Already done and merged for Swift.gitignore (#2662). It also applies to Objective-C projects, not to Android projects though. Therefore it wasn't changed on Android.gitignore file.

**Links to documentation supporting these rule changes:** 

https://docs.fastlane.tools/actions/frameit/#usage
