### PR TITLE
Update Objective-C.gitignore

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -35,6 +35,9 @@ xcuserdata/
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 # Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
 
 # Carthage
 #


### PR DESCRIPTION
Adding a comment in case one wants to ignore .xcworkspace

**Reasons for making this change:**

Most people using cocoa pods will likely run pod install after getting the repository so the xcworkspace will be recreated. 

**Links to documentation supporting these rule changes:**

[https://stackoverflow.com/questions/22345575/should-xcworkspace-be-in-gitignore](https://stackoverflow.com/questions/22345575/should-xcworkspace-be-in-gitignore)