### PR TITLE
[VisualStudio] Added line to exclude coverity analysis directory.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -336,3 +336,6 @@ ASALocalRun/
 
 # Local History for Visual Studio
 .localhistory/
+
+# Coverity Analysis Folder
+.cov/


### PR DESCRIPTION
**Reasons for making this change:**

Coverity Desktop analysis folder was not being excluded but git

**Links to documentation supporting these rule changes:**

I don't have any outside documentation to link to other than all the developers here have Coverity Desktop Analysis loaded in Visual Studio and it creates a .cov hidden directory in the top level of the source code similar to the .vs cache directory. I tried searching to find some documentation of it online but I didn't find any. This is a line we add to all our git ignore files to exclude the Coverity folder.

If this is a new template:

 - **Link to application or project’s homepage**: Not a new template.
