### PR TITLE
Ignore the .cache folder for LabVIEW projects

### DIFF
--- a/LabVIEW.gitignore
+++ b/LabVIEW.gitignore
@@ -14,3 +14,4 @@
 # Metadata
 *.aliases
 *.lvlps
+.cache/


### PR DESCRIPTION
Ignore the .cache folder for LabVIEW projects. 

**Reasons for making this change:**

.cache/ is a local folder with metadata used by LabVIEW NXG.
