### PR TITLE
Don't ignore tmp and log directory

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -1,8 +1,6 @@
 *.rbc
 capybara-*.html
 .rspec
-/log
-/tmp
 /db/*.sqlite3
 /db/*.sqlite3-journal
 /public/system
@@ -11,6 +9,12 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb


### PR DESCRIPTION
**Reasons for making this change:**

Rails `5.2.2.1` requires `tmp` directory committed to git repository for CI to run successfully.

**Links to documentation supporting these rule changes:**

https://weblog.rubyonrails.org/2019/3/13/Rails-4-2-5-1-5-1-6-2-have-been-released/