### PR TITLE
Update R.gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -28,7 +28,7 @@ vignettes/*.pdf
 .httr-oauth
 
 # knitr and R markdown default cache directories
-/*_cache/
+*_cache/
 /cache/
 
 # Temporary files created by R markdown


### PR DESCRIPTION
**Reasons for making this change:**

Ignore knitr and R markdown default cache directories in subdirectories as well
