### PR TITLE
Create Dframe.gitignore

### DIFF
--- a/Dframe.gitignore
+++ b/Dframe.gitignore
@@ -1,0 +1,16 @@
+# Ignore files that are auto-generated
+app/View/templates_c/*
+app/View/cache/*
+app/View/logs/*
+web/assets/*
+vendor
+
+# Force include 
+!app/View/templates_c/.gitkeep
+!app/View/cache/.gitkeep
+!app/View/logs/.gitkeep
+!web/assets/.gitkeep
+
+# Ignore IDE
+.project
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**

To add gitignore for Dframe Framework

**Links to documentation supporting these rule changes:**

https://github.com/dframe/dframe-demo/blob/master/.gitignore

 - **Link to application or project’s homepage**: 

http://dframeframework.com/
