### PR TITLE
Add .DS_Store folder layout file to gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -76,3 +76,7 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+## File Organization File
+
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

Taking an iOS development course and this instructor was saying that .DS_Store should be included because people won't need to have these folder settings in their project file.

**Links to documentation supporting these rule changes:**

https://www.udemy.com/ios-12-app-development-bootcamp/learn/lecture/10929408#questions

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
