### PR TITLE
Fixing MIDL header file pattern for Visual Studio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -59,7 +59,7 @@ StyleCopReport.xml
 # Files built by Visual Studio
 *_i.c
 *_p.c
-*_i.h
+*_h.h
 *.ilk
 *.meta
 *.obj


### PR DESCRIPTION
**Reasons for making this change:**

_i.h given in 799ee6b79e1d32f49ded6683b5364017fd4ee0a5#gitext://gotocommit/799ee6b79e1d32f49ded6683b5364017fd4ee0a5 is wrong

**Links to documentation supporting these rule changes:**

Default of VS 2005:
![vs2005](https://user-images.githubusercontent.com/41993823/43639607-4be3d892-970c-11e8-941b-294d52cd8721.png)

Default of VS 2017:
![vs2017](https://user-images.githubusercontent.com/41993823/43639608-4e07036a-970c-11e8-97b6-fde290482937.png)


