### PR TITLE
add Docker.ignore

### DIFF
--- a/Docker.gitignore
+++ b/Docker.gitignore
@@ -1,0 +1,19 @@
+.git
+.idea
+.DS_Store
+.gitignore
+README.md
+env.*
+logs/
+
+# Docker files
+.dockerignore
+Dockerfile
+Dockerfile-dev
+Dockerfile-prod
+docker-compose.yml
+
+# To prevent storing dev/temporary container data
+*.csv
+/tmp/*
+


### PR DESCRIPTION
**Reasons for making this change:**

adding Dockerfile for docker users

**Links to documentation supporting these rule changes:**

https://docs.docker.com/engine/reference/builder/#dockerignore-file

If this is a new template:

docker.com