### PR TITLE
[Godot] Don't ignore export presets 

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,8 +1,5 @@
-
 # Godot-specific ignores
 .import/
-export.cfg
-export_presets.cfg
 
 # Mono-specific ignores
 .mono/


### PR DESCRIPTION
**Reasons for making this change:**

Export presets are useful to keep around, especially for use in CI/CD.