### PR TITLE
added gitignore for .NET Core

### DIFF
--- a/DotnetCore.gitignore
+++ b/DotnetCore.gitignore
@@ -1,0 +1,7 @@
+# .NET Core build folders
+/bin
+/obj
+
+# Common node modules locations
+/node_modules
+/wwwroot/node_modules


### PR DESCRIPTION
**Reasons for making this change:**

.NET Core is a popular cross platform framework. This file covers the common build folders and front end scenarios


