### PR TITLE
Added jigsaw template

### DIFF
--- a/Jigsaw.gitignore
+++ b/Jigsaw.gitignore
@@ -1,8 +1,5 @@
 # Jigsaw Static Site Generator
 
-# Jigsaw specific
-# Reference - https://github.com/tightenco/jigsaw/blob/master/stubs/site/.gitignore
-
 # Ignore build folder
 /build_local/
 /build_staging/
@@ -17,3 +14,10 @@
 # Optionally ignore lock files
 # composer.lock
 # yarn.lock
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Jigsaw.gitignore
+++ b/Jigsaw.gitignore
@@ -1,0 +1,19 @@
+# Jigsaw Static Site Generator
+
+# Jigsaw specific
+# Reference - https://github.com/tightenco/jigsaw/blob/master/stubs/site/.gitignore
+
+# Ignore build folder
+/build_local/
+/build_staging/
+/build_production/
+
+# Ignore node dependencies resolved by npm/yarn
+/node_modules/
+
+# Ignore php dependecies resolved by composer 
+/vendor/
+
+# Optionally ignore lock files
+# composer.lock
+# yarn.lock


### PR DESCRIPTION
**Reasons for making this change:**

Jigsaw is a Static Site Generator build on top of Laravel5 PHP Framework

**Links to documentation supporting these rule changes:** 

https://github.com/tightenco/jigsaw/blob/master/stubs/site/.gitignore

If this is a new template: 

https://jigsaw.tighten.co/
