### PR TITLE
Added *.opendb

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -22,6 +22,7 @@ ExportedObj/
 *.booproj
 *.svd
 *.pdb
+*.opendb
 
 # Unity3D generated meta files
 *.pidb.meta


### PR DESCRIPTION
**Reasons for making this change:**

Set `*.opendb` to be ignored, as these files are generated by Visual Studio. This same change was made to `VisualStudio.ignore` in commit a393ef8de999946cbb0210c24bb8ba39ffb511c0

**Links to documentation supporting these rule changes:** 

* [StackOverflow](https://stackoverflow.com/a/34979320/205245)
* [MDSN blog comment](https://blogs.msdn.microsoft.com/bharry/2015/11/30/vs-2015-update-1-and-tfs-2015-update-1-are-available/#div-comment-153621)
* [MSDN forum comment](https://social.msdn.microsoft.com/Forums/vstudio/en-US/2fc30d7c-0508-4283-9f9c-545c7a7a92af/cannot-commit-change-to-c-solution?forum=tfsversioncontrol#ed3f8690-0d3b-40d4-8d3d-5343bcb58a88)