### PR TITLE
Add gitignore for Snapcraft, Snaps are Universal Linux Packages

### DIFF
--- a/Snapcraft.gitignore
+++ b/Snapcraft.gitignore
@@ -1,0 +1,11 @@
+/parts/
+/stage/
+/prime/
+/*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2


### PR DESCRIPTION
Snaps are universal Linux packages that can be installed on a broad
range of GNU+Linux distributions with ease.  This patch implements
`gitignore(5)` file for Snapcraft, the official build utilty for building
snaps.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>

**Reasons for making this change:**

A large number of build artifacts will be created during the snap building process, which will be displayed as 'untracked files' and slow down Git and its frontends operation.

**Links to documentation supporting these rule changes:**

Refer [Snap Documentation - Documentation for snaps: Universal Linux packages](https://docs.snapcraft.io/t/snap-documentation/3781) for documentation of snapcraft.

The documentation site is just been transitioned to a new forum based infrastructure and may missing some pages, refer the old documentation site sources for those: [snappy-docs/build-snaps at master · canonical-docs/snappy-docs](https://github.com/canonical-docs/snappy-docs/tree/master/build-snaps).

Also refer [Create your first snap | Ubuntu tutorials](https://tutorials.ubuntu.com/tutorial/create-your-first-snap).

Some non-trivial paths are documented by comments.

 - **Link to application or project’s homepage**: [Snapcraft - Snaps are universal Linux packages](https://snapcraft.io/)
