### PR TITLE
Add Flask.gitignore

### DIFF
--- a/Flask.gitignore
+++ b/Flask.gitignore
@@ -1,0 +1,17 @@
+# Reference for Flask gitignore: http://flask.pocoo.org/docs/1.0/tutorial/layout/
+
+.gitignore
+venv/
+
+*.pyc
+__pycache__/
+
+instance/
+
+.pytest_cache/
+.coverage
+htmlcov/
+
+dist/
+build/
+*.egg-info/

--- a/Flask.gitignore
+++ b/Flask.gitignore
@@ -1,6 +1,4 @@
 # Reference for Flask gitignore: http://flask.pocoo.org/docs/1.0/tutorial/layout/
-
-.gitignore
 venv/
 
 *.pyc


### PR DESCRIPTION
**Reasons for making this change:**

There is currently not a gitignore for Flask.

**Links to documentation supporting these rule changes:**

I'm working through the Flask tutorial and found the gitignore here:
http://flask.pocoo.org/docs/1.0/tutorial/layout/

If this is a new template:

 - **Link to application or project’s homepage**: http://flask.pocoo.org
