### PR TITLE
 Add MS-DOS Device Driver names for Global/Windows.gitignore

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -22,3 +22,16 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# MS-DOS Device Driver names cannot be used as file names in Windows. 
+# As a result, we are unable to name folders as con, aux, nul, etc.
+CON
+PRN
+NUL
+COM1
+COM2
+COM3
+COM4
+LPT1
+LPT2
+LPT3


### PR DESCRIPTION
**Reasons for making this change:**

Some colleagues will submit files named MS-DOS Device Driver names on Linux or other non-Windows systems. After git repo is cloned on Windows, there may be problems.

MS-DOS Device Driver names cannot be used as file names in Windows. 
As a result, we are unable to name folders as con, aux, nul, etc.

**Links to documentation supporting these rule changes:**

https://www.thewindowsclub.com/create-restricted-files-folders-con-aux-nul-click-windows
