### PR TITLE
Update TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -226,6 +226,9 @@ TSWLatexianTemp*
 # Texpad
 .texpadtmp
 
+#LyX
+*.lyx~
+
 # Kile
 *.backup
 

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -226,7 +226,7 @@ TSWLatexianTemp*
 # Texpad
 .texpadtmp
 
-#LyX
+# LyX
 *.lyx~
 
 # Kile


### PR DESCRIPTION
**Reasons for making this change:**

Adding LyX editor backup file format: i.e. `.lyx~`

**Links to documentation supporting these rule changes:**

https://www.mail-archive.com/lyx-users@lists.lyx.org/msg78488.html

