### PR TITLE
Add .phpunit.result.cache to the .gitignore

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -15,3 +15,4 @@ storage/*.key
 Homestead.yaml
 Homestead.json
 /.vagrant
+.phpunit.result.cache


### PR DESCRIPTION
**Reasons for making this change:**

PHPUnit version 7.3 adds a new argument `--cache-result` which allows you to do things like re-run test failures.

**Links to documentation supporting these rule changes:**

https://github.com/laravel/laravel/blob/master/.gitignore
