### PR TITLE
Swift: ignore .swiftpm

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -38,7 +38,9 @@ playground.xcworkspace
 # Packages/
 # Package.pins
 # Package.resolved
+# *.xcodeproj
 .build/
+.swiftpm
 
 # CocoaPods
 #

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -39,8 +39,12 @@ playground.xcworkspace
 # Package.pins
 # Package.resolved
 # *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
 .build/
-.swiftpm
 
 # CocoaPods
 #


### PR DESCRIPTION
**Reasons for making this change:**

SPM now supported with Xcode 11; .swiftpm is generated by Xcode and is not needed on git

**Links to documentation supporting these rule changes:**

Basing off Apple's swift-package-manager .gitignore
https://github.com/apple/swift-package-manager/blob/master/.gitignore