### PR TITLE
Update VisualStudio.gitignore to ignore NuGet Symbol Packages

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -185,6 +185,8 @@ PublishScripts/
 
 # NuGet Packages
 *.nupkg
+# NuGet Symbol Packages
+*.snupkg
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.


### PR DESCRIPTION
This is to ignore the new Nuget Symbol Packages, which are now the recommended approach for debug symbols of public NuGet packages.

https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg
