### PR TITLE
Improve comment capitalization consistency

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -29,7 +29,7 @@ ExportedObj/
 *.pidb.meta
 *.pdb.meta
 
-# Unity3D Generated File On Crash Reports
+# Unity3D generated file on crash reports
 sysinfo.txt
 
 # Builds


### PR DESCRIPTION
**Reasons for making this change:**

One comment in Unity.gitignore has capitalization that differs from all the others. This bothers OCD people like me, so I figured we might as well fix it.