### PR TITLE
Un-ignore .tfstate and lock.json files for Terraform

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -25,3 +25,4 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -3,10 +3,6 @@
 !**/.terraform/**/
 !**/.terraform/**/lock.json
 
-# .tfstate files
-*.tfstate
-*.tfstate.*
-
 # Crash log files
 crash.log
 

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -1,5 +1,7 @@
 # Local .terraform directories
-**/.terraform/*
+**/.terraform/**/*
+!**/.terraform/**/
+!**/.terraform/**/lock.json
 
 # .tfstate files
 *.tfstate

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -3,6 +3,10 @@
 !**/.terraform/**/
 !**/.terraform/**/lock.json
 
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
 # Crash log files
 crash.log
 


### PR DESCRIPTION
State file(s) (`.tfstate`) and plugin lock file(s) (`lock.json`) should be kept.

**Links to documentation supporting these rule changes:**

- For state file(s), there are no mention in the [official documentation](https://www.terraform.io/docs/backends/types/local.html) which says that `.tfstate` files should be kept in source control. However, if the `.tfstate` file is lost, then it's a hassle to import them again. Essentially, the `.tfstate` file should not be lost, and thus it should be in source control:
  - [Recovering Terraform State](https://someguys.blog/2017-04-26-recovering-terraform-state/)
  - [Terraform state file missing](https://github.com/hashicorp/terraform/issues/19747)
- For the plugin lock file, there are also no mention of this in the official documentation, but the lock file is important to ensure everyone working on the project is using the exact same plugins.
