### PR TITLE
updated SFDC gitignore

### DIFF
--- a/ForceDotCom.gitignore
+++ b/ForceDotCom.gitignore
@@ -1,4 +1,68 @@
+# Credit:
+# https://github.com/mailtoharshit/gitignore/blob/master/.gitignore
+# https://github.com/github/gitignore/blob/master/ForceDotCom.gitignore
+
+# GitIgnore for Salesforce Projects
+# Project Settings and MetaData
 .project
-.settings
+.settings/
+.metadata
+build.properties
+config
+
+# Apex Log as optional
+apex-scripts/log
+
+# Eclipse specific 
 salesforce.schema
 Referenced Packages
+bin/
+tmp/
+config/
+*.tmp
+*.bak 
+local.properties
+.settings
+.loadpath
+.classpath
+*.cache
+
+# Illuminated Cloud (IntelliJ IDEA)
+IlluminatedCloud
+out
+.idea
+*.iml
+
+# Mavensmate
+*.sublime-project
+*.sublime-settings
+*.sublime-workspace
+mm.log
+
+# Haoide SublimeText
+.config
+.deploy
+.history
+
+# OSX-specific exclusions
+.[dD][sS]_[sS]tore
+
+# The Welkin Suite specific
+**/.localHistory
+
+*.sfuo
+
+TestCache.xml
+
+TestsResultsCache.xml
+
+# Salesforce DX
+.sfdx
+.salesforce
+node_modules
+
+# SFDX Plugins
+pids
+*.pid
+*.seed
+*.pid.lock


### PR DESCRIPTION
**Reasons for making this change:**

The force.com gitignore was lacking many IDE project files

**Links to documentation supporting these rule changes:**

https://github.com/mailtoharshit/gitignore/blob/master/.gitignore
https://github.com/github/gitignore/blob/master/ForceDotCom.gitignore
https://github.com/mailtoharshit/gitignore/blob/master/.gitignore

