### PR TITLE
Remove *- Backup*.rdl from VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -260,7 +260,6 @@ ServiceFabricBackup/
 *.bim.layout
 *.bim_*.settings
 *.rptproj.rsuser
-*- Backup*.rdl
 
 # Microsoft Fakes
 FakesAssemblies/


### PR DESCRIPTION


**Reasons for making this change:**

This probably should not be here. A .rdl file is a valid thing to version in source control.

Having the name _*Backup*_ could mean anything.

**Links to documentation supporting these rule changes:**

n/a
