### PR TITLE
add community template for ReactJS

### DIFF
--- a/community/JavaScript/ReactJS.gitignore
+++ b/community/JavaScript/ReactJS.gitignore
@@ -1,0 +1,24 @@
+# gitignore template for ReactJS projects
+# website: https://reactjs.org/
+
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Production
+/build
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
**Reasons for making this change:**

There is currently not a gitignore template for ReactJS projects.

**Links to documentation supporting these rule changes:**

I am working through a ReactJS tutorial and was provided with the gitignore here:
[https://reactjs.org/docs/getting-started.html](https://reactjs.org/docs/getting-started.html)

If this is a new template:

 - **Link to application or project’s homepage**: [https://reactjs.org/](https://reactjs.org/)
