### PR TITLE
[Node] Ignore diagnostic report files

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -5,7 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Diagnostic reports
+# Diagnostic reports (https://nodejs.org/api/report.html)
 report.*.json
 
 # Runtime data

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Diagnostic reports
+report.*.json
+
 # Runtime data
 pids
 *.pid

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -6,7 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
-report.*.json
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Runtime data
 pids


### PR DESCRIPTION
**Reasons for making this change:**

To ignore diagnostic reports created by NodeJS, usually only relevant to the current computer.

**More information:**

[NodeJS Reporting Documentation](https://nodejs.org/api/report.html)
[What is NodeJS?](https://nodejs.org)
