### PR TITLE
Android.gitignore: Add build_file_checksums.ser and modules.xml files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -42,6 +42,9 @@ captures/
 .idea/dictionaries
 .idea/libraries
 .idea/caches
+# Android Studio 3 in .gitignore file.
+.idea/caches/build_file_checksums.ser
+.idea/modules.xml
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.


### PR DESCRIPTION
**Reasons for making this change:**

**Android.gitignore** was missing `.idea/caches/build_file_checksums.ser` and `.idea/modules.xml`

**Links to documentation supporting these rule changes:**

New Android projects in Android Studio +3 created with a **.gitignore** file that contain `build_file_checksums.ser` and `modules.xml`

Also: https://stackoverflow.com/a/17803964/1429432

If this is a new template:

 - **Link to application or project’s homepage**: 
