### PR TITLE
Add fp-info-cache to KiCad gitignore

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -12,6 +12,7 @@ _autosave-*
 *-rescue.lib
 *-save.pro
 *-save.kicad_pcb
+fp-info-cache
 
 # Netlist files (exported from Eeschema)
 *.net


### PR DESCRIPTION
**Reasons for making this change:**

`fp-info-cache` serves only as a cache for footprint information (name, description, datasheet link, etc) There isn't a lot of documentation on this file (it was added recently, and the official documentation hasn't included it yet), however it seems like it doesn't really do anything as part of a Git repository but add commit noise.

**Links to documentation supporting these rule changes:**

See https://lists.launchpad.net/kicad-developers/msg38339.html and https://lists.launchpad.net/kicad-developers/msg38638.html for other developers' ideas on committing this file.
