### PR TITLE
Add "network-security.data"

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -43,3 +43,7 @@ flycheck_*.el
 
 # directory configuration
 .dir-locals.el
+
+# network security
+/network-security.data
+


### PR DESCRIPTION
**Reasons for making this change:**
emacs adds `network-security.data` file automatically and the file should not be committed.

**Links to documentation supporting these rule changes:**
+ http://network-security.data
