### PR TITLE
docs: update Terraform.gitignore

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -24,3 +24,6 @@ override.tf.json
 # Include override files you do wish to add to version control using negated pattern
 #
 # !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*


### PR DESCRIPTION
**Reasons for making this change:**

Adding `tfplan` option for command `terraform plan -out=tfplan -input=false` used in automation.

**Links to documentation supporting these rule changes:**

https://learn.hashicorp.com/terraform/development/running-terraform-in-automation
