### PR TITLE
Laravel: only ignore root vendor directory

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -1,4 +1,4 @@
-vendor/
+/vendor/
 node_modules/
 npm-debug.log
 yarn-error.log


### PR DESCRIPTION
**Reasons for making this change:**
In Laravel, we often use `artisan vendor:publish` to export views, notifications etc from dependencies so that they can be customized. These views are created in /resources/views/vendor/ directory.

When using the current gitignore for Laravel, vendor is inserted like vendor/ which ignores all the directories named vendor anywhere in the source tree, including the customized views.

The proposed file change tries to fix this problem by ensuring only the root vendor directory is ignored by git.

**Links to documentation supporting these rule changes:**
https://laravel.com/docs/5.6/mail#customizing-the-components
https://laravel.com/docs/5.6/notifications#customizing-the-templates
https://laravel.com/docs/5.6/pagination#customizing-the-pagination-view
