### PR TITLE
Ignore the default ipython notebook.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -76,6 +76,7 @@ target/
 # IPython
 profile_default/
 ipython_config.py
+Untitled.ipynb
 
 # pyenv
 .python-version


### PR DESCRIPTION
**Reasons for making this change:**

I often run Jupyter Notebook from within a directory controlled by git. Sometimes I do this just to have a scratch space to test things in. Jupyter creates a notebook with the default name of Untitled.ipynb, which I view as Jupyter's version of a tmp file.  I think this should be ignored by git, as anything I want to keep will end up in a notebook with a real name.

**Links to documentation supporting these rule changes:**

No documentation.

If this is a new template:

 - **Link to application or project’s homepage**: N/A
