### PR TITLE
Updating Swift.gitignore with accio folders

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -58,6 +58,10 @@ playground.xcworkspace
 
 Carthage/Build
 
+# Accio dependency management
+Dependencies/
+.accio/
+
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the


### PR DESCRIPTION
**Reasons for making this change:**

This PR includes both the config and dependency folders for [Accio](https://github.com/JamitLabs/Accio)

**Links to documentation supporting these rule changes:**

https://github.com/JamitLabs/Accio#usage
