### PR TITLE
Ignore backup of the report in VisualStudio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -242,6 +242,8 @@ UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/
 *.rptproj.bak
+* - Backup.rdl
+* - Backup (*).rdl
 
 # SQL Server files
 *.mdf


### PR DESCRIPTION
Ignore backups created during upgrading to newer version of VS

**Reasons for making this change:**

Example of the files created during upgrade from VS2005 to VS2013:
Alarms - Backup.rdl
Alarms - Backup (2).rdl

Those files are in the same directory as original Alarms.rdl, so it is not possible to filter by folder name.
