### PR TITLE
Ignore *nix swap files

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -71,3 +71,7 @@ typings/
 
 # Serverless directories
 .serverless
+
+# Linux Swap Files
+*.swp
+*.swo


### PR DESCRIPTION
**Reasons for making this change:**

ViM developers may appreciate not having *nix swap files in their commits accidentally, this prevents that from happening.

**Links to documentation supporting these rule changes:**

[Description of what swap files are for non-ViM reviewers](https://stackoverflow.com/questions/11313639/what-is-a-swap-file)
