### PR TITLE
added .DS_Store

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -97,6 +97,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Mac OSX
+.DS_Store
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
**Reasons for making this change:**

Mac OSX adds `.DS_Store` to directories which are viewed in Finder. This file
is not needed as part of a normal git repo.