### PR TITLE
unity 2019 package directory

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -9,6 +9,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Mm]emoryCaptures/
+/[Pp]ackages/
 
 # Never ignore Asset meta data
 !/[Aa]ssets/**/*.meta


### PR DESCRIPTION
these packages are auto downloaded if they are missing.

**Reasons for making this change:**

becuse unity 2019 has a package manager

**Links to documentation supporting these rule changes:**

https://docs.unity3d.com/Packages/com.unity.package-manager-ui@1.8/manual/index.html

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
