### PR TITLE
Update SCons.gitignore

### DIFF
--- a/SCons.gitignore
+++ b/SCons.gitignore
@@ -1,2 +1,6 @@
 # for projects that use SCons for building: http://http://www.scons.org/
 .sconsign.dblite
+
+# When configure fails, SCons outputs these
+config.log
+.sconf_temp


### PR DESCRIPTION
Hi,

I've added some files that SCons generates when its tries to configure libraries.

**Reasons for making this change:**

Missing files that SCons automatically generates when configuring libraries.

**Documentation supporting change**

[Autoconf functionality](https://scons.org/doc/production/HTML/scons-user.html#chap-sconf) does not list generated files, but basically:
- `config.log` contains the compilation logs from SCons trying to link against libraries
- `.sconf_temp` contains the files and executables that SCons tries to compile to test library validity.
