### PR TITLE
Update OCaml.gitignore

### DIFF
--- a/OCaml.gitignore
+++ b/OCaml.gitignore
@@ -21,3 +21,9 @@ setup.log
 
 # Merlin configuring file for Vim and Emacs
 .merlin
+
+# Dune generated files
+*.install
+
+# Local OPAM switch
+_opam/


### PR DESCRIPTION
**Reasons for making this change:**

- `*.install` files are generated by dune in the course of building the `@install` rule
- `_opam/` directories are local OPAM installations, sort of analogous to `node_modules/` or `vendor/`

**Links to documentation supporting these rule changes:**

- [dune documentation][dune]
- [opam local switches blog post][opam]

[dune]: https://dune.readthedocs.io/en/latest/project-layout-specification.html#package-opam-files
[opam]: http://www.ocamlpro.com/2017/04/27/new-opam-features-local-switches/
