### PR TITLE
Ballerina gitignore file added

### DIFF
--- a/Ballerina.gitignore
+++ b/Ballerina.gitignore
@@ -1,0 +1,44 @@
+*.class
+*.log
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+.idea
+*.iml
+*.ipr
+*.iws
+
+# generated files
+target
+results
+.ballerina
+/gen
+/compiler/ballerina-lang/src/main/resources/grammar/BallerinaLexer.tokens
+/tool-plugins/intellij/src/main/antlr/org/ballerinalang/plugins/idea/grammar/BallerinaLexer.tokens
+/composer/modules/web/dist-electron/
+velocity.log
+/composer/modules/web/dist-electron
+
+# gradle
+.gradle
+build/
+gradle-app.setting
+!gradle-wrapper.jar
+.gradletasknamecache
+
+# mac
+.DS_Store
+
+.classpath
+.project
+.settings
+.vscode


### PR DESCRIPTION
**Reasons for making this change:**

This repository didn't have ballerina language gitignore file

**Links to documentation supporting these rule changes:**

https://ballerina.io/learn/#reference-documentation

If this is a new template:

 - **Link to application or project’s homepage**: https://ballerina.io/
