### PR TITLE
[Codesniffer] remove duplicate Composer rule

### DIFF
--- a/community/PHP/CodeSniffer.gitignore
+++ b/community/PHP/CodeSniffer.gitignore
@@ -3,5 +3,4 @@
 #
 # Recommended template: PHP.gitignore
 
-/vendor/*
 /wpcs/*


### PR DESCRIPTION
**Reasons for making this change:**

**/vendor/** directory is already defined in it's own file: **Composer.gitignore**
https://github.com/github/gitignore/blob/master/Composer.gitignore


**Links to documentation supporting these rule changes:**

https://github.com/github/gitignore/blob/master/Composer.gitignore


**Link to application or project’s homepage**: 

https://github.com/squizlabs/PHP_CodeSniffer