### PR TITLE
Don't ignore *.pot files.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -52,7 +52,6 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
 
 # Django stuff:
 *.log


### PR DESCRIPTION
**Reasons for making this change:**

Although dynamically generated from i18n tools, in some situations (specially in the Plone world) you need to add a manual.pot with manual entries that need to be versioned.

**Links to documentation supporting these rule changes:**

https://github.com/plone/documentation/blob/0ea1b1f715e9031a434d72f57c189f25aa1f4b73/develop/plone/i18n/internationalisation.rst#manual-po-entries