### PR TITLE
Updated Unity's gitignore file to include JetBrains Rider's cache folder

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -14,6 +14,9 @@
 # Visual Studio cache directory
 .vs/
 
+# JetBrain Rider cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
JetBrains Rider's full support for Unity is on the run for a long time now and many developers are using it. However, each time .idea folder must be added to .gitignore file. It should be there by default.

An example case can be found here: https://stackoverflow.com/questions/53236846/the-gitignore-setting-for-the-idea-folder-of-jetbrains-riders-does-not-work

