### PR TITLE
[CakePHP] Ignoring user's migration lock file

### DIFF
--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -17,9 +17,13 @@
 /logs/*
 !/logs/empty
 
+/config/Migrations/schema-dump-default.lock
+
 # CakePHP 2
 
 /app/tmp/*
 /app/Config/core.php
 /app/Config/database.php
 /vendors/*
+
+

--- a/CakePHP.gitignore
+++ b/CakePHP.gitignore
@@ -25,5 +25,3 @@
 /app/Config/core.php
 /app/Config/database.php
 /vendors/*
-
-


### PR DESCRIPTION
Ignoring lock files htat are generated after cakephp migration is done
