### PR TITLE
Add latexrun default directory for auxiliary files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -40,6 +40,10 @@
 *.synctex.gz(busy)
 *.pdfsync
 
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
 ## Auxiliary and intermediate files from other packages:
 # algorithms
 *.alg


### PR DESCRIPTION
**Reasons for making this change:**

Add the default directory where latexrun outputs all intermediate files.
Also add a new section for possible future latex build tools using similar mechanisms.

**Links to documentation supporting these rule changes:** 

The author haven't documented this, or at least I couldn't find it.
Below is the line that specifies this default build path
https://github.com/aclements/latexrun/blob/38ff6ec2815654513c91f64bdf2a5760c85da26e/latexrun#L90
