### PR TITLE
[TeX] Ignore generated files by 'comment' and 'xcolor' package

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -64,6 +64,9 @@ acs-*.bib
 # changes
 *.soc
 
+# comment
+*.cut
+
 # cprotect
 *.cpt
 
@@ -204,6 +207,9 @@ pythontex-files-*/
 
 # easy-todo
 *.lod
+
+# xcolor
+*.xcp
 
 # xmpincl
 *.xmpi


### PR DESCRIPTION
**Reasons for making this change:**

Certain environments for scientific journals use document templates that create a few more auxiliary files for the build that are not ignored by the project.

**Links to documentation supporting these rule changes:**

 * [`comment`](http://texdoc.net/texmf-dist/doc/latex/comment/comment.pdf) § 3.1 _"The cutfile"_
 * [`xcolor`](http://mirrors.nxthost.com/ctan/macros/latex/contrib/xcolor/xcolor.pdf) page 18, lower half: 

> [will] generate some PostScript code that is written to auxiliary file with the extension `.xcp`
