### PR TITLE
update Craft CMS gitignore to follow Craft team's recommendations

### DIFF
--- a/CraftCMS.gitignore
+++ b/CraftCMS.gitignore
@@ -1,3 +1,4 @@
-# Craft Storage (cache) [http://buildwithcraft.com/help/craft-storage-gitignore]
+# Craft 2 Storage (https://craftcms.com/support/craft-storage-gitignore)
+# not necessary for Craft 3 (https://github.com/craftcms/craft/issues/26)
 /craft/storage/*
-!/craft/storage/logo/*
+!/craft/storage/rebrand


### PR DESCRIPTION
**Reasons for making this change:**

The existing Craft CMS gitignore is not what is recommended in the official source referenced in the existing `CraftCMS.gitignore`. My first change is updating the ignore list to reflect the official recommendations.

Craft cache can refer to something else, so I dropped the word "cache."

The recently released v3 comes with gitignores out of the box, and does not require anything additional. I added a comment pointing this out.

I can see replacing

```
# Craft 2 Storage (https://craftcms.com/support/craft-storage-gitignore)
# not necessary for Craft 3 (https://github.com/craftcms/craft/issues/26)
```

with a simple

```
# Craft 2 Storage (Craft 3 requires no gitignores beyond what it comes with)
```

but thought I'd start by sticking with the existing format. Let me know if you'd like me to make that change!

Another way to go would have been renaming the file to `CraftCMSv2.gitignore`, but I don't think that would be as clear.

**Links to documentation supporting these rule changes:**

- Craft 2 documentation: https://craftcms.com/support/craft-storage-gitignore
- Craft team's confirmation that Craft 3 doesn't need additional ignores: https://github.com/craftcms/craft/issues/26