### PR TITLE
Ignore *.xyd outline files generated by xy LaTeX package

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -226,8 +226,9 @@ pythontex-files-*/
 # xindy
 *.xdy
 
-# xypic precompiled matrices
+# xypic precompiled matrices and outlines
 *.xyc
+*.xyd
 
 # endfloat
 *.ttt


### PR DESCRIPTION
The xy package generates *.xyd files whenever the commands

    \MakeOutlines
    \OnlyOutlines
    \ShowOutlines
    \NoOutlines

are present in the LaTeX source. These automatically-generated files
contain the dimensions of figures typeset with xy and are recreated as
needed. This is documented on pp. 15f. of the XY-pic Reference Manual
(1999/02/16).

As automatically-generated, temporary files, they should be ignored.

**Reasons for making this change:**

These files are automatically generated and should be ignored.

**Links to documentation supporting these rule changes:**

http://www.ctex.org/documents/packages/graphics/xyrefer.pdf