### PR TITLE
Add .godot/ folder to Godot.gitignore

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,8 +1,10 @@
 
 # Godot-specific ignores
+.cache/
 .import/
 export.cfg
 export_presets.cfg
 
 # Mono-specific ignores
 .mono/
+.vs/


### PR DESCRIPTION
**Reasons for making this change:**

Add `.godot/` folder to the Godot gitignore because in Godot 4.0 all generated files that should be gitignored will go in `.godot/`. This PR also updates the comments, let me know what you think.

Ignoring `.godot/` is harmless in Godot 3.x, and ignoring the rest will be harmless in Godot 4.x, so we can include both.

**Links to documentation supporting these rule changes:**

https://github.com/godotengine/godot/pull/38607 and https://github.com/godotengine/godot/pull/38704

 - **Link to application or project’s homepage**: https://godotengine.org/ and https://github.com/godotengine/godot
