### PR TITLE
Add ignorer to .env.test variable in NodeJS

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -56,6 +56,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.env.test
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
**Reasons for making this change:**

while working on my project, I realized that I always needed to add an ignore in the .env variable of tests, where I call .env.test, and I thought that many other people using this pattern go through the same thing, so I decided to try to sub.

**Links to documentation supporting these rule changes:**

I dont have a specific documentation link talking about having to use this pattern, but it's almost a convention, separating .env from tests by .env.test

If this is a new template:

None
