### PR TITLE
Remove trailing whitespace

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,10 @@
 
 _TODO_
 
-**Links to documentation supporting these rule changes:** 
+**Links to documentation supporting these rule changes:**
 
 _TODO_
 
-If this is a new template: 
+If this is a new template:
 
  - **Link to application or project’s homepage**: _TODO_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,17 @@ high quality, we request that contributions adhere to the following guidelines.
 - **Provide a link to the application or project’s homepage**. Unless it’s
   extremely popular, there’s a chance the maintainers don’t know about or use
   the language, framework, editor, app, or project your change applies to.
-  
+
 - **Provide links to documentation** supporting the change you’re making.
   Current, canonical documentation mentioning the files being ignored is best.
   If documentation isn’t available to support your change, do the best you can
   to explain what the files being ignored are for.
-  
+
 - **Explain why you’re making a change**. Even if it seems self-evident, please
   take a sentence or two to tell us why your change or addition should happen.
   It’s especially helpful to articulate why this change applies to *everyone*
   who works with the applicable technology, rather than just you or your team.
-  
+
 - **Please consider the scope of your change**. If your change specific to a
   certain language or framework, then make sure the change is made to the
   template for that language or framework, rather than to the template for an

--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -20,7 +20,7 @@
 # Deployment Manager configuration file for your project. Added in Delphi XE2.
 # Uncomment this if it is not mobile development and you do not use remote debug feature.
 #*.deployproj
-# 
+#
 # C++ object files produced when C/C++ Output file generation is configured.
 # Uncomment this if you are not using external objects (zlib library for example).
 #*.obj

--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -23,7 +23,7 @@ local.properties
 # CDT-specific (C/C++ Development Tooling)
 .cproject
 
-# CDT- autotools 
+# CDT- autotools
 .autotools
 
 # Java annotation processor (APT)

--- a/Global/Matlab.gitignore
+++ b/Global/Matlab.gitignore
@@ -7,12 +7,12 @@
 # Compiled MEX binaries (all platforms)
 *.mex*
 
-# Packaged app and toolbox files 
-*.mlappinstall 
-*.mltbx 
-  
-# Generated helpsearch folders 
-helpsearch*/ 
+# Packaged app and toolbox files
+*.mlappinstall
+*.mltbx
+
+# Generated helpsearch folders
+helpsearch*/
 
 # Simulink code generation folders
 slprj/

--- a/Global/SynopsysVCS.gitignore
+++ b/Global/SynopsysVCS.gitignore
@@ -4,8 +4,8 @@
 *.evcd
 *.fsdb
 
-# Default name of the simulation executable.  A different name can be 
-# specified with this switch (the associated daidir database name is 
+# Default name of the simulation executable.  A different name can be
+# specified with this switch (the associated daidir database name is
 # also taken from here):  -o <path>/<filename>
 simv
 
@@ -13,7 +13,7 @@ simv
 simv.daidir/
 simv.db.dir/
 
-# Infrastructure necessary to co-simulate SystemC models with 
+# Infrastructure necessary to co-simulate SystemC models with
 # Verilog/VHDL models.  An alternate directory may be specified with this
 # switch:  -Mdir=<directory_path>
 csrc/
@@ -22,7 +22,7 @@ csrc/
 # used to write all messages from simulation:  -l <filename>
 *.log
 
-# Coverage results (generated with urg) and database location.  The 
+# Coverage results (generated with urg) and database location.  The
 # following switch can also be used:  urg -dir <coverage_directory>.vdb
 simv.vdb/
 urgReport/

--- a/Umbraco.gitignore
+++ b/Umbraco.gitignore
@@ -19,7 +19,7 @@
 !**/App_Data/[Pp]ackages/*
 !**/[Uu]mbraco/[Dd]eveloper/[Pp]ackages/*
 
-# ImageProcessor DiskCache 
+# ImageProcessor DiskCache
 **/App_Data/cache/
 
 # Ignore the Models Builder models out of date flag

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -220,7 +220,7 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk 
+# Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk
 
@@ -316,7 +316,7 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Azure Stream Analytics local run output 
+# Azure Stream Analytics local run output
 ASALocalRun/
 
 # MSBuild Binary and Structured Log
@@ -325,5 +325,5 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/


### PR DESCRIPTION
**Reasons for making this change:**

Trailing whitespace should be avoided whenever possible.

**Links to documentation supporting these rule changes:** 

https://softwareengineering.stackexchange.com/questions/121555/why-is-trailing-whitespace-a-big-deal

(I used `find . -not -path "./.git/*" -type f -exec sed -i 's/ $//g' {} \;` to get rid of the trailing whitespace)
