### PR TITLE
adding idea and impl for go gitignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+.idea/
+*.impl


### PR DESCRIPTION
**Reasons for making this change:**

Currently, it does not have the capability to remove .idea and *.impl

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
