### PR TITLE
Ignore Visual Studio Code cache directory for Unity project

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -14,6 +14,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**

Ignore visual studio cache directory for Unity projects

**Links to documentation supporting these rule changes:**

> The workspace setting file is located under the `.vscode` folder in your root folder.
> \- https://code.visualstudio.com/docs/getstarted/settings

