### PR TITLE
Ignore .DS_Store which only Apple generates

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -342,3 +342,6 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Reasons for making this change:

VisualStudio 2017 and 2019 for Mac runs on macOS. 
And macOS creates .DS_Store files that are not used by other file systems.

Links to documentation supporting these rule changes:

https://en.wikipedia.org/wiki/.DS_Store

If this is a new template:

This change is not a new template.