### PR TITLE
Remove wwwroot/lib exclusion for ASP.NET Core

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -236,8 +236,6 @@ orleans.codegen.cs
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
 #bower_components/
-# ASP.NET Core default setup: bower directory is configured as wwwroot/lib/ and bower restore is true
-**/wwwroot/lib/
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
ASP.NET Core projects no longer use Bower by default (since Bower is now deprecated), and instead create static files in the wwwroot/lib path.  This path is can also be used by convention for ASP.NET Core developers, and since it's no longer populated by Bower, it is unituitive to be excluded by default.

This change removes the lines added by #2307.

**Reasons for making this change:**

VS default flow is now broken by excluding files required to run an ASP.NET Core project.

**Links to documentation supporting these rule changes:**

The changes to the ASP.NET Core templates was tracked by https://github.com/aspnet/templating/issues/48.
