### PR TITLE
[Unity] Added leading slashes to ignored directories so that valid subdirectories aren't ignored incorrectly

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -1,9 +1,9 @@
-[Ll]ibrary/
-[Tt]emp/
-[Oo]bj/
-[Bb]uild/
-[Bb]uilds/
-[Ll]ogs/
+/[Ll]ibrary/
+/[Tt]emp/
+/[Oo]bj/
+/[Bb]uild/
+/[Bb]uilds/
+/[Ll]ogs/
 
 # Never ignore Asset meta data
 ![Aa]ssets/**/*.meta

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -1,3 +1,5 @@
+# This .gitignore file should be placed at the root of your Unity project directory
+
 /[Ll]ibrary/
 /[Tt]emp/
 /[Oo]bj/
@@ -9,7 +11,7 @@
 ![Aa]ssets/**/*.meta
 
 # Uncomment this line if you wish to ignore the asset store tools plugin
-# [Aa]ssets/AssetStoreTools*
+# /[Aa]ssets/AssetStoreTools*
 
 # Visual Studio cache directory
 .vs/

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -8,7 +8,7 @@
 /[Ll]ogs/
 
 # Never ignore Asset meta data
-![Aa]ssets/**/*.meta
+!/[Aa]ssets/**/*.meta
 
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # /[Aa]ssets/AssetStoreTools*


### PR DESCRIPTION
**Reasons for making this change:**

The lines at the top of the .gitignore would ignore the folders at the root of the directory (which is correct behaviour), but would also ignore **any subfolder with that name** anywhere else in the project (which is incorrect behaviour).

Example of Incorrect Behaviour: `/Assets/Scripts/Library/Example.cs` would previously be incorrectly ignored.

This change fixes that issue and **only** ignores the folders at the root of the project directory.

**Links to documentation supporting these rule changes:**

StackOverflow post detailing a similar situation: https://stackoverflow.com/questions/24139478/when-to-use-leading-slash-in-gitignore

My own testing replicates the behaviour described in that post.