### PR TITLE
Added JetBrains IDEs (pyCharm etc.) config folder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -104,4 +104,8 @@ venv.bak/
 .mypy_cache/
 
 # JetBrains IDEs (pyCharm etc.)
+# Depending on your work environment, sometimes you just need to ignore those two files which are user specific instead of the .idea folder
+# More at: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+# .idea/workspaces.xml
+# .idea/tasks.xml
 .idea/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# JetBrains IDEs (pyCharm etc.)
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**

It is very common to use PyCharm as a Python IDE.

**Links to documentation supporting these rule changes:** 

https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems

If this is a new template: 

NO
