### PR TITLE
Make ignoring .ist files for glossaries-extra ...

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -110,6 +110,9 @@ acs-*.bib
 *.gls
 *.glsdefs
 
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
 # gnuplottex
 *-gnuplottex-*
 
@@ -259,6 +262,3 @@ TSWLatexianTemp*
 
 # standalone packages
 *.sta
-
-# glossaries-extra
-*.ist


### PR DESCRIPTION
There has been an accepted pull request recently which added `*.ist` pattern to the bottom of the `TeX.gitignore`. I see two issues with this pull request:

1. __The major one:__ `*.ist` files are also custom style files for `makeindex`. Therefore, simply adding `*.ist` pattern under `#glossaries-extra` section can be misleading for those who use `makeindex` but not `glossaries-extra`. This problem is similar to the `*.pdf` problem. So, I suggest solving it the same way: let's add a commented line for `*.ist` files under `#glossaries-extra` section with an extended comment.

2. __The minor one__: there is already `#glossaries` section in `TeX.gitignore`. I suggest moving `*.ist` pattern to this section for easier navigation.
