### PR TITLE
Create HOL.gitignore

### DIFF
--- a/community/HOL.gitignore
+++ b/community/HOL.gitignore
@@ -1,0 +1,11 @@
+*Script
+
+# Holmake generated files
+*Theory.sig
+*Theory.sml
+*.uo
+*.ui
+
+# Holmake auxiliary files
+.hollogs
+.HOLMK


### PR DESCRIPTION
### Reasons

Making it easier to get started with HOL.

### Support

 * The [`.gitignore` of the HOL repository itself](https://github.com/HOL-Theorem-Prover/HOL/blob/1987aafcbd814f863390e4d8de9f5b93bed479cb/.gitignore#L1-L8).
 * The [`.gitignore` of CakeML, a large project implemented in HOL](https://github.com/CakeML/cakeml/blob/master/.gitignore#L1-L10).
 * Section 8.3 in [The HOL System Description](http://sourceforge.net/projects/hol/files/hol/kananaskis-12/kananaskis-12-description.pdf/download).
 * A private conversation with long-time maintainer @mn200 confirming that the change represents a reasonable default.

### About

Quoting from [hol-theorem-prover.org](https://hol-theorem-prover.org):

> **What is HOL?**
> The HOL interactive theorem prover is a proof assistant for higher-order logic: a programming environment in which theorems can be proved and proof tools implemented. Built-in decision procedures and theorem provers can automatically establish many simple theorems (users may have to prove the hard theorems themselves!) An oracle mechanism gives access to external programs such as SMT and BDD engines. HOL is particularly suitable as a platform for implementing combinations of deduction, execution and property checking.

> **History**
> During the last 30 years there have been several widely used versions of the HOL system:
>
>  1. HOL88 from Cambridge;
>  2. HOL90 from Calgary and Bell Labs;
>  3. HOL98 from Cambridge, Glasgow and Utah.
