### PR TITLE
Add MAlonzo directory.

### DIFF
--- a/Agda.gitignore
+++ b/Agda.gitignore
@@ -1,1 +1,2 @@
 *.agdai
+MAlonzo/**


### PR DESCRIPTION
**Reasons for making this change:**

Agda generates a MAlonzo directory, which should not be included in repositories.

**Links to documentation supporting these rule changes:**

https://wiki.portal.chalmers.se/agda/pmwiki.php?n=Docs.MAlonzo
