### PR TITLE
Create Emacs.gitignore

### DIFF
--- a/Emacs.gitignore
+++ b/Emacs.gitignore
@@ -1,0 +1,5 @@
+# Auto-save files
+*#
+
+# Auto-backup files
+*~


### PR DESCRIPTION
**Reasons for making this change:**

The great auto saving mode from Emacs tend to be a source of pollution in you repo as it is not necessary to keep the auto-generated files under Git. As Emacs is there for a while now, I think it can be usefull for some people around :) 

**Links to documentation supporting these rule changes:**

The links below show you that you can parameter Emacs to get rid of the backup files, but for those who like this fonctionnality like me, it is better to keep it and just to ignore it in you Github repo :
https://emacsredux.com/blog/2013/05/09/keep-backup-and-auto-save-files-out-of-the-way/
https://www.gnu.org/software/emacs/manual/html_node/emacs/Backup.html

If this is a new template:

 - **Link to application or project’s homepage**: 
This is an exemple with an Emacs.gitignore :
https://github.com/tlentali/cheshire/tree/master

Thank you for your time, have a great day !