### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -34,6 +34,7 @@ captures/
 
 # IntelliJ
 *.iml
+.idea
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml


### PR DESCRIPTION
I don't think the .idea should ever be checked in.

**Reasons for making this change:**

Noticed it was adding other .idea files.  Since Gradle has been used, it is unnecessary.

**Links to documentation supporting these rule changes:** 

https://stackoverflow.com/a/26290130

