### PR TITLE
Update the Unity Gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -25,6 +25,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
Added ignore line for VSCode users (.vscode cache directory)

**Reasons for making this change:**

If the developer uses a light VSCode to write the source code, the cache folder will be ignored (just like ".vs/" )


