### PR TITLE
ignore ipython profile

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -73,7 +73,7 @@ target/
 .ipynb_checkpoints
 
 # IPython
-default_profile/
+profile_default/
 ipython_config.py
 
 # pyenv

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -72,6 +72,10 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# IPython
+default_profile/
+ipython_config.py
+
 # pyenv
 .python-version
 


### PR DESCRIPTION
**Reasons for making this change:**

When invoking ipython shell if a virtual environment is activated, ipython will read profiles under `profile_default` or read `ipython_config.py`, if exist.
I'd suggest we ignore these since they're often not related to the project per se.

**Links to documentation supporting these rule changes:**

https://ipython.readthedocs.io/en/stable/development/config.html
