### PR TITLE
Modifies Unity gitignore to keep saved backup scenes

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -1,11 +1,14 @@
 # This .gitignore file should be placed at the root of your Unity project directory
 
 /[Ll]ibrary/
-/[Tt]emp/
+/[Tt]emp/*
 /[Oo]bj/
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
+
+# Keep backup scenes
+![Tt]emp/__Backupscenes
 
 # Never ignore Asset meta data
 !/[Aa]ssets/**/*.meta


### PR DESCRIPTION
**Reasons for making this change:**

This PR is to save backup scenes in Unity. 
On playing an unsaved scene, Unity saves this in `Temp/__Backupscenes/0.backup`. However, on opening Unity after the crash (i.e., at the point where one realises they have lost work), it deletes this file.
My suggestion is to add it to the version control. Thus if a crash happens, one can commit their changes, and be secure they have a backup in their commit history.

**Links to documentation supporting these rule changes:**

https://support.unity3d.com/hc/en-us/articles/210224803-Can-I-restore-my-unsaved-scene-after-Unity-crash-
