### PR TITLE
Add new pico-8 console template

### DIFF
--- a/pico8.gitignore
+++ b/pico8.gitignore
@@ -1,0 +1,10 @@
+# exported file types
+*.p8.png
+*.png
+*.wav
+*.js
+*.html
+*.bin
+
+# demos folder
+demos/


### PR DESCRIPTION
Pico-8 is popular fantasy console for making/playing/sharing tiny games written in Lua.
The tiny footprint executable includes and editor+tools to make all code and assets.
(more details at: https://www.lexaloffle.com/pico-8.php)

Pico-8 project files have a .p8 extension.
This template disallows exported file type extensions and the default 'demos' folder.

**Reasons for making this change:**
Support GitHub workflow for Pico-8 developers

**Links to documentation supporting these rule changes:**
https://www.lexaloffle.com/pico8_manual.txt
(sections [:: Example Cartridges] and [:: Exporters / Importers])

If this is a new template:
https://www.lexaloffle.com/pico-8.php
