### PR TITLE
Fix: python.gitignore ignore unnecessary

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+./build/
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
only directory build in basedir should be ignored. 
