### PR TITLE
New template for diff files

### DIFF
--- a/Global/Diff.gitignore
+++ b/Global/Diff.gitignore
@@ -1,0 +1,2 @@
+*.patch
+*.diff


### PR DESCRIPTION
**Reasons for making this change:**

patch files are rarely added to a repository, and typically are added in a special location where an override .gitignore can ensure they are caught.

**Links to documentation supporting these rule changes:**

I'm not sure there is official documentation recommending people use .diff or .patch for these files, but a >10 year old redirect on enwp might suffice:
https://en.wikipedia.org/w/index.php?title=.diff&action=history

If this is a new template:

 - **Link to application or project’s homepage**: https://en.wikipedia.org/wiki/Diff
