### PR TITLE
Add ".serverless" to gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # vuepress build output
 .vuepress/dist
+
+# Serverless directories
+.serverless


### PR DESCRIPTION
**Reasons for making this change:**
This is for when new projects are initialize for use with the [Serverless framework](https://serverless.com/). Whenever you initialize a new Serverless project, it generates a hidden .serverless folder (see the gitignore below).

**Links to documentation supporting these rule changes:** 

Serverless node.js template [gitignore](https://github.com/serverless/serverless/blob/master/lib/plugins/create/templates/aws-nodejs/gitignore).