### PR TITLE
vscode directory not ignored

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,4 +1,4 @@
-.vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json


### PR DESCRIPTION
**Reasons for making this change:**

.vscode/ folder is not being ignored when asterisk is used, so use just . .vscode/ instead
$ git --version
git version 2.17.1