### PR TITLE
Added Hugo.gitignore

### DIFF
--- a/Hugo.gitignore
+++ b/Hugo.gitignore
@@ -1,0 +1,44 @@
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.exe~
+*.o
+*.so
+*.dylib
+*.out
+*.test
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*.swp
+
+# Hugo #
+########
+/public
+/themes


### PR DESCRIPTION
**Reasons for making this change:**

Hugo is a rising star in static site development because:
- it's easy to develop with,
- it provides nearly instantaneous export of the static site(usually measured in milliseconds or seconds at most)
- of the performance it yields once the site is deployed.

Therefore a `gitignore` file is long overdue.

 - **Link to application or project’s homepage**: [http://gohugo.io](http://gohugo.io)