### PR TITLE
fix gradle ignore

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,6 +1,9 @@
 .gradle
 /build/
 
+# Ignore some java file
+!/build/**/*.java
+
 # Ignore Gradle GUI config
 gradle-app.setting
 


### PR DESCRIPTION
**Reasons for making this change:**

Some java file that located at  'src/com/company/build/' would also be ignored.
So I add exclude expression.

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
