### PR TITLE
Added .gitignore for EiffelStudio projects

### DIFF
--- a/EiffelStudio.gitignore
+++ b/EiffelStudio.gitignore
@@ -1,0 +1,53 @@
+# Generated from https://www.gitignore.io/api/macos,windows,eiffelstudio with changes recommended by http://ftft.dk/articles/gitignore/
+### EiffelStudio ###
+# The compilation directory
+EIFGENs
+!EIFGENs/*/Diagrams
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk


### PR DESCRIPTION
Generated from https://www.gitignore.io/api/macos,windows,eiffelstudio with changes recommended by http://ftft.dk/articles/gitignore/

**Reasons for making this change:**

Provides a base .gitignore for development of Eiffel projects in Eiffel Studio

**Links to documentation supporting these rule changes:**

* https://www.gitignore.io/api/macos,windows,eiffelstudio
* http://ftft.dk/articles/gitignore/

If this is a new template:

https://www.eiffel.com/
