### PR TITLE
Exclude memory profiler captures from git

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -6,6 +6,7 @@
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
+/[Mm]emoryCaptures/
 
 # Never ignore Asset meta data
 !/[Aa]ssets/**/*.meta


### PR DESCRIPTION
**Reasons for making this change:**

Excluding memory captures from git since they use 80-500MB or even more.

**Links to documentation supporting these rule changes:**

https://docs.unity3d.com/Packages/com.unity.memoryprofiler@0.1/manual/index.html
Note: The memory profiler is still a preview package!
Also it may or may not make sense to exclude folders used by specific packages.