### PR TITLE
Add .tsbuildinfo files to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -43,6 +43,9 @@ jspm_packages/
 # TypeScript v1 declaration files
 typings/
 
+# TypeScript cache
+*.tsbuildinfo
+
 # Optional npm cache directory
 .npm
 


### PR DESCRIPTION
**Reasons for making this change:**

Typescript 3.4 has added `.tsbuildinfo` files for caching. 

"These .tsbuildinfo files can be safely deleted and don’t have any impact on our code at runtime - they’re purely used to make compilations faster"

**Links to documentation supporting these rule changes:**

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html
