### PR TITLE
Added .gradle folder to unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -3,7 +3,11 @@
 [Oo]bj/
 [Bb]uild/
 [Bb]uilds/
+#Andoid build folder
+/.gradle/
 Assets/AssetStoreTools*
+
+
 
 # Visual Studio cache directory
 .vs/


### PR DESCRIPTION
The newest version of Unity creates a .gradle folder when creating an Android build, that is just unnecessary clutter.

This small addition helps solve that problem by ignoring it.