### PR TITLE
Pycharm project settings

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#PyCharm project settings
+.idea/


### PR DESCRIPTION
For users of PyCharm IDE, ignores the .idea directory (https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore)

**Reasons for making this change:**

PyCharm IDE Community / Pro is heavily used, .idea 

(https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore)