### PR TITLE
adding exception for *.spl from elsarticle.cls

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -237,3 +237,6 @@ TSWLatexianTemp*
 
 # standalone packages
 *.sta
+
+# generated if using elsarticle.cls
+*.spl


### PR DESCRIPTION
**Reasons for making this change:**

When compiling latex articles using elsarticle.cls for elsevier journals, an extra temp file with extension .spl is created. 

**Links to documentation supporting these rule changes:** 

- https://tex.stackexchange.com/questions/7770/file-extensions-related-to-latex-etc
- https://www.elsevier.com/authors/author-schemas/latex-instructions