### PR TITLE
Add pip-wheel-metadata to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -20,6 +20,7 @@ parts/
 sdist/
 var/
 wheels/
+pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
 .installed.cfg


### PR DESCRIPTION
**Reasons for making this change:**

PEP-517 has resulted in some updates to the Python build process. As a result, a new directory called pip-wheel-metadata is created on fresh builds. This PR adds this directory into the Python default gitignore. 

**Links to documentation supporting these rule changes:**

See
https://github.com/pypa/pip/blob/e5f4bbb7ddff87f48f2b5815513e4211ccdde83a/src/pip/_internal/req/req_install.py#L568