### PR TITLE
ignore various linux-specific project files that can be generated by …

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -43,6 +43,15 @@
 *.sdf
 *.VC.db
 *.VC.opendb
+*.pro
+*.pro.user
+*.pri
+*.kdev4
+*.workspace
+*CodeCompletionFolders.txt
+*CodeLitePreProcessor.txt
+CMakeLists.txt
+Makefile
 
 # Precompiled Assets
 SourceArt/**/*.png

--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -4,6 +4,13 @@
 # Visual Studio 2015 database file
 *.VC.db
 
+# Visual Studio Code user specific files
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
 # Qt Creator
 *.autosave
 *.pro.user
@@ -53,6 +60,7 @@ CMakeLists.txt.user.*
 *.pro
 *.pri
 *.kdev4
+.code-workspace
 *.workspace
 *CodeCompletionFolders.txt
 *CodeLitePreProcessor.txt

--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -4,6 +4,11 @@
 # Visual Studio 2015 database file
 *.VC.db
 
+# Qt Creator
+*.autosave
+*.pro.user
+CMakeLists.txt.user*
+
 # Compiled Object files
 *.slo
 *.lo
@@ -44,7 +49,6 @@
 *.VC.db
 *.VC.opendb
 *.pro
-*.pro.user
 *.pri
 *.kdev4
 *.workspace

--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -7,7 +7,9 @@
 # Qt Creator
 *.autosave
 *.pro.user
-CMakeLists.txt.user*
+*.pro.user.*
+CMakeLists.txt.user
+CMakeLists.txt.user.*
 
 # Compiled Object files
 *.slo


### PR DESCRIPTION
…the engine

**Reasons for making this change:**

The current UnrealEngine.gitignore is written with Windows and Mac (Visual Studio and XCode) in mind. On Linux which is officially supported by the later versions of UE4 (became stable since 4.15 onward), plenty of development environments are natively supported by the engine (e.g. Qt Creator, KDevelop, CodeLite). Furthermore, UE4 does support plain Makefiles and CMake for building projects from command-line. When you invoke ${ENGINE_ROOT}/GenerateProjectFiles.sh on any project, it generates all those project files unless a specific ide explicitly specified by passing a parameter to GenerateProjectFiles.sh script (e.g. -cmakefile, -makefile, -qmakefile). Here are generated project files by the engine on one of my projects. I can safely remove them and it will either be regenerated by the engine or I can regenerate them manually using the mentioned script:

```
CMakeLists.txt
GodsOfDeceit.code-workspace
GodsOfDeceit.kdev4
GodsOfDeceit.pro
GodsOfDeceit.pro.user
GodsOfDeceit.uproject
GodsOfDeceit.workspace
GodsOfDeceitCodeCompletionFolders.txt
GodsOfDeceitCodeLitePreProcessor.txt
GodsOfDeceitConfig.pri
GodsOfDeceitDefines.pri
GodsOfDeceitHeader.pri
GodsOfDeceitIncludes.pri
GodsOfDeceitSource.pri
Makefile
```

As it can be seen all those files are redundant and they all can be generated from GodsOfDeceit.uproject.

**Links to documentation supporting these rule changes:** 

Unfortunately, documentation on this is very sparse https://wiki.unrealengine.com/Building_On_Linux#Generating_project_files_for_your_project

But, you can try it on Linux by invoking GenerateProjectFiles.sh on any UE4 project. e.g.

```
$ cd ${ENGINE_ROOT}
$ ./GenerateProjectFiles.sh -project="/path/to/any/ue4.uproject" -game -engine
```

If this is a new template: 

 - **Link to application or project’s homepage**: _TODO_
