### PR TITLE
[Xcode, Obj-C, Swift] Remove legacy settings files 

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -9,18 +9,5 @@ xcuserdata/
 *.xcscmblueprint
 *.xccheckout
 
-## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
-build/
-DerivedData/
-*.moved-aside
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-
 ## Gcc Patch
 /*.gcno

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -9,19 +9,6 @@ xcuserdata/
 *.xcscmblueprint
 *.xccheckout
 
-## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
-build/
-DerivedData/
-*.moved-aside
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-
 ## Obj-C/Swift specific
 *.hmap
 

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -9,19 +9,6 @@ xcuserdata/
 *.xcscmblueprint
 *.xccheckout
 
-## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
-build/
-DerivedData/
-*.moved-aside
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-
 ## Obj-C/Swift specific
 *.hmap
 


### PR DESCRIPTION
**Reasons for making this change:**

If you look for popular Xcode gitignore templates and its descriptions, you'll see that `pbxuser`, `mode1v3`, `mode2v3` and `perspectivev3` are ignored everywhere with comment that it is "user's preferences for the project, e.g. window sizes, active build style, file bookmarks, and a few other things". Original reference about its purpose comes back to Apple mailing lists from 2004-2007.

But for last 3+ years I never saw those files in Xcode projects. For my own use I removed them (lines in gitignore for my projects) and had no issues. Xcode still saves breakpoints and windows sizes, but they don't go inside repository. Easy to check - open your local `xcodeproj` folder (not just fresh git clone, but opened in Xcode before this) and try to find them. There are none.

We can safely exclude it to make templates cleaner.