### PR TITLE
Do not ignore launchsettings.json for VS

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -52,7 +52,6 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
 
 # StyleCop
 StyleCopReport.xml


### PR DESCRIPTION
**Reasons for making this change:**

Ignoring `launchSettings.json` does not make much sense. Now .NET CLI even considers this file when running with `dotnet run`, as you can read [here](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run?tabs=netcore2x).

This settings will be useful if shared among project members, so it should be commited to the repo.

Also, on the default `.gitignore` file generated by Visual Studio it is not ignored, so this causes confusion, as depending on how `.gitignore` was created it could be commited or not.


**Links to documentation supporting these rule changes:** 

https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run?tabs=netcore2x