### PR TITLE
Ignore public/assets in Rails .gitignore

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -50,6 +50,7 @@ node_modules/
 # Ignore precompiled javascript packs
 /public/packs
 /public/packs-test
+/public/assets
 
 # Ignore yarn files
 /yarn-error.log


### PR DESCRIPTION
**Reasons for making this change:**

Ignore `public/assets` folder per https://github.com/rails/webpacker/issues/534.

**Links to documentation supporting these rule changes:**

https://github.com/rails/webpacker/issues/534
https://github.com/rails/rails/pull/29583