### PR TITLE
Unity: ignore mdbs, fix path to crashlytics file, make AssetStoreTools optional

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -4,7 +4,9 @@
 [Bb]uild/
 [Bb]uilds/
 [Ll]ogs/
-[Aa]ssets/AssetStoreTools*
+
+# Uncomment this line if you wish to ignore the asset store tools plugin
+# [Aa]ssets/AssetStoreTools*
 
 # Visual Studio cache directory
 .vs/

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,12 +26,14 @@ ExportedObj/
 *.booproj
 *.svd
 *.pdb
+*.mdb
 *.opendb
 *.VC.db
 
 # Unity3D generated meta files
 *.pidb.meta
 *.pdb.meta
+*.mdb.meta
 
 # Unity3D generated file on crash reports
 sysinfo.txt
@@ -41,5 +43,5 @@ sysinfo.txt
 *.unitypackage
 
 # Crashlytics generated file
-Assets/StreamingAssets/crashlytics-build.properties
+crashlytics-build.properties
 


### PR DESCRIPTION
Unity projects targeting the 2.0/3.5 runtime or built with mono < v5.0 generate `mdb` files, not `pdb` files, so those need to be in here as well.

Looks like the `crashlytics-build.properties` gets around in more than just the `StreamingAssets` folder, looking at [examples around the internets](https://github.com/auth0/sharelock-android/blob/master/app/src/main/assets/crashlytics-build.properties), so it should probably just be ignored as a filename.

As for the `AssetStoreTools` entry, only people building Unity plugins will need to import the asset store tools plugin into their project, and it's a toss up whether they want to commit the tooling into their repo (they might or they might not want to, it highly depends on their workflow). The default .gitignore shouldn't be making this choice for these users, and this line isn't relevant for game projects. Maybe a separate `Unity Asset Store Package` template would be useful... 🤔 