### PR TITLE
Add swap file to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# temporary files
+*.swp


### PR DESCRIPTION
**Reasons for making this change:**

Many a times a user adds and commits the temporary os generated files like the ones with *.swp extension which becomes a little irritating. I'm not sure if anyone really wants to commit these, just like the pyc files. These are the files generated by vim, so the users shall be benefited.

**Links to documentation supporting these rule changes:** 

https://unix.stackexchange.com/questions/27923/what-causes-swap-files-to-be-created - Link to a solution on stack overflow.
