### PR TITLE
remove not needed blank line from macOS global gitignore

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -4,7 +4,7 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
**Reasons for making this change:**

* There was a unnecessary blank line

**Links to documentation supporting these rule changes:** 

_Too small a change, to link documentary_