### PR TITLE
Updated Craft CMS .gitignore to recommendation

### DIFF
--- a/CraftCMS.gitignore
+++ b/CraftCMS.gitignore
@@ -1,4 +1,4 @@
-# Craft 2 Storage (https://craftcms.com/support/craft-storage-gitignore)
-# not necessary for Craft 3 (https://github.com/craftcms/craft/issues/26)
-/craft/storage/*
-!/craft/storage/rebrand
+/.env
+/.idea
+/vendor
+.DS_Store


### PR DESCRIPTION
Now based on https://github.com/craftcms/craft/blob/master/.gitignore

**Reasons for making this change:**

The current Craft CMS .gitignore is for an old version of Craft. This is now updated for Craft 3.

**Links to documentation supporting these rule changes:**

This is the same .gitignore you’d get if you created a new Craft project using the [installation instructions](https://docs.craftcms.com/v3/installation.html).
