### PR TITLE
Unity: ignore Rider cache as well as Visual Studio

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -11,6 +11,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Rider cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**

IDE cache files are not typically committed to source control, and the master branch currently ignores one such IDE's cache already (VS).

https://unity3d.com

https://www.jetbrains.com/help/idea/creating-and-managing-projects.html