### PR TITLE
Add IntelliJ specific files to Java ignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -7,6 +7,12 @@
 # BlueJ files
 *.ctxt
 
+# IntelliJ
+*.iml
+.idea/
+out/
+.idea_modules/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 


### PR DESCRIPTION
**Reasons for making this change:**

IntelliJ IDEA is used more and more often for Java based project and this means that more people need IntelliJ specific files to be ignored.

[IntelliJ support page](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems) 