### PR TITLE
Added *.VC.db to Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -23,6 +23,7 @@ ExportedObj/
 *.svd
 *.pdb
 *.opendb
+*.VC.db
 
 # Unity3D generated meta files
 *.pidb.meta


### PR DESCRIPTION
**Reasons for making this change:**

*.VC.db is an auto generated IntelliSense file from VS2015 Update 2 (replacing the .sdf file).

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/questions/36407386/what-is-the-vc-db-file-in-visual-studio-projects
