### PR TITLE
updated jetbrains gitignore to ignore contentModel

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -8,6 +8,9 @@
 .idea/**/dictionaries
 .idea/**/shelf
 
+# Generated files
+.idea/**/contentModel.xml
+
 # Sensitive or high-churn files
 .idea/**/dataSources/
 .idea/**/dataSources.ids


### PR DESCRIPTION
**Reasons for making this change:**

contentModel.xml is automatically generated and can be safely ignored.

**Links to documentation supporting these rule changes:**

https://rider-support.jetbrains.com/hc/en-us/community/posts/115000661950-A-lot-of-files-in-contentModel-xml?page=1#community_comment_115000538984