### PR TITLE
Fix log filename for Vagrant

### DIFF
--- a/Global/Vagrant.gitignore
+++ b/Global/Vagrant.gitignore
@@ -2,4 +2,4 @@
 .vagrant/
 
 # Log files (if you are creating logs in debug mode, uncomment this)
-# *.logs
+# *.log


### PR DESCRIPTION
**Reasons for making this change:**

Actually, the log generated by debug mode is *.log
i.e. ubuntu-xenial-16.04-cloudimg-console.log

**Links to documentation supporting these rule changes:**

https://www.vagrantup.com/docs/other/debugging.html

If this is a new template: No

 - **Link to application or project’s homepage**: 
