### PR TITLE
Ignore Reporting Project Upgrade backup files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -240,6 +240,7 @@ Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/
+*.rptproj.bak
 
 # SQL Server files
 *.mdf


### PR DESCRIPTION
**Reasons for making this change:**

I took a look at #1887 but settled on a more directed fix for what I'm hitting right now.
The conversion process from the old custom rptproj to the MSBuild based projects creates a MYProject.rptproj.bak backup file

**Links to documentation supporting these rule changes:** 

This doesn't call out the backup directly, but is the process that is creating these files https://blogs.msdn.microsoft.com/sqlrsteamblog/2017/09/25/msbuild-support-for-reporting-services-projects-now-available/

