### PR TITLE
[TeX] Ignore generated files by 'vhistory' package

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -205,6 +205,10 @@ pythontex-files-*/
 # todonotes
 *.tdo
 
+# vhistory
+*.hst
+*.ver
+
 # easy-todo
 *.lod
 


### PR DESCRIPTION
**Reasons for making this change:**

The `vhistory` package generates two files, with `.hst` and `.ver` extensions.

**Links to documentation supporting these rule changes:**

[See chapter 1 - Introduction](http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/vhistory/doc/vh_sets_en.pdf)