### PR TITLE
Ignore Generated Files

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -1,4 +1,6 @@
 **/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
 build/
 nbbuild/
 dist/


### PR DESCRIPTION
Netbeans Linux and Windows Makefile-*.mk and Package-*.bash files in nbproject directories are automatically generated during compile.  These files are continually updated, which can cause a long list of unnecessary files to add, commit, and push (or that are Untracked).  This has been experienced for Linux and Windows C++ projects.  Helpful supporting link: https://stackoverflow.com/questions/27490608/netbeans-c-and-git