### PR TITLE
ignore various linux-specific project files that can be generated by ue4

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -4,6 +4,13 @@
 # Visual Studio 2015 database file
 *.VC.db
 
+# Qt Creator
+*.autosave
+*.pro.user
+*.pro.user.*
+CMakeLists.txt.user
+CMakeLists.txt.user.*
+
 # Compiled Object files
 *.slo
 *.lo

--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -43,6 +43,22 @@
 *.sdf
 *.VC.db
 *.VC.opendb
+.idea/
+.kdev4/
+.vscode/
+*.code-workspace
+*.kdev4
+*.pro
+*.workspace
+*CodeCompletionFolders.txt
+*CodeLitePreProcessor.txt
+*Config.pri
+*Defines.pri
+*Header.pri
+*Includes.pri
+*Source.pri
+CMakeLists.txt
+Makefile
 
 # Precompiled Assets
 SourceArt/**/*.png


### PR DESCRIPTION
**Reasons for making this change:**

The current UnrealEngine.gitignore is written with Windows and Mac (Visual Studio and XCode) in mind. On Linux which is officially supported by the later versions of UE4 (became stable since 4.15 onward), plenty of development environments are natively supported by the engine (e.g. Qt Creator, KDevelop, CodeLite, VSCode, IntelliJ IDEA, ...). Furthermore, UE4 does support plain Makefiles and CMake for building projects from command-line. When you invoke ${ENGINE_ROOT}/GenerateProjectFiles.sh on any project, it generates all those project files unless a specific IDE explicitly specified by passing a parameter to GenerateProjectFiles.sh script (e.g. -cmakefile, -makefile, -qmakefile). Here are generated project files by the engine on one of my projects. I can safely remove them and it will either be regenerated by the engine or I can regenerate them manually using the mentioned script:

```
.idea/
.kde4/
.vscode/
CMakeLists.txt
GodsOfDeceit.code-workspace
GodsOfDeceit.kdev4
GodsOfDeceit.pro
GodsOfDeceit.uproject
GodsOfDeceit.workspace
GodsOfDeceitCodeCompletionFolders.txt
GodsOfDeceitCodeLitePreProcessor.txt
GodsOfDeceitConfig.pri
GodsOfDeceitDefines.pri
GodsOfDeceitHeader.pri
GodsOfDeceitIncludes.pri
GodsOfDeceitSource.pri
Makefile
```

As it can be seen all those folders/files are redundant and they all can be generated from GodsOfDeceit.uproject.

**Links to documentation supporting these rule changes:** 

Unfortunately, documentation on this is very sparse https://wiki.unrealengine.com/Building_On_Linux#Generating_project_files_for_your_project

But, you can try it on Linux by invoking GenerateProjectFiles.sh on any UE4 project. e.g.

```
$ cd ${ENGINE_ROOT}
$ ./GenerateProjectFiles.sh -project="/path/to/any/ue4.uproject" -game -engine
```

The second commit addresses Qt Creator specific project files which was also present in https://github.com/github/gitignore/blob/master/Qt.gitignore

*.user are generated by qt creator if you open a .pro or CMakeLists.txt files in Qt Creator.

If you open the .pro project file in Qt Creator, it generates the following (even if you move this file to another pc it will be overwritten by Qt Creator again):

```
GodsOfDeceit.pro.user
```

For CMake file it is (if we open it in Qt Creator):
```
CMakeLists.user
```

In some cases, Qt Creator will create a CMakeLists.txt.user or ProjectName.user file with a short hash which should also be ignored. https://github.com/github/gitignore/commit/f3643325e477fa38cc57de49d029b37f5619a580#diff-3ceaecac7596fb8195a713804031f548

For example:

```
GodsOfDeceit.pro.user.34915ab
CMakeLists.txt.user.1fa15d5
```

It also saves modified files into *.autosave until the file is saved by the user (it is useful in case of crash or power loss).