### PR TITLE
Add ignore rules for Pipenv

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -82,6 +82,9 @@ ipython_config.py
 # pyenv
 .python-version
 
+# pipenv
+Pipfile.lock
+
 # celery beat schedule file
 celerybeat-schedule
 

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -83,7 +83,9 @@ ipython_config.py
 .python-version
 
 # pipenv
-Pipfile.lock
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in VCS.
+#   However, in case of collaboration, Pipfile.lock may conflict on different OS.
+#Pipfile.lock
 
 # celery beat schedule file
 celerybeat-schedule

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -83,7 +83,7 @@ ipython_config.py
 .python-version
 
 # pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in VCS.
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, Pipfile.lock may conflict on different OS.
 #Pipfile.lock
 

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -84,7 +84,9 @@ ipython_config.py
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, Pipfile.lock may conflict on different OS.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   install all needed dependencies.
 #Pipfile.lock
 
 # celery beat schedule file


### PR DESCRIPTION
Pipenv uses Pipfile.lock to maintain Python package information
(metadata, hash, etc.) installed as described in Pipfile. Thus,
Pipfile.lock may vary on different operating systems, platforms
when collaborating. This PR adds Pipfile.lock into the Python
default gitignore. See http://pipenv.org