### PR TITLE
Add lerna-debug.log to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -4,6 +4,8 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+lerna-debug.log*
+
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json


### PR DESCRIPTION
**Reasons for making this change:**

Lerna is an increasingly popular tool within node ecosystem to manage package dependencies and writes to a `lerna-debug.log` if problem occurs while running any lerna command following precedence set by Yarn and npm

**Links to documentation supporting these rule changes:**

https://github.com/lerna/lerna#concepts
