### PR TITLE
[JetBrains] exclude dataSources.xml

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -15,6 +15,7 @@
 .idea/**/dataSources/
 .idea/**/dataSources.ids
 .idea/**/dataSources.local.xml
+.idea/**/dataSources.xml
 .idea/**/sqlDataSources.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml


### PR DESCRIPTION
**Reasons for making this change:**
we already exclude `.idea/dataSources.local.xml` but not yet  `.idea/dataSources.xml`

dataSources.xml file goes in pair with .idea/dataSources.local.xml, look at the sample below, postgres uri is referenced in dataSources.xml , the uuid of both files match

```
$ cat .\.idea\dataSources.local.xml
<?xml version="1.0" encoding="UTF-8"?>
<project version="4">
  <component name="dataSourceStorageLocal">
    <data-source name="postgres@localhost" uuid="1a7ade1c-21eb-4654-8858-fcaea9b4babf">
      <database-info product="PostgreSQL" version="9.6.12" jdbc-version="4.2" driver-name="PostgreSQL JDBC Driver" driver-version="42.2.5" dbms="POSTGRES" exact-version="9.6.12" exact-driver-version="42.2">
        <identifier-quote-string>&quot;</identifier-quote-string>
      </database-info>
      <case-sensitivity plain-identifiers="lower" quoted-identifiers="exact" />
      <secret-storage>master_key</secret-storage>
      <user-name>postgres</user-name>
      <introspection-schemas>*:*|@:</introspection-schemas>
    </data-source>
  </component>
</project>
$ cat .\.idea\dataSources.xml
<?xml version="1.0" encoding="UTF-8"?>
<project version="4">
  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
    <data-source source="LOCAL" name="postgres@localhost" uuid="1a7ade1c-21eb-4654-8858-fcaea9b4babf">
      <driver-ref>postgresql</driver-ref>
      <synchronize>true</synchronize>
      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
      <jdbc-url>jdbc:postgresql://localhost:5432/postgres</jdbc-url>
    </data-source>
  </component>
</project>
```

**Links to documentation supporting these rule changes:**

I did not find much doc but an article on sharing datasources https://blog.jetbrains.com/datagrip/2018/05/21/copy-and-share-data-sources-in-datagrip/

