### PR TITLE
Add *.creator.user* files to the Qt .gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -44,3 +44,6 @@ CMakeLists.txt.user*
 
 # QtCreator 4.8< compilation database 
 compile_commands.json
+
+# QtCreator local machine specific files for imported projects
+*creator.user*


### PR DESCRIPTION
When importing a Makefile based project the QtCreator creates a {projectname}.creator.user and a {projectname}.creator.user.{version} files.

These files contains machine specific things (like used Qt kits, build paths, etc.) thus it is useful to add to the .gitignore.

For proof this here is a section from one imported project:
```
   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Qt 5.10.0 (gcc_64)</value>
   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Qt 5.10.0 (gcc_64)</value>
   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{ac6ca3f1-1d92-48a4-8be8-745f8830b0d7}</value>
   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/mm/Projektek/rescube/r16_ws/src/rqt_plot_qtcharts</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
```
(Both the kits name/type and the BuildDirectory is machine specific).