### PR TITLE
Cases for Jetbrains Rider's with Unity3d

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -34,3 +34,9 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
+
+# Jetbrains Rider User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/dictionaries
+.idea/**/shelf


### PR DESCRIPTION
**Reasons for making this change:**

Cases for Jetbrains Rider's user specific stuff
For people using JetBrains Rider as a replacement for Visual Studio in Unity3D


**Links to documentation supporting these rule changes:** 

https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
