### PR TITLE
Revert "KiCad: add footprint cache"

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -14,9 +14,6 @@ _autosave-*
 *-save.kicad_pcb
 fp-info-cache
 
-# Footprint cache
-fp-info-cache
-
 # Netlist files (exported from Eeschema)
 *.net
 


### PR DESCRIPTION
**Reverts github/gitignore#3043**

Recently filed pull request #3013 adds the `fp-info-cache` line in duplicate but in a more sensible location.
Propose we revert #3043 and remove the duplicate line as it's just clutter.