### PR TITLE
Ignore for Maven

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -19,6 +19,10 @@
 .idea/**/gradle.xml
 .idea/**/libraries
 
+# Maven
+log/
+target/
+
 # CMake
 cmake-build-debug/
 cmake-build-release/


### PR DESCRIPTION
Ignore build outputs by [Apache Maven](https://maven.apache.org/index.html), one of most popular build and dependency manager tools

**Reasons for making this change:**

Maven project outputs build files in ``target/`` directory and logs to ``log/`` directory. Files in those directories need to be ignored into git repository. 

**Links to documentation supporting these rule changes:** 

Here is a official documentation of [standard directory layout](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html) on maven's website


