### PR TITLE
[Android] Ignore output.json instead of release/

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -2,6 +2,7 @@
 *.apk
 *.ap_
 *.aab
+output.json
 
 # Files for the ART/Dalvik VM
 *.dex
@@ -13,7 +14,6 @@
 bin/
 gen/
 out/
-release/
 
 # Gradle files
 .gradle/


### PR DESCRIPTION

**Reasons for making this change:**

`release/` will ignore all of the `release` build source directories such as `app/src/release/`.
So we should not ignore `release/`.
Since Android Studio 3.0, the `Generate signed Bundle / APK` task will generate both of an APK and `output.json` in the same directory.
APK files are already ignored so we can ignore the generated signed APK just adding `output.json` instead of `release/`.

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/a/47151123/7296678
