### PR TITLE
[JetBrains] Add ignores for file-based projects

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -31,6 +31,8 @@
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules
+# *.iml
+# *.ipr
 
 # CMake
 cmake-build-*/


### PR DESCRIPTION
When IntelliJ project is created as a file-based (i.e. without `.idea` folder, but with `.iws`, `.iml` and `.ipr` files), and this is a Gradle or Maven project with auto-import, should ignore them as well for the same reason we ignore `.idea` folder content in that case.
