### PR TITLE
JetBrains CLion ignore for CMake

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -9,3 +9,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+#JetBrains CLion
+.idea
+cmake-build-debug/


### PR DESCRIPTION
**Reasons for making this change:**

`.idea` and `cmake-build-debug` are IDE generated files and varies from developers

**Links to documentation supporting these rule changes:**

https://www.jetbrains.com/help/clion/managing-cmake-project-files.html

If this is a new template:
N/A
