### PR TITLE
updated vscode ignore, now it's works

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json


### PR DESCRIPTION
**Reasons for making this change:**

the old version of .gitignore for vscode folder did not works for me, so I've change this file and add new line and it's works now

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
