### PR TITLE
Ignore files from Local History plug-ins

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -327,3 +327,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder
 .mfractor/
+
+# Local History for Visual Studio
+.localhistory/


### PR DESCRIPTION
Local History for Visual Studio automatically creates a history of your files every time they are saved. The history can be compared with the current version. It is a solution situated between version control and undo/redo of history, available by default in Eclipse and IntelliJ IDEs.
* https://marketplace.visualstudio.com/items?itemName=AronDCurzon.LocalHistoryforVisualStudio
* https://marketplace.visualstudio.com/items?itemName=lostalloy.LocalHistory-for-Visual-Studio

**Reasons for making this change:**

This change ignores a folder which contains a history of local changes. The content is managed by a Visual Studio plug-in that mimics behavior commonly available in other IDEs.

**Links to documentation supporting these rule changes:**

https://github.com/LostAlloy/LocalHistory-for-Visual-Studio/issues/4
