### PR TITLE
Add DS_STORE to lazarus gitignore

### DIFF
--- a/Global/Lazarus.gitignore
+++ b/Global/Lazarus.gitignore
@@ -28,3 +28,4 @@ lib/
 
 # Application bundle for Mac OS
 *.app/
+.DS_Store


### PR DESCRIPTION
This file is autogenerated and even not related with the project. I suppose it's worth adding

_TODO_

I consider there's no reason to add any documentation :smile: