### PR TITLE
added adbkey

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -6,3 +6,6 @@ export_presets.cfg
 
 # Mono-specific ignores
 .mono/
+
+#android-build specific
+adbkey


### PR DESCRIPTION

This file is generated by the android SDK when making a a build through godot, but it's not actually part of the project