### PR TITLE
ignore vendor directory

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/


### PR DESCRIPTION
**Reasons for making this change:**

`go mod vendor` creates a `vendor` directory for dependency.

**Links to documentation supporting these rule changes:**

https://github.com/golang/go/wiki/Modules
