### PR TITLE
KiCAD: the -rescue.lib file is also precious!

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -9,7 +9,6 @@
 *~
 _autosave-*
 *.tmp
-*-rescue.lib
 *-save.pro
 *-save.kicad_pcb
 


### PR DESCRIPTION
**Reasons for making this change:**

the -rescue.lib file is also precious! 

**Links to documentation supporting these rule changes:**

https://forum.kicad.info/t/lost-the-schematic-components/12026/11
https://forum.kicad.info/t/how-to-clone-a-project/3878/23
