### PR TITLE
Ignoring multi-directory a path without ** is not enough

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -1,4 +1,4 @@
-nbproject/private/
+**/nbproject/private/
 build/
 nbbuild/
 dist/


### PR DESCRIPTION
Ignoring multi-directory a path without ** is not enough for nested projects

**Reasons for making this change:**

The ignored path with multiple subdirs is not ignored when there are several of them in nested projects.

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
