### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -327,3 +327,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Visual Studio Code working folder
+.vscode/** 


### PR DESCRIPTION
**Reasons for making this change:**

Visual Studio Code is part of the family now and creates its own working folder, for supporting multiple root spaces since version 1.1.8. It would be nice to keep these files out of Git.

**Links to documentation supporting these rule changes:** 

https://code.visualstudio.com/docs/editor/multi-root-workspaces#_settings
