### PR TITLE
JetBrains.gitignore -- Added Markdown Navigator plugin config

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -65,8 +65,10 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
-# Markdown Navigator Plugin
+# Markdown Navigator Plugin for JetBrains' IDEs
 .idea/markdown-navigator/profiles_settings.xml
 markdown-exported-files.xml
 markdown-navigator.xml
 
+# Sonarlint Plugin for JetBrains' IDEs
+**/.idea/sonarlint

--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -67,4 +67,7 @@ fabric.properties
 
 # Markdown Navigator Plugin
 .idea/markdown-navigator/profiles_settings.xml
+markdown-exported-files.xml
+markdown-navigator.xml
+
 

--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -70,4 +70,3 @@ fabric.properties
 markdown-exported-files.xml
 markdown-navigator.xml
 
-

--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -64,3 +64,7 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Markdown Navigator Plugin
+.idea/markdown-navigator/profiles_settings.xml
+


### PR DESCRIPTION
Added the settings file created by Markdown Navigator, as it contains licensing information and should not normally be tracked.