### PR TITLE
Add Intermediate folder for exclusion

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -23,6 +23,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+[Ii]ntermediate/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
Some projects use Intermediate instead of obj, e.g.: https://github.com/github/gitignore/blob/master/UnrealEngine.gitignore#L70