### PR TITLE
added gitignore for MATLAB

### DIFF
--- a/MATLAB.gitignore
+++ b/MATLAB.gitignore
@@ -1,0 +1,3 @@
+# Temporary Files
+*~
+


### PR DESCRIPTION
**Reasons for making this change:**

Added the missing gitignore for MATLAB

**Links to documentation supporting these rule changes:** 

* (common sense)
* https://www.mathworks.com/help/?s_tid=srchtitle

If this is a new template: 

 - **Link to application or project’s homepage**: https://www.mathworks.com/products/matlab.html