### PR TITLE
KiCad .gitignore library fix

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -9,7 +9,6 @@
 *~
 _autosave-*
 *.tmp
-*-cache.lib
 *-rescue.lib
 *-save.pro
 *-save.kicad_pcb


### PR DESCRIPTION
We shouldn't ignore -cache.lib files, because it causes missing components in your schema

http://kicad-pcb.org/help/file-formats/ specifically mentions this:

> `-cache.lib`: …​ a local copy of all the symbols used in the corresponding schematic, so that when the folder containing a KiCad project is copied to a different PC, the schematic can still be opened and printed and will still look the same as the original draughtsperson intended - even if that other PC does not have those symbols in its main libraries (or has symbols that coincidentally have the same name but are completely different).
