### PR TITLE
VisualStudio: Add more Windows Store app package types

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -209,6 +209,8 @@ BundleArtifacts/
 Package.StoreAssociation.xml
 _pkginfo.txt
 *.appx
+*.appxbundle
+*.appxupload
 
 # Visual Studio cache files
 # files ending in .cache can be ignored


### PR DESCRIPTION
**Reasons for making this change:**

Visual Studio can also generate .appxbundle and .appxupload files for Windows Store apps.

**Links to documentation supporting these rule changes:**

https://docs.microsoft.com/en-us/windows/uwp/packaging/packaging-uwp-apps#types-of-app-packages
