### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -26,6 +26,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+enc_temp_folder/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
**Reasons for making this change:**

enc_temp_folder/  folder is created after building a project in visual studio.

**Links to documentation supporting these rule changes:**
Take a look at this repository for example.
https://github.com/jackmott/dungeonbuilder/blob/master/.gitignore

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
