### PR TITLE
Add .pyre directory for Pyre type checker

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# Pyre type checker
+.pyre/


### PR DESCRIPTION
Pyre is a new type-checker for Python developed by facebook in May 2018.
https://pyre-check.org/

**Reasons for making this change:**

`.pyre` directory stores result (including logs) and analysis (cache) for type checking.
This is environment dependent. So it should be ignored in Git.

**Links to documentation supporting these rule changes:**

- https://pyre-check.org/docs/overview.html
