### PR TITLE
Add db.sqlite3-journal to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+db.sqlite3-journal
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
Hi there!

**Reasons for making this change:**

A similar change was introduced in 15e56afe into Rails.gitignore, see #1280.
We've just come across the same need for this in a project in Python (Django) and found it wasn't in the github gitignore. h/t @nickittynack.

**Links to documentation supporting these rule changes:**

Docs on Sqlite temporary files
https://www.sqlite.org/tempfiles.html#rollback_journals

No real upstream changes I can make out, just something that was missing.

Please let me know if the quality of this PR can be improved.
Thanks!