### PR TITLE
Added PyCharm project directory in Python's gitignore.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -103,6 +103,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea/
+
 # mkdocs documentation
 /site
 


### PR DESCRIPTION
**Reasons for making this change:**

PyCharm creates a .idea directory for storing project settings, so this line is for developers using PyCharm.

**Links to documentation supporting these rule changes:**

https://www.jetbrains.com/help/pycharm/project-and-ide-settings.html
"Project settings are stored with each specific project as a set of xml files under the .idea folder. If you specify the template project settings, these settings will be automatically used for each newly created project."
