### PR TITLE
Create Flutter.gitignore

### DIFF
--- a/Flutter.gitignore
+++ b/Flutter.gitignore
@@ -1,0 +1,5 @@
+.flutter-plugins
+
+# Firebase / Google Cloud Services
+android/*/google-services.json
+ios/*/GoogleService-Info.plist


### PR DESCRIPTION
Ignore rules for the Flutter SDK (see flutter.io). Based of the default
.gitignore rule generated for new projects. Does not include
rules already covered by Dart.gitignore.

**Reasons for making this change:**

Google's Flutter SDK needs custom ignore rules on top of Dart.gitignore

**Links to documentation supporting these rule changes:** 

https://github.com/flutter/flutter/blob/master/.gitignore

If this is a new template: 

 - **Link to application or project’s homepage**: https://flutter.io/
