### PR TITLE
add .dmypy.json to Python.gitignore.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -103,3 +103,5 @@ venv.bak/
 # mypy
 .mypy_cache/
 .dmypy.json
+dmypy.json
+

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.dmypy.json

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -104,4 +104,3 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
-


### PR DESCRIPTION
**Reasons for making this change:**

MyPy includes a daemon server that creates a file named .dmypy.json to
manage socket connection data. 

**Links to documentation supporting these rule changes:**

MyPy includes a server, dmypy, to check typing in Python code. This server creates a file .dmypy.json to handle socket information. 
https://github.com/python/mypy/blob/v0.620/mypy/dmypy_util.py#L11

The MyPy project has included .dmypy.json in it's own .gitignore file:
https://github.com/python/mypy/blob/master/.gitignore#L16

It's very unlikely anyone would want to reuse this file. As MyPy is used almost exclusively to aide developers, it is unlikely to be wanted in a production environment. 
