### PR TITLE
Unity: Never ignore asset meta data

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -5,6 +5,9 @@
 [Bb]uilds/
 [Ll]ogs/
 
+# Never ignore Asset meta data
+![Aa]ssets/**/*.meta
+
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # [Aa]ssets/AssetStoreTools*
 


### PR DESCRIPTION
**Reasons for making this change:**

If I were to use the Unity.gitignore (for example as part of a project) and the VisualStudio.gitignore (for example as my global gitignore) at the same time, I could run into problems, because the VS one ignores *.meta and Unity relies heavily on these.

This change just makes sure that the *.meta files in the Assets directory are always added to the version control. 

I can see that the necessity of this is debatable, but due to the fact that Visual Studio is the de facto default for Unity under Windows, I think this fix is reasonable.

**Links to documentation supporting these rule changes:**

https://docs.unity3d.com/Manual/ExternalVersionControlSystemSupport.html

