### PR TITLE
Ignore usage statistics file

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -4,6 +4,7 @@
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml
+.idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
 


### PR DESCRIPTION
**Reasons for making this change:**

.idea/misc.xml used to contain usage statistics.  This was broken out to usage.statistics.xml in the latest EAP (2018.2 EAP).  It should be excluded from git.

**Links to documentation supporting these rule changes:** 

See https://youtrack.jetbrains.com/issue/IDEA-192913