### PR TITLE
Removed Microsoft Word 2016 Auto Backuped File on macOS

### DIFF
--- a/Global/MicrosoftOffice.gitignore
+++ b/Global/MicrosoftOffice.gitignore
@@ -3,6 +3,9 @@
 # Word temporary
 ~$*.doc*
 
+# Word Auto Backup File
+Backup of *.doc*
+
 # Excel temporary
 ~$*.xls*
 


### PR DESCRIPTION
**Reasons for making this change:**

If checked the option "Always create backup copy" under Settings -> Save within Microsoft Word 2016 on macOS, when editing a docx file, a folder named as same as docx file name(without ext) will be created and placed a docx backup file named "Backup of DOCX_ORIGINAL_FILENAME.docx".

**Links to documentation supporting these rule changes:**

N/A

If this is a new template:

N/A