### PR TITLE
✨ Create iOS.gitignore

### DIFF
--- a/iOS.gitignore
+++ b/iOS.gitignore
@@ -1,0 +1,2 @@
+# Google Services (e.g. APIs or Firebase)
+GoogleService-Info.plist


### PR DESCRIPTION
**Reasons for making this change:**

By default, the template for Android ignores the Android equivalent of this file: `google-services.json`. Because this file contains API keys, it should be ignored by default.

**Links to documentation supporting these rule changes:**

https://github.com/github/gitignore/blob/18654b47c86bef38add5cd091ec2dac7d6e6e37b/Android.gitignore#L54-L55

If this is a new template:

 - **Link to application or project’s homepage**:
   - https://developer.apple.com/
   - https://firebase.google.com/docs/ios/setup
   - https://firebase.google.com/docs/flutter/setup#configure_an_ios_app
