### PR TITLE
Add VS Code for Python

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -112,3 +112,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Visual Studio Code settings
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**

The folder added stores only local settings and is not necessary for a project to be shared with someone.

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs/getstarted/settings

If this is a new template:

 - **Link to application or project’s homepage**: https://github.com/Microsoft/vscode
