### PR TITLE
Add Vuepress build defalult output Directory

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# vuepress build output
+.vuepress/dist


### PR DESCRIPTION
**Reasons for making this change:**

`.vuepress/dist` is [vuepress](https://vuepress.vuejs.org/) build default output dir.

**Links to documentation supporting these rule changes:** 

https://vuepress.vuejs.org/config/#dest
