### PR TITLE
Update Perl6.gitignore

### DIFF
--- a/Perl6.gitignore
+++ b/Perl6.gitignore
@@ -4,4 +4,7 @@
 # precompiled files
 .precomp
 lib/.precomp
-
+# macOS
+.DS_Store
+# vi
+.swp


### PR DESCRIPTION
Add some macOS and vi hidden files to gitignore

**Reasons for making this change:**

Some basic changes that make this gitignore file work for my (commonplace) perl6 env
