### PR TITLE
KiCad: add footprint cache

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -13,6 +13,9 @@ _autosave-*
 *-save.pro
 *-save.kicad_pcb
 
+# Footprint cache
+fp-info-cache
+
 # Netlist files (exported from Eeschema)
 *.net
 


### PR DESCRIPTION
**Reasons for making this change:**

As described in commit c5a2ea1dd8b8f85f7524bbdaa17844f2324d02c5 in the
kicad repository itself, the fp-info-cache file should not be checked
in to version control.

**Links to documentation supporting these rule changes:**

https://git.launchpad.net/kicad/commit/?id=c5a2ea1dd8b8f85f7524bbdaa17844f2324d02c5