### PR TITLE
[JetBrains] starts to ignore all *.iml and modules.xml files

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -28,8 +28,8 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/modules.xml
-# .idea/*.iml
+# .idea/**/modules.xml
+# .idea/**/*.iml
 # .idea/modules
 
 # CMake


### PR DESCRIPTION
**Reasons for making this change:**

`*.iml` and `.idea/modules.xml` files will be generated on import so should be ignored by default

**Links to documentation supporting these rule changes:**

https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems