### PR TITLE
Create Mule.gitignore

### DIFF
--- a/community/Mule.gitignore
+++ b/community/Mule.gitignore
@@ -1,0 +1,48 @@
+# gitignore template for Mule projects
+# website: https://www.mulesoft.com/platform/enterprise-integration
+#
+# Recommended template: Mule.gitignore
+
+# Java defaults (https://github.com/github/gitignore/blob/master/Java.gitignore) #
+# --- #
+*.class
+# Package Files #
+*.jar
+*.war
+*.ear
+# --- #
+# Eclipse-specific (https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore) #
+# --- #
+*.pydevproject
+.metadata
+bin/**
+tmp/**
+tmp/**/*
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+# You may want to remove the sharp symbols here if you are using Maven
+.project
+.classpath
+# External tool builders
+.externalToolBuilders/
+# Locally stored "Eclipse launch configurations"
+*.launch
+# CDT-specific
+.cproject
+# PDT-specific
+.buildpath
+# --------------- #
+# Studio-specific #
+# --------------- #
+.studio/
+flows/
+target/
+**/*.mflow
+catalog/
+reports/
+.mule/

--- a/community/Mule.gitignore
+++ b/community/Mule.gitignore
@@ -1,18 +1,20 @@
-# gitignore template for Mule projects
+# gitignore template for Mule projects (https://github.com/github/gitignore/pull/2891/files)
 # website: https://www.mulesoft.com/platform/enterprise-integration
 #
 # Recommended template: Mule.gitignore
 
+---------------------------------------------------------------------------------#
 # Java defaults (https://github.com/github/gitignore/blob/master/Java.gitignore) #
-# --- #
+---------------------------------------------------------------------------------#
 *.class
 # Package Files #
 *.jar
 *.war
 *.ear
-# --- #
+
+# --------------------------------------------------------------------------------------------#
 # Eclipse-specific (https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore) #
-# --- #
+----------------------------------------------------------------------------------------------#
 *.pydevproject
 .metadata
 bin/**
@@ -25,10 +27,14 @@ tmp/**/*
 local.properties
 .settings/
 .loadpath
+
 # You may want to remove the sharp symbols here if you are using Maven
 .project
 .classpath
+
+# -----------------------#
 # External tool builders
+# -----------------------#
 .externalToolBuilders/
 # Locally stored "Eclipse launch configurations"
 *.launch
@@ -36,6 +42,7 @@ local.properties
 .cproject
 # PDT-specific
 .buildpath
+
 # --------------- #
 # Studio-specific #
 # --------------- #


### PR DESCRIPTION
**Reasons for making this change:**

Mulesoft's[1] toolset is popular in the Middleware Application development and API enablement industry[2]. Its offerings are used by development teams at multiple organisations.

**Links to documentation supporting these rule changes:** 

Here's a brief description of why the listed files need to be ignored
 - *.studio/*: IDE specific configuration files
 - *flows/*: (No more valid. Preserved for the purpose of old projects)
 - *target/*: Compiled data
 - *catalog/*: Compiled data
 - *reports/*: Non-critical and runtime generated (unit test related) assets
 - *.mule/*: Runtime storage
  * **/*.mflow *: (No more valid. Preserved for the purpose of old projects)

 [1] **Link to application or project’s homepage**: https://www.mulesoft.com/platform/enterprise-integration
[2] http://www.investors.com/news/technology/mulesoft-ipo/
