### PR TITLE
Adding fix to properly ignore everything but wp-content

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,5 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
The small addition needed to properly ignore everything but wp-content in various environments

**Reasons for making this change:**

The current file doesn't ignore root files as well as other directories