### PR TITLE
Add configure logs

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -16,6 +16,8 @@ autom4te.cache
 /compile
 /config.guess
 /config.h.in
+/config.log
+/config.status
 /config.sub
 /configure
 /configure.scan


### PR DESCRIPTION
These files are created when running `autoreconf`; however they don't need to be added to version control.

**Reasons for making this change:**

`config.log` and `config.status` are two files produced by autotools that report the status. Typically they are not needed in git.

**Links to documentation supporting these rule changes:**

The first two lines of `config.log`:
```
This file contains any messages produced by compilers while
running configure, to aid debugging if configure makes a mistake.
```

First lines of `config.status`:
```
# Generated by configure.
# Run this file to recreate the current configuration.
# Compiler output produced by configure, useful for debugging
# configure, is in config.log if it exists.
```
After that it's a copy of `configure` until the point it stopped execution.
