### PR TITLE
Added Line for Visual Studio Code (.vscode/)

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -328,3 +328,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Visual Studio Code on Mac OS X
+.vscode/ 


### PR DESCRIPTION
**Reasons for making this change:**

Adds .vscode/ which is automatically generated by Visual Studio Code editor on Mac OSX 
