### PR TITLE
Ignore CMake FetchContent directory

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -8,3 +8,4 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
+_deps


### PR DESCRIPTION
**Reasons for making this change:**

CMake's `FetchContent` module creates a `_deps` directory on the root (configurable by modifying `FETCHCONTENT_BASE_DIR`).

**Links to documentation supporting these rule changes:**

https://cmake.org/cmake/help/latest/module/FetchContent.html