### PR TITLE
Updated Unity.gitignore to allow subfolders by default

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -1,9 +1,9 @@
-[Ll]ibrary/
-[Tt]emp/
-[Oo]bj/
-[Bb]uild/
-[Bb]uilds/
-[Ll]ogs/
+/[Ll]ibrary/
+/[Tt]emp/
+/[Oo]bj/
+/[Bb]uild/
+/[Bb]uilds/
+/[Ll]ogs/
 
 # Never ignore Asset meta data
 ![Aa]ssets/**/*.meta


### PR DESCRIPTION
**Reasons for making this change:**
The existing .gitignore also ignores folders subfolders with the given names. For example, a plugin or user code might exist at Assets/Buildings/Library/code.cs which would be ignored. This change makes only the given folders in the base directory get ignored.
