### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -35,3 +35,7 @@ sysinfo.txt
 # Builds
 *.apk
 *.unitypackage
+
+# Crashlytics generated file
+Assets/StreamingAssets/crashlytics-build.properties
+


### PR DESCRIPTION
Add ignore for Crashlytics generated file

**Reasons for making this change:**

This will ignore an automatically generated file from Crashlytics.

**Links to documentation supporting these rule changes:**

From inside this file:
>\# This file is automatically generated by Crashlytics to uniquely
>\# identify individual builds of your Android application.
>
>\# Do NOT modify, delete, or commit to source control!
