### PR TITLE
Added cpython extension, found in vscode flask project

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.cpython
 
 # Distribution / packaging
 .Python


### PR DESCRIPTION
The extension refers to the files included because of the original implementation of python written in C. 
I encountered it, when I was working on a flask project in visual studio code, using python 3.7 and using default python extension from Microsoft for vs code and a linter for 64-bit version.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
