### PR TITLE
[Python] set .python-version as Opt-In

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -78,7 +78,9 @@ profile_default/
 ipython_config.py
 
 # pyenv
-.python-version
+# for a library or a package, you might want to ignore this file since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# .python-version
 
 # celery beat schedule file
 celerybeat-schedule


### PR DESCRIPTION
This PR set `.python-version` as opt-in, and add detail comment like `.ruby-version`.

**Reasons for making this change:**

One of the major objectives of `pyenv` as stated [here](https://github.com/pyenv/pyenv/tree/75ca7613ada2533fb5a37b38eaff8c3b529dfcc9#pyenv-does) is:

* Provide support for per-project Python versions.

To achieve this objective, `.python-version` is used to set a local application-specific Python version. When this file is created in a project, it usually follows that developers lock Python version **by intention, not by accident**. Therefore, IMHO, it should be usually included in the target project.

If we want to support multiple versions, we can omit calling `pyenv local`, or opt-in `.python-version` as an ignored file.

Also, opt-in feature, by which `.python-version` is initially visible with `git`, improves developers' awareness on versions and avoids unnecessary cross version problems. In other words, opt-in helps maintain the situation where `.python-version` is intentionally added to ignores by developers who know well on version issues.

Feedback is welcome.

**Links to documentation supporting these rule changes:**

https://github.com/pyenv/pyenv
https://github.com/pyenv/pyenv/blob/75ca7613ada2533fb5a37b38eaff8c3b529dfcc9/COMMANDS.md#pyenv-local