### PR TITLE
ignore .DS_Store from repos using Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -74,3 +74,6 @@ typings/
 
 # FuseBox cache
 .fusebox/
+
+# macOS .DS_Store
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

.DS_Store files are currently useless for GitHub repositories.

**Links to documentation supporting these rule changes:**

?
