### PR TITLE
The global .gitignore ignores DLL, this is a problem with plugins in …

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -39,3 +39,5 @@ sysinfo.txt
 # Crashlytics generated file
 Assets/StreamingAssets/crashlytics-build.properties
 
+#Do not ignore plugins
+!/**/*.dll


### PR DESCRIPTION
…Unity 3D

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
