### PR TITLE
Python: Adding project files created by Eclipse+PyDev

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -108,6 +108,10 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Eclipse + PyDev project settings
+.project
+.pydevproject
+
 # Rope project settings
 .ropeproject
 


### PR DESCRIPTION
**Reasons for making this change:**

Adding files created by Eclipse and Pydev installed as plugin.

**Links to documentation supporting these rule changes:**

???
