### PR TITLE
Add .localhistory folder to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -327,3 +327,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Local History for Visual Studio working folder
+.localhistory


### PR DESCRIPTION
**Reasons for making this change:**

"Local History for Visual Studio" is a popular and useful extension that stores its data in the .localhistory folder which should be ignored by git.

**Links to documentation supporting these rule changes:** 

https://marketplace.visualstudio.com/items?itemName=AronDCurzon.LocalHistoryforVisualStudio#overview

