### PR TITLE
Processing: Add ignore rules for Linux ARM exports

### DIFF
--- a/Processing.gitignore
+++ b/Processing.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 applet
+application.linux-arm64
+application.linux-armv6hf
 application.linux32
 application.linux64
 application.windows32


### PR DESCRIPTION
**Reasons for making this change:**
Since Processing version 3.0.1 you can compile Linux ARM versions of your Processing sketch, distinct from the regular 32 and 64 bit Linux exports.

**Links to documentation supporting these rule changes:**
- https://github.com/processing/processing/releases/tag/processing-0247-3.0.1