### PR TITLE
Ignoring Visual Studio Code workspace files.

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -40,6 +40,7 @@
 *.sdf
 *.VC.db
 *.VC.opendb
+*.code-workspace
 
 # Precompiled Assets
 SourceArt/**/*.png


### PR DESCRIPTION
**Reasons for making this change:**

Unreal Engine can generate Visual Studio Code workspace project files.

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
