### PR TITLE
Ignore build cache file for Android Studio 3.1+

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -61,3 +61,6 @@ fabric.properties
 
 # Editor-based Rest Client
 .idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser


### PR DESCRIPTION
**Reasons for making this change:**

This build cache file is generated and contains full paths (specific to the user's checkout directory).

**Links to documentation supporting these rule changes:**

See this SO post: https://stackoverflow.com/questions/49557737/should-i-add-idea-caches-build-file-checksums-ser-to-gitignore

and this Google issue tracker ticket: https://issuetracker.google.com/issues/77544553

for justification.