### PR TITLE
Remove Packages folder from .gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -178,8 +178,6 @@ PublishScripts/
 
 # NuGet Packages
 *.nupkg
-# The packages folder can be ignored because of Package Restore
-**/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
 # Uncomment if necessary however generally it will be regenerated when needed


### PR DESCRIPTION
It is very common to have `Packages` folder in domain business logic (it happened to me and to other colleagues), and because of this entry, it has been excluded from our repository. Therefore I would remove this folder from the ignore list.
