### PR TITLE
[Android] Change to Android Studio 3

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -41,9 +41,8 @@ captures/
 .idea/assetWizardSettings.xml
 .idea/dictionaries
 .idea/libraries
-.idea/caches
 # Android Studio 3 in .gitignore file.
-.idea/caches/build_file_checksums.ser
+.idea/caches
 .idea/modules.xml
 
 # Keystore files

--- a/Android.gitignore
+++ b/Android.gitignore
@@ -13,6 +13,7 @@
 bin/
 gen/
 out/
+release/
 
 # Gradle files
 .gradle/


### PR DESCRIPTION
**Reasons for making this change:**

1) There is no need to add cache files one by one if we already ignore all cache files.
2) Since Android Studio 3.0 update, the apk generated will be in `{project-folder}/app/release/app-release.apk`

**Links to documentation supporting these rule changes:**
1) https://github.com/github/gitignore/pull/2644
2) https://stackoverflow.com/questions/46949719/android-studio-3-0-does-not-generate-signed-apk
