### PR TITLE
Ignore the new Android Bundle generated files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,6 +1,7 @@
 # Built application files
 *.apk
 *.ap_
+*.aab
 
 # Files for the ART/Dalvik VM
 *.dex


### PR DESCRIPTION
A couple of weeks ago Google added a new format for Android generated files apart from the typical APKs: the [Android Bundle Files](https://developer.android.com/guide/app-bundle/#aab_format). They give more flexibility when uploading apps to the Google Play Console, and they shouldn't be tracked in Git projects.