### PR TITLE
Add `ARM` and `ARM64` to Visual Studio's ignore file.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -20,6 +20,8 @@
 [Rr]eleases/
 x64/
 x86/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
 bld/
 [Bb]in/
 [Oo]bj/


### PR DESCRIPTION
**Reasons for making this change:**

Recent editions of Visual Studio now permit building Windows drivers and Windows desktop apps for the ARM and ARM64 architectures. Visual Studio uses the architecture name for some of its build directories, 

**Links to documentation supporting these rule changes:**

This change follows existing precedent used for the `x64` and `x86` platforms.
