### PR TITLE
Matlab - Exclude coder temporary folders

### DIFF
--- a/Global/Matlab.gitignore
+++ b/Global/Matlab.gitignore
@@ -18,6 +18,9 @@ helpsearch*/
 slprj/
 sccprj/
 
+# Matlab code generation folders
+codegen/
+
 # Simulink autosave extension
 *.autosave
 


### PR DESCRIPTION
**Reasons for making this change:**

When using the matlab coder to generate C/C++/Mex files, matlab generate a lot of files that should not be committed, including documentation.
For the C sources codes, for me they should not be commited by defaut, as it depends on the architectures/toolbox versions... 

**Links to documentation supporting these rule changes:** 
https://www.mathworks.com/examples/matlab-coder/mw/coder_product-coderdemo_hello_world-hello-world
