### PR TITLE
Update VisualStudio.gitignore to add a safer rule for rdl backups

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -262,7 +262,9 @@ ServiceFabricBackup/
 *.bim.layout
 *.bim_*.settings
 *.rptproj.rsuser
-*- Backup*.rdl
+*- [Bb]ackup.rdl
+*- [Bb]ackup ([0-9]).rdl
+*- [Bb]ackup ([0-9][0-9]).rdl
 
 # Microsoft Fakes
 FakesAssemblies/


### PR DESCRIPTION
**Reasons for making this change:**

In #3024 there was a discussion about the rule for SSRS rdl backups that can match something by mistake. I'm updating it to have a more specific version.

**Links to documentation supporting these rule changes:**

https://feedback.azure.com/forums/908035-sql-server/suggestions/32897485-ssrs-2016-creates-a-new-rdl-backup-file-each-time

