### PR TITLE
Remove directory slashes.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -8,19 +8,19 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
+build
+develop-eggs
+dist
+downloads
+eggs
+.eggs
+lib
+lib64
+parts
+sdist
+var
+wheels
+*.egg-info
 .installed.cfg
 *.egg
 MANIFEST


### PR DESCRIPTION
These are unnecessary and can lead to issues. For instance, a user may use Python 3 to create a virtualenv such as:

```sh
python3 -m venv .
```

The problem is that, in this case, Python 3 creates a symlink (lib64 -> lib) which isn't ignored based on these rules. Removing directory slashes solves the problem.

Another potential solution would be to specifically ignored files within that directory (since git doesn't recognize directories, just files) - which I'm happy to change this to.

Hopefully others find this helpful! :smiley_cat:
