### PR TITLE
Include Library/*.asset files for Unity3D

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -61,3 +61,6 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+# keep the *.asset files from Library
+# including e.g. the current build target and build settings
+!/[Ll]ibrary/*.asset


### PR DESCRIPTION
**Reasons for making this change:**

For me it made sense to also include the [Ll]ibrary/*.asset files.

This includes e.g. the build target and build settings so after cloning on a different device I don't have to go to the Build settings and switch platform or re-add all required scenes.

**Links to documentation supporting these rule changes:**

There isn't really one, this is just my experience.
