### PR TITLE
Ignore logs for Symfony4

### DIFF
--- a/Symfony.gitignore
+++ b/Symfony.gitignore
@@ -15,6 +15,10 @@
 !var/logs/.gitkeep
 !var/sessions/.gitkeep
 
+# Logs (Symfony4)
+/var/log/*
+!var/log/.gitkeep
+
 # Parameters
 /app/config/parameters.yml
 /app/config/parameters.ini


### PR DESCRIPTION
Ignore /var/log/* for Symfony

**Reasons for making this change:**
Folder structure for logs has been changed for Symfony 4, from /var/logs/* in v3.x to /var/log/* in v4.x

**Links to documentation supporting these rule changes:**
https://symfony.com/doc/master/logging.html
Under Where Logs are Stored