### PR TITLE
Add .gitignore for Bazel projects

### DIFF
--- a/Bazel.gitignore
+++ b/Bazel.gitignore
@@ -1,0 +1,3 @@
+# Ignore all bazel-* symlinks. There is no full list since this can change
+# based on the name of the directory bazel is cloned into.
+/bazel-*


### PR DESCRIPTION
Closes https://github.com/bazelbuild/bazel/issues/555

**Reasons for making this change:**

Allow new repositories that use Bazel to easily start with a preconfigured `.gitignore` file.

**Links to documentation supporting these rule changes:** 
This is based on discussion on Closes https://github.com/bazelbuild/bazel/issues/555
which is copy-pasted from Bazel's own `.gitignore` file.

If this is a new template: 

 - **Link to application or project’s homepage**: http://bazel.build
