### PR TITLE
No need to fully exclude CodeRush settings

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -291,8 +291,8 @@ paket-files/
 .idea/
 *.sln.iml
 
-# CodeRush
-.cr/
+# CodeRush personal settings
+.cr/personal
 
 # Python Tools for Visual Studio (PTVS)
 __pycache__/


### PR DESCRIPTION
Currently, CodeRush provides the capability to store team settings and images used in Rich Comments and they should be shared among all team members. I have corrected the gitignore file to exclude only personal settings.

**Links to documentation supporting these rule changes:**

https://community.devexpress.com/blogs/rorybecker/archive/2018/07/02/coderush-new-options.aspx
