### PR TITLE
Ignore transpiled .java and .class files

### DIFF
--- a/Processing.gitignore
+++ b/Processing.gitignore
@@ -7,3 +7,4 @@ application.linux64
 application.windows32
 application.windows64
 application.macosx
+out


### PR DESCRIPTION
**Reasons for making this change:**

Ignore the transpiled .java and .class files since they aren't related to processing (they're autogenerated at runtime since Processing is a JVM language)



**Links to documentation supporting these rule changes:**


These files aren't don't influence the source code, and these files are only generated at compile time. Other folders which are generated at compile time (e.g. `application.windows32`) are also ignored by default.

![](https://i.imgur.com/QzX5ZRI.png)
