### PR TITLE
Ignore Local History folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -336,8 +336,9 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder
 .mfractor/
 
-# Local History for Visual Studio
+# Local History for Visual Studio (Code)
 .localhistory/
+.history/
 
 # BeatPulse healthcheck temp database
 healthchecksdb


### PR DESCRIPTION
**Reasons for making this change:**

This will add support for the default location the Local History extension for Visual Studio Code uses.

**Links to documentation supporting these rule changes:**

See https://marketplace.visualstudio.com/items?itemName=xyz.local-history
