### PR TITLE
Added *.listing extension to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -188,6 +188,9 @@ sympy-plots-for-*.tex/
 *.pytxcode
 pythontex-files-*/
 
+# tcolorbox
+*.listing
+
 # thmtools
 *.loe
 


### PR DESCRIPTION
**Reasons for making this change:**

This is the default extension of auxiliary file the environment `tcblisting` of LaTeX package `tcolorbox` may generate. The actual extension may be changed by key `listing file` of `tcolorbox`.

**Links to documentation supporting these rule changes:**

See Sec. 15.6, page 310 of [`tcolorbox` doc on CTAN](http://mirrors.ctan.org/macros/latex/contrib/tcolorbox/tcolorbox.pdf).
