### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -16,6 +16,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+coverage.lcov
 
 # nyc test coverage
 .nyc_output

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -16,7 +16,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
-coverage.lcov
+*.lcov
 
 # nyc test coverage
 .nyc_output


### PR DESCRIPTION
**Reasons for making this change:**

It need `coverage.lcov` file to integrate **nyc** and **Codecov**. I recommend to add it because it's created locally when someone will check that the node command that creating `coverage.lcov` file works correctly.

**Links to documentation supporting these rule changes:**

https://github.com/istanbuljs/nyc#integrating-with-codecov
