### PR TITLE
Remove trailing whitespace added last commit.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -337,5 +337,5 @@ ASALocalRun/
 # Local History for Visual Studio
 .localhistory/
 
-# BeatPulse healthcheck temp database 
+# BeatPulse healthcheck temp database
 healthchecksdb


### PR DESCRIPTION
**Reasons for making this change:**

Last commit on this file added trailing whitespace.

**Links to documentation supporting these rule changes:**

[Why is trailing whitespace a big deal? [closed]](https://softwareengineering.stackexchange.com/questions/121555/why-is-trailing-whitespace-a-big-deal)