### PR TITLE
Creates go.gitignore

### DIFF
--- a/go.gitignore
+++ b/go.gitignore
@@ -1,0 +1,2 @@
+vendor
+gin-bin


### PR DESCRIPTION
Go gitignore for use with deb and gin

The gin live-reloader for Go web applications https://github.com/codegangsta/gin creates a gin-bin file for serving the live server. This file is a binary file and is updated after each start of the gin server but not deleted when stop. To avoid checking it in i added the gin-bin to the ignore list.

The vendor folder is create by the deb dependency manager of go. The versions and dependencies are stored in the Gopkg.lock and Gopkg.yml and can be generated by deb ensure on the build system. So there is no reason checking the vendor folder in.

https://github.com/codegangsta/gin
https://github.com/golang/dep
