### PR TITLE
Add support for FuseBox

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -71,3 +71,6 @@ typings/
 
 # Serverless directories
 .serverless
+
+# FuseBox cache
+.fusebox/


### PR DESCRIPTION
Project site: [link](https://fuse-box.org/)

Corroboration: [link](https://fuse-box.org/docs/development/configuration#cache)

Reason: Don't VC cache

Hopefully, I did this correctly!

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
