### PR TITLE
add OS generated files to Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -55,3 +55,11 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
**Reasons for making this change:**

Removing unwanted OS generated files inside git project.