### PR TITLE
Replace non-ASCII character in comment

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
 #Pipfile.lock
 


### PR DESCRIPTION
**Reasons for making this change:**

The curly apostrophe in the pipenv comment (added in commit 7079791) is causing AWS EB CLI to fail. https://stackoverflow.com/a/55988700/594211