### PR TITLE
Unity: ignore TextMesh Pro

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -11,6 +11,9 @@
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # [Aa]ssets/AssetStoreTools*
 
+# TextMesh Pro files
+[Aa]ssets/TextMesh*Pro/
+
 # Visual Studio cache directory
 .vs/
 


### PR DESCRIPTION
**Reasons for making this change:**
TextMesh Pro is fully integrated in Unity since 2017 and all related resources are managed by Unity's Package Manager. So it would make sense to ignore them by default
**Links to documentation supporting these rule changes:**
Check out [the official blog post](https://blogs.unity3d.com/2017/03/20/textmesh-pro-joins-unity/) from early 2017