### PR TITLE
Add Visual studio code's .vscode/ folder.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -1,3 +1,7 @@
+# Visual Studio Code
+.vscode/
+# Remove a .DS_Store 
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
**Reasons for making this change:**

Add Visual Studio Code's .vscode/ folder, that's useless for many people who don't use vscode.

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_