### PR TITLE
Update Julia.gitignore

### DIFF
--- a/Julia.gitignore
+++ b/Julia.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 deps/deps.jl
+docs/build
+docs/site


### PR DESCRIPTION
added the build folder for the documentation.

**Reasons for making this change:**

Documenter.jl creates all the needed files for the documentation in a doc/build folder. Best to ignore that.

**Links to documentation supporting these rule changes:**

https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#.gitignore-1
