### PR TITLE
Delete .ist from TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -144,7 +144,6 @@ acs-*.bib
 *.idx
 *.ilg
 *.ind
-*.ist
 
 # minitoc
 *.maf


### PR DESCRIPTION
**Reasons for making this change:**

.ist files are makeindex style files, which determine how a
makeindex-generated index will look like. Therefore, they must be
included in source control.

**Links to documentation supporting these rule changes:**

A link to an example .ist file for customizing the look of an index:
https://tex.stackexchange.com/questions/245368/how-to-create-a-ist-file-for-the-purpose-of-customizing-the-index
