### PR TITLE
Ignore files generated by luatexja-ruby

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -137,6 +137,9 @@ acs-*.bib
 # listings
 *.lol
 
+# luatexja-ruby
+*.ltjruby
+
 # makeidx
 *.idx
 *.ilg


### PR DESCRIPTION
**Reasons for making this change:**

To ignore files generated by luatexja-ruby

**Links to documentation supporting these rule changes:**

https://ctan.org/tex-archive/macros/luatex/generic/luatexja/doc
