### PR TITLE
add terraform.tfvars explicitly

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -13,3 +13,9 @@ crash.log
 # version control.
 #
 # example.tfvars
+
+# ignore terraform.tfvars file as it is a best-practices convention to either use environment
+# variables for secrets or this file.  This allows for the previous PR's logic based on environment
+# configuration answer files to persist while covering this edge case which does not apply to
+# environment-specific files.
+terraform.tfvars


### PR DESCRIPTION
**Reasons for making this change:**

terraform.tfvars is a file which is used by convention to populate variables in a Terraform build.  As terraform.tfvars does not point to any specific environment, but is global this is a common place to put persistent secrets that should never be committed.  I agree with the logic of removing the global *.tfvars file for the multi-environment scenario, but this makes sense to still ignore as it's auto-loaded by Terraform at a global level, and as such might be a good place to store AWS/Azure credentials without manually setting the environment variables which could have its own set of repercussions.

**Links to documentation supporting these rule changes:** 

https://www.terraform.io/intro/getting-started/variables.html 