### PR TITLE
[Terraform] added plan files

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -24,3 +24,6 @@ override.tf.json
 # Include override files you do wish to add to version control using negated pattern
 #
 # !example_override.tf
+
+# Ignore files created by `terraform plan -out=...`
+*plan


### PR DESCRIPTION
**Reasons for making this change:**

It is very convenient to save plans to a file, but this file should not be commited: they often contain secrets, credentials, etc.

**Links to documentation supporting these rule changes:**

https://www.terraform.io/docs/commands/plan.html#out-path
