### PR TITLE
Added ignore for basic editor level settings for error in path, env etc.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -112,3 +112,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode stuff igonred
+.vscode/*
+
+# sublime stuff ignored
+*.sublime-*


### PR DESCRIPTION
Added Ignore for Basic Editor Level Changes Which Usually Causes:-
Env Error or Not Found
Uncompatible system level paths
Non existing keys etc.

Added For:-
Sublime-text
vscode
