### PR TITLE
Autotools: De-duplicate autom4te entry

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -9,7 +9,7 @@ Makefile.in
 
 # http://www.gnu.org/software/autoconf
 
-/autom4te.cache
+autom4te.cache
 /autoscan.log
 /autoscan-*.log
 /aclocal.m4
@@ -39,4 +39,3 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
-autom4te.cache


### PR DESCRIPTION
**Reasons for making this change:**

Duplication added in https://github.com/github/gitignore/pull/2480

leaving the original `/autom4te.cache` is probably also ok.  Someone putting their autotools files in a subdirectory is off on their own path and many of the other rules will still not work for them, so it isnt particularly useful to only change one.

But I've made the change to avoid any possible regression.  Perhaps @Ckins might be able to shed some light on why the leading `/` causes problems.