### PR TITLE
ignore android lint temp files.

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -68,3 +68,10 @@ fastlane/readme.md
 
 # Version control
 vcs.xml
+
+# lint
+lint/intermediates/
+lint/generated/
+lint/outputs/
+lint/tmp/
+# lint/reports/


### PR DESCRIPTION
Android lint result contains some tmp files, should not be tracked.
