### PR TITLE
Update Ruby.ignore to ignore .byebug_history file

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -13,6 +13,9 @@
 # Used by dotenv library to load environment variables.
 # .env
 
+# Ignore Byebug command history file.
+.byebug_history
+
 ## Specific to RubyMotion:
 .dat*
 .repl_history


### PR DESCRIPTION




**Reasons for making this change:**

The file `.byebug_history` is generated when using the popular https://github.com/deivid-rodriguez/byebug gem for debugging in Ruby. It contains a list of commands the user has run while debugging, which should not be committed to the repository. 

**Links to documentation supporting these rule changes:**

The author of the gem agrees with excluding the history file: https://github.com/deivid-rodriguez/byebug/issues/204#issuecomment-178238302

I have copied this from the Rails gitignore here: https://github.com/github/gitignore/blob/f908e51bcf38ae5ede449c55189a7b25d8c507cc/Rails.gitignore#L44-L45

If this is a new template:

 - **Link to application or project’s homepage**: n/a
