### PR TITLE
Ignore .DS_Store files in Nim.gitignore

### DIFF
--- a/Nim.gitignore
+++ b/Nim.gitignore
@@ -1,1 +1,4 @@
 nimcache/
+
+# OS X
+.DS_Store


### PR DESCRIPTION
The goal of this change is to ignore `.DS_Store` files from OS X.

**Reasons for making this change:**

The `.DS_Store` file, according to [Wikipedia](https://en.wikipedia.org/wiki/.DS_Store), is "a file that stores custom attributes of its containing folder, such as the position of icons or the choice of a background image."

Unless I'm missing something, there is no reason to commit `.DS_Store` files and propagate them within source control.

Thanks for considering this change! It's my first PR in this project, so if this isn't properly done, please let me know what I can do to fix it.