### PR TITLE
Update Autotools.gitignore

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -41,3 +41,6 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
+
+# Generated Makefile
+Makefile

--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -42,5 +42,8 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 
-# Generated Makefile
+# Generated Makefile 
+# (meta build system like autotools, 
+# can automatically generate from config.status script
+# (which is called by configure script))
 Makefile


### PR DESCRIPTION
Add ignore-rule for Makefiles generated by configure
(directly by config.status)

**Reasons for making this change:**
Makefiles are also unnecessary to be tracked because they are also be generated.

**Links to documentation supporting these rule changes:**

_TODO_

