### PR TITLE
Add all Sass sourcemap file formats

### DIFF
--- a/Sass.gitignore
+++ b/Sass.gitignore
@@ -1,2 +1,4 @@
 .sass-cache/
 *.css.map
+*.sass.map
+*.scss.map


### PR DESCRIPTION
**Reasons for making this change:**

This ignores the other Sass/SCSS sourcemap formats `sass` creates. If `*.css.map` is ignored by default, it stands to reason a user would probably want to exclude `*.sass.map` and `*.scss.map` as well.