### PR TITLE
Create CRBasic.gitignore

### DIFF
--- a/CRBasic.gitignore
+++ b/CRBasic.gitignore
@@ -1,0 +1,5 @@
+# optional table definintions created at compile time
+*.tdf
+
+# any encrypted files
+*_Enc.*


### PR DESCRIPTION
Add generic `.gitignore` for Campbell Scientific's CRBasic language. There is no central homepage for the language, but documentation is publicly available ([.pdf](https://s.campbellsci.com/documents/us/manuals/loggernet.pdf)) and there is a website (sales page) for [the IDE](https://www.campbellsci.com/crbasiceditor).
