### PR TITLE
add pycharm settings folder to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -97,6 +97,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea/
+
 # mkdocs documentation
 /site
 


### PR DESCRIPTION
**Reasons for making this change:**

Since **PyCharm** is a common IDE for python based projects, which stores **project specific settings** in the folder **.idea/** right beside the projects code, the settings folder should be added to .gitignore.


**Links to documentation supporting these rule changes:**

https://www.jetbrains.com/help/pycharm/project-and-ide-settings.html#location_of_directories

