### PR TITLE
[Global/Eclipse] add ".project" file

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -11,6 +11,9 @@ local.properties
 .loadpath
 .recommenders
 
+# Project description file
+.project
+
 # External tool builders
 .externalToolBuilders/
 


### PR DESCRIPTION
ignore project description file

**Reasons for making this change:**

Ignore generated file by eclipse .

**Links to documentation supporting these rule changes:**

https://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fproject_description_file.html

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
