### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -71,3 +71,6 @@ typings/
 
 # Serverless directories
 .serverless
+
+# VS Code history directory
+.history


### PR DESCRIPTION
added the history dir for VS Code IDE

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
