### PR TITLE
Adding .DS_Store to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -220,6 +220,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 orleans.codegen.cs
+.DS_Store
 
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)


### PR DESCRIPTION
**Reasons for making this change:**

`.DS_Store` is a file that gets generated by macOS. It contains metadata about the containing folder. The file is not meant to be shared. 

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store
