### PR TITLE
Add storage and yarn related entries for rails 5.2

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -47,3 +47,15 @@ bower.json
 # Ignore node_modules
 node_modules/
 
+# Ignore precompiled javascript packs
+/public/packs
+/public/packs-test
+
+# Ignore yarn files
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep


### PR DESCRIPTION
**Reasons for making this change:**

ActiveStorage has become part of Rails 5.2. File uploads are uploaded to /storage and you shouldn't add them to git.
Added precompiled packs and yarn logs to git ignore.

**Links to documentation supporting these rule changes:**

https://github.com/rails/webpacker/issues/534
https://github.com/rails/webpacker/issues/1193
https://stackoverflow.com/questions/50538316/should-active-storage-binary-variant-files-get-pushed-to-version-control
