### PR TITLE
remove rsconnect folder from R.gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -31,6 +31,3 @@ vignettes/*.pdf
 # Temporary files created by R markdown
 *.utf8.md
 *.knit.md
-
-# Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
-rsconnect/


### PR DESCRIPTION
**Reasons for making this change:**

The `rsconnect` folder does not contain any sensitive information (the deployment token is stored elsewhere). Moreover, it is recommended to be _tracked_ by VCS (and therefore _not_ in gitignore) in order to enable collaboration on published content.

**Links to documentation supporting these rule changes:**

http://docs.rstudio.com/connect/user/publishing.html#collaboration
