### PR TITLE
New dependency manager delphi for delphi

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -64,3 +64,6 @@ __recovery/
 
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
+
+#Boss dependency manager vendor folder
+modules/

--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -65,5 +65,5 @@ __recovery/
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
 
-#Boss dependency manager vendor folder https://github.com/HashLoad/boss
+# Boss dependency manager vendor folder https://github.com/HashLoad/boss
 modules/

--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -65,5 +65,5 @@ __recovery/
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
 
-#Boss dependency manager vendor folder
+#Boss dependency manager vendor folder https://github.com/HashLoad/boss
 modules/


### PR DESCRIPTION
**Reasons for making this change:**

[boss](https://github.com/HashLoad/boss) use the module folder for the download dependencies and it is not necessary commit 

If this is a new template:

 - **Link to application or project’s homepage**: [boss](https://github.com/HashLoad/boss)
