### PR TITLE
[Android] ignore .idea/navEditor.xml

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -45,6 +45,8 @@ captures/
 # Android Studio 3 in .gitignore file.
 .idea/caches/build_file_checksums.ser
 .idea/modules.xml
+# Comment next line if keeping position of elements in Navigation Editor is relevant for you
+.idea/navEditor.xml
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.


### PR DESCRIPTION
**Reasons for making this change:**

By default, avoid storing the positions of your elements in the Navigation Editor.

**Links to documentation supporting these rule changes:**

[Get started with the Navigation component](https://developer.android.com/guide/navigation/navigation-getting-started)
[Deep dive into .idea folder in Android Studio](https://proandroiddev.com/deep-dive-into-idea-folder-in-android-studio-53f867cf7b70)
