### PR TITLE
ignore files generated by Elixir Language Server

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -7,3 +7,4 @@ erl_crash.dump
 *.ez
 *.beam
 /config/*.secret.exs
+.elixir_ls/


### PR DESCRIPTION
**Reasons for making this change:**

In a lot of Elixir projects these days, I use the [Elixir Language Ssrver](https://github.com/JakeBecker/elixir-ls) for better integration with my text editor. ElixirLS caches a bunch of files it uses in the `.elixir_ls` directory, and this isn't intended to be checked in to source control.

**Links to documentation supporting these rule changes:**

https://github.com/JakeBecker/elixir-ls#dialyzer-integration