### PR TITLE
Hide wheels directory used on Debian-like systems (Ubuntu)

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -20,6 +20,7 @@ parts/
 sdist/
 var/
 wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg


### PR DESCRIPTION
**Reasons for making this change:**

I keep having to do this when I create virtual environments for development on Ubuntu 18.04.1 LTS, so I thought it might help others to add it here. This affects all virtual environments created using, e.g., `python3 -m venv .`, in my experience.

**Links to documentation supporting these rule changes:**

This seems to be required by Debian Python Packaging Policy as outlined in [Section 3.2 here](https://www.debian.org/doc/packaging-manuals/python-policy/ch-module_packages.html)

In particular:
> When these binary packages are installed, `*.whl` files must be placed in the `/usr/share/python-wheels` directory. **The location inside a virtual environment will be rooted in the virtual environment, instead of `/usr`.**
(emphasis added to original)

🙇