### PR TITLE
Add Python venv and Django settings

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -297,6 +297,19 @@ paket-files/
 __pycache__/
 *.pyc
 
+# Python virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Python/Django
+local_settings.py
+db.sqlite3
+
 # Cake - Uncomment if you are using it
 # tools/**
 # !tools/packages.config


### PR DESCRIPTION
For improving experience with PTVS.
Prevents default venvs from being added to source control with project creation.

Entries are copied directly from python.gitignore, https://github.com/github/gitignore/blob/master/Python.gitignore.
