### PR TITLE
Add VLab.gitignore template

### DIFF
--- a/VLab.gitignore
+++ b/VLab.gitignore
@@ -1,0 +1,37 @@
+# VLab/Lstudio files
+input.i
+lsys.dll
+lsys.so
+lsys.exp
+lsys.i
+lsys.ii
+lsys.lib
+lsys.obj
+lsys.o
+lpfg.log
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app


### PR DESCRIPTION
Add a new template for VLab/Lstudio.

The software uses lpfg/cpfg and will generate specific temporary files.

"The Biological Modeling and Visualization group develops a set of related plant modeling software packages collectively called the Virtual Laboratory / L-studio. Versions are available for Windows, Mac OSX, and Linux."

http://algorithmicbotany.org/virtual_laboratory/
