### PR TITLE
Fix Cargo.lock recommendation

### DIFF
--- a/Rust.gitignore
+++ b/Rust.gitignore
@@ -2,7 +2,7 @@
 # will have compiled files and executables
 /target/
 
-# Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
+# Remove Cargo.lock from gitignore if creating a library, leave it for executables
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html
 Cargo.lock
 


### PR DESCRIPTION
Message in gitignore file is the opposite of what is in rust docs.