### PR TITLE
Only unignore directories that have at least a character ending with .cache

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -211,7 +211,7 @@ _pkginfo.txt
 # files ending in .cache can be ignored
 *.[Cc]ache
 # but keep track of directories ending in .cache
-!*.[Cc]ache/
+!?*.[Cc]ache/
 
 # Others
 ClientBin/


### PR DESCRIPTION
**Reasons for making this change:**

We have an Fmod project in our C# repository that generates a `.cache` directory containing cache files. After updating the `.gitignore` file from this repository it is included in the git changes due to PR #1503.

**Links to documentation supporting these rule changes:**

The `?` makes sure we only include directories that end with `.cache`, but start with at least one other character.
