### PR TITLE
Support other editors in VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -32,6 +32,12 @@ bld/
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 
+# VS Code cache/options directory
+.vscode/
+
+# JetBrains Rider cache/options directory
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
Add the settings directories for:
- VS Code: `.vscode`
- JetBrains Rider: `.idea`

**Reasons for making this change:**

I keep having to add these entries to the `.gitignore` files generated by GitHub using the Visual Studio option. People work on .NET projects using lots of different editors these days, so they should all be included.