### PR TITLE
Ignore Windows dump files

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -5,6 +5,9 @@ ehthumbs_vista.db
 
 # Dump file
 *.stackdump
+*.dmp
+*.dump
+*.mdmp
 
 # Folder config file
 [Dd]esktop.ini

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -224,6 +224,11 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
+# Dump files containing OS information including username, network shares, etc. recorded during crash
+*.dmp
+*.dump
+*.mdmp
+
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk


### PR DESCRIPTION
Ignores several possible dump file extensions where OS information (including username, network shares, etc.) may be recorded during application crash. This issue was only discovered after being pushed to a remote origin from a *non-VisualStudio* repository.

Without further analysis, the suspected origin of the dump file is a SublimeText plugin. Consideration should be given as to whether these ignore lines should be introduced for other project types where software running in the local repository directory may be involved.