### PR TITLE
Added wildcard ignore for .keystore files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -43,8 +43,9 @@ captures/
 .idea/caches
 
 # Keystore files
-# Uncomment the following line if you do not want to check your keystore files in.
+# Uncomment the following lines if you do not want to check your keystore files in.
 #*.jks
+#*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild


### PR DESCRIPTION
Keystore files with an extension of `.keystore` are also valid and commonly used.
