### PR TITLE
Add .env.* to optionally ignored files in Rails.gitignore.

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -23,9 +23,10 @@ config/master.key
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml
 
-# dotenv
-# TODO Comment out this rule if environment variables can be committed
+# dotenv, dotenv-rails
+# TODO Comment out these rules if environment variables can be committed
 .env
+.env.*
 
 ## Environment normalization:
 /.bundle


### PR DESCRIPTION
**Reasons for making this change:**

`.env` is ignored in Rails.gitignore. but dotenv-rails can handle more files other than .env (`.env.local`, `.env.development.local`, etc..)
So this PR adds `.env.*` to optionally ignored files in Rails.gitignore.

**Links to documentation supporting these rule changes:**

Files that dotenv-rails can handle.
https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
