### PR TITLE
Add ATE.gitignore for ATE development

### DIFF
--- a/ATE.gitignore
+++ b/ATE.gitignore
@@ -1,0 +1,60 @@
+
+### For C++ language related files
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+
+### For D10/DX Platform
+
+*.pat
+*/**/*rto/*
+*/**/*rtol/*
+*.make
+*.properties
+*.vpj
+*.vpw
+*.scan
+*.patl
+*.bakvpj
+*.bakvpw
+*.vpwhistu
+*.vtg
+*.pvs
+
+
+### For Project Management Related files
+.bak*
+*.xml
+*.zip
+*.tar
+*.gz


### PR DESCRIPTION
**Reasons for making this change:**

Currently there is no gitignore for test development using Automatic Test Equitment(ATE). It is tester-depedent and there may be many intermediate files and results of specific formats that shoudl be ignored.

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/Automatic_test_equipment

If this is a new template:

Since ATE is a field including many platforms, this template is to be further added.
