### PR TITLE
added Pycharm/IntelliJ files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IntelliJ Pycharm
+*.idea


### PR DESCRIPTION
**Reasons for making this change:**

JetBrains makes a Python IDE called PyCharm.  PyCharm projects generate ".idea" folders that contain meta data including version control history, workspace and other environment specific files that should no be version controlled.

**Links to documentation supporting these rule changes:**

[PyCharm IDE](https://www.jetbrains.com/pycharm/)

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
