### PR TITLE
Remove Rider (idea) ignore statements from Visual Studio template

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -293,10 +293,6 @@ paket-files/
 # FAKE - F# Make
 .fake/
 
-# JetBrains Rider
-.idea/
-*.sln.iml
-
 # CodeRush personal settings
 .cr/personal
 


### PR DESCRIPTION
Rider has its own ignore file, so does Visual Studio. The ignore statements for Rider (idea) IDE should be removed from Visual Studio .gitignore file template.

Discussion: https://github.com/github/gitignore/commit/e429db11802448b3d7e7305ee78df1ee918b8fc6