### PR TITLE
Add .nox directory for the nox testing tool

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -38,6 +38,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache


### PR DESCRIPTION
**Reasons for making this change:**

This is a new Python testing tool, similar to tox and is being used in a lot of Google Cloud projects.

**Links to documentation supporting these rule changes:**

Couldn't find specific documentation about the `.nox/` directory but the tool uses this directory to house it's virtualenvs.

 - **Link to application or project’s homepage**: https://nox.readthedocs.io/en/stable/
