### PR TITLE
Adds .gitignore for Adventure Game Studio Projects

### DIFF
--- a/AGS.gitignore
+++ b/AGS.gitignore
@@ -1,0 +1,26 @@
+# Adventure Game Studio git ignore
+# --------------------------------
+# Built things
+_Debug/
+_Release/
+Compiled/
+*.exe
+
+#Audio Cache can be rebuilt from sources
+AudioCache/
+
+# User
+_OpenInEditor.lock
+Game.agf.user
+
+# backups
+Game.agf.bak
+backup_acsprset.spr
+
+# memory dumps
+*.dmp
+
+# temporary files
+~aclzw.tmp
+game28.dta
+warnings.log

--- a/AGS.gitignore
+++ b/AGS.gitignore
@@ -1,26 +1,34 @@
 # Adventure Game Studio git ignore
 # --------------------------------
+
 # Built things
 _Debug/
-_Release/
 Compiled/
-*.exe
 
-#Audio Cache can be rebuilt from sources
+# AudioCache can be rebuilt from sources
 AudioCache/
 
-# User
+# Lockfile
 _OpenInEditor.lock
-Game.agf.user
 
-# backups
+# User settings
+Game.agf.user
+*.crm.user
+
+# Backups
 Game.agf.bak
 backup_acsprset.spr
 
-# memory dumps
+# Memory dumps
 *.dmp
 
-# temporary files
+# Temporary files
+# temporarily created during sprite or room background compression
 ~aclzw.tmp
+# temporary, main game data, before getting packed into exe
 game28.dta
+# temporary build of the game before being moved to Compiled/ folder
+*.exe
+
+# Log files
 warnings.log

--- a/AdventureGameStudio.gitignore
+++ b/AdventureGameStudio.gitignore
@@ -1,6 +1,3 @@
-# Adventure Game Studio git ignore
-# --------------------------------
-
 # Built things
 _Debug/
 Compiled/


### PR DESCRIPTION
**Reasons for making this change:**

Adds a .gitignore for [Adventure Game Studio](https://github.com/adventuregamestudio/ags) Projects. There is some [discussion](https://www.adventuregamestudio.co.uk/forums/index.php?topic=52882.0) on it here.

**Links to documentation supporting these rule changes:**

This is a new template for Adventure Game Studio projects. The game is written in AGScript using the [Adventure Game Studio](https://github.com/adventuregamestudio/ags) tool. This `.gitignore` should help game creators who wants to use **`git`** through ***Github*** to version their game.

If this is a new template:

 - **Link to application or project’s homepage**: https://www.adventuregamestudio.co.uk/
