### PR TITLE
Add macOS to Visual Studio .gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -346,3 +346,6 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

As a .NET Developer that uses a Mac I add `.DS_Store` to every .gitignore file.

**Links to documentation supporting these rule changes:**

None.  I'd just like macOS as part of the main VS template.
