### PR TITLE
Update VisualStudio.gitignore file

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -21,14 +21,14 @@ mono_crash.*
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
-[Xx]64/
-[Xx]86/
+x64/
+x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
-[Bb]in*/
-[Oo]bj*/
-[Ll]og*/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -13,19 +13,22 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# Mono auto generated files
+mono_crash.*
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
-x64/
-x86/
+[Xx]64/
+[Xx]86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
-[Bb]in/
-[Oo]bj/
-[Ll]og/
+[Bb]in*/
+[Oo]bj*/
+[Ll]og*/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
**Reasons for making this change:**

Added
mono_crash.* // Some executed unit tests in a .NET Core project may lead to a mono crash which then generates this file

Changed:
// Just to be conform with the other folder name conventions
x64/ => [Xx]64/
x86/ => [Xx]86/

// Visual Studio For Mac sometimes creates multiple bin and obj folders with increasing numbers, e.g. "bin 2/" (bin n/ where n = i + 1 and i starts from 0)
[Bb]in/ => [Bb]in*/
[Oo]bj/ => [Oo]bj*/
[Ll]og/ => [Ll]og*/

**Links to documentation supporting these rule changes:**

🤷🏻‍♂️