### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -63,3 +63,6 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+
+# Release
+app/release


### PR DESCRIPTION
**Reasons for making this change:**

Release apk and output.json shouldnt belong in a git repo

**Links to documentation supporting these rule changes:** 

n/a
