### PR TITLE
Add .DS_STORE for mac os

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -78,3 +78,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+# MacOs
+*.DS_STORE


### PR DESCRIPTION
Mac os created .DS_STORE into each folder. We don't need to include this file into the git repository.

**Reasons for making this change:**

The previous version don't be well for MacOs user