### PR TITLE
Ignore Vim Swap file (*.swp)

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# Vim Swap files
+*.swp


### PR DESCRIPTION
**Reasons for making this change:**

Ignore Vim Swap file (*.swp)