### PR TITLE
Use https for gruntjs link in Node gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -20,7 +20,7 @@ coverage
 # nyc test coverage
 .nyc_output
 
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
 # Bower dependency directory (https://bower.io/)


### PR DESCRIPTION
**Reasons for making this change:**

Saves a redirect when following the link and is consistent with other links in the same file. See #2467 for a similar PR.

**Links to documentation supporting these rule changes:**

https://gruntjs.com/creating-plugins#storing-task-files
