### PR TITLE
Added *_wpftmp.csproj to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -76,6 +76,7 @@ StyleCopReport.xml
 *.tlh
 *.tmp
 *.tmp_proj
+*_wpftmp.csproj
 *.log
 *.vspscc
 *.vssscc


### PR DESCRIPTION
**Reasons for making this change:**

The temp proj file generated by msbuild for wpf projects was renamed from `*.tmp_proj` to `*_wpftmp.csproj`

**Links to documentation supporting these rule changes:**

https://github.com/Microsoft/msbuild/blob/master/documentation/wiki/MSBuild-Tips-%26-Tricks.md#diagnose-wpf-temporary-assembly-compilation-issues

>Also the name of the project was renamed from *.tmp_proj to *_wpftmp.csproj so the file extension is now C#: WpfApp1_jzmidb3d_wpftmp.csproj

