### PR TITLE
Added .pytest_cache/ into Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pytest
+.pytest_cache/


### PR DESCRIPTION
**Reasons for making this change:**

Generally developer adds tests into repository during development phase, pytest adds .pytest_cache/ directory while testing.
