### PR TITLE
R: ignore user-specific files

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -5,6 +5,9 @@
 # Session Data files
 .RData
 
+# User-specific files
+.Ruserdata
+
 # Example code in package build process
 *-Ex.R
 


### PR DESCRIPTION
This request is based on [RStudio](https://www.rstudio.com/)'s [default gitignore file](https://github.com/rstudio/rstudio/blob/master/src/cpp/session/modules/SessionGit.cpp). [It includes .Ruserdata](https://github.com/rstudio/rstudio/blob/0befc1f6ac03b3ce66f1e3d250ddaa48041b75f1/src/cpp/session/modules/SessionGit.cpp#L2983) in addition to other files which are already included here.