### PR TITLE
Create AtmelStudio.gitignore

### DIFF
--- a/community/embedded/AtmelStudio.gitignore
+++ b/community/embedded/AtmelStudio.gitignore
@@ -1,0 +1,22 @@
+## Ignore Atmel Studio temporary files and build results
+# https://www.microchip.com/mplab/avr-support/atmel-studio-7
+
+# Atmel Studio is powered by an older version of Visual Studio,
+# so most of the project and solution files are the same as VS files,
+# only prefixed by an `at`.
+
+#Build Directories
+[Dd]ebug/
+[Rr]elease/
+
+#Build Results
+*.o
+*.d
+*.eep
+*.elf
+*.hex
+*.map
+*.srec
+
+#User Specific Files
+*.atsuo


### PR DESCRIPTION
Per PR #1614, creating a new PR that moves it into the `community/` folder.

Added a new .gitignore for Atmel Studio.
https://www.microchip.com/mplab/avr-support/atmel-studio-7

Atmel Studio is for embedded development, so the build result files are mostly C.
It's built on top of an old version of Visual Studio, so they prefixed VS file extensions with `at`.
Keeping user settings out of the repo applies to everyone in my opinion. 
It also used a similar build output directory structure as Visual Studio, hence the exclusion of `Debug` and `Release` directories.

This PR also introduces an `Embedded` directory in the community section.
I noticed a number of unmerged PRs for embedded development, like #2887, #2735, #2167, and #1239.
This introduces a place for the community to place embedded dev environment .gitignore files.
