### PR TITLE
Create Defold.gitignore

### DIFF
--- a/Defold.gitignore
+++ b/Defold.gitignore
@@ -1,0 +1,10 @@
+/.internal
+/build
+.externalToolBuilders
+.DS_Store
+Thumbs.db
+.lock-wscript
+*.pyc
+.project
+.cproject
+builtins


### PR DESCRIPTION
A simple .gitignore file for the Defold Game Engine (https://www.defold.com).

**Reasons for making this change:**

There is no `.gitignore` file available yet for Defold, a multi-platform game engine.

**Links to application and project’s homepage**: 
Homepage: https://www.defold.com
Empty project: https://github.com/defold/template-empty
