### PR TITLE
Added gitignore-file for Beckhoff TwinCAT3.

### DIFF
--- a/TwinCAT.gitignore
+++ b/TwinCAT.gitignore
@@ -1,0 +1,15 @@
+# gitignore template for TwinCAT
+# website: https://www.beckhoff.com/twincat/
+#
+# Recommended: VisualStudio.gitignore
+
+# TwinCAT files
+*.tpy
+*.tclrs
+*.compiled-library
+*.compileinfo
+*.tmc
+*.library
+_Boot/
+_CompileInfo/
+_Libraries/

--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -1,5 +1,5 @@
-# gitignore template for TwinCAT
-# website: https://www.beckhoff.com/twincat/
+# gitignore template for TwinCAT3
+# website: https://www.beckhoff.com/twincat3/
 #
 # Recommended: VisualStudio.gitignore
 

--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -9,7 +9,11 @@
 *.compiled-library
 *.compileinfo
 *.tmc
+*.tmcRefac
 *.library
+*.project.~u
+*.tsproj.bak
+*.xti.bak
 _Boot/
 _CompileInfo/
 _Libraries/

--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -17,6 +17,8 @@
 *.project.~u
 *.tsproj.bak
 *.xti.bak
+LineIDs.dbg
+LineIDs.dbg.bak
 _Boot/
 _CompileInfo/
 _Libraries/

--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -22,3 +22,4 @@ LineIDs.dbg.bak
 _Boot/
 _CompileInfo/
 _Libraries/
+_ModuleInstall/

--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -8,6 +8,9 @@
 *.tclrs
 *.compiled-library
 *.compileinfo
+# Don't include the tmc-file rule if either of the following is true:
+#   1. You've got TwinCAT C++ projects, as the information in the TMC-file is created manually for the C++ projects (in that case, only (manually) ignore the tmc-files for the PLC projects)
+#   2. You've created a standalone PLC-project and added events to it, as these are stored in the TMC-file.
 *.tmc
 *.tmcRefac
 *.library


### PR DESCRIPTION
**Provide a link to the application or project’s homepage:**
https://www.beckhoff.com/english.asp?twincat/twincat-3.htm
TwinCAT3 is a realtime kernel and development environment for PLCs (programmable logic controller). The IDE is based on Visual Studio, which TwinCAT is integrated into. It's one of the more popular development environments for industrial automation.

**Provide links to documentation:**
The official one:
https://download.beckhoff.com/download/document/automation/twincat3/TC3_SourceControl_EN.pdf
This only covers part of the files (specifying that TMC and TPY-files are not necessary to version control). Unfortunately, even Beckhoff (the manufacturer of TwinCAT) have failed to properly document which files should be version controlled and not.

Regarding the other files included in the gitignore-file of the pull request:
- *.tclrs - These are license response files, basically license files that are residing on the target PLC device
- *.compiled-library and *.library - which are libraries of which the project depends on. These are put here when they are referenced in the project, but the actual libraries needed for development are installed in "C:\TwinCAT\3.1\Components\Plc\Managed Libraries", which need to be installed there prior of compilation. The ones residing in the project must not be version controlled.
- *.compileinfo - Self explaining, file created everytime a compilation is made. Beckhoff documentation says: "The compile information was created during the last download of the PLC project and stored in a file".
- _Boot/ - Folder generated when project is compiled with all the binaries. This is what is transferred to the actual target device (PLC) for execution.
- _CompileInfo/ - Self explaining. Folder created during compilation. Holding the *.compileinfo-files.
- _Libraries/ - Folder holding the *.compiled-library and *.library in the local development folder. 

There are various github repos for TwinCAT that use this list for gitignore, one being TcUnit, a unit testing framework for TwinCAT3:
https://github.com/tcunit/TcUnit/blob/master/.gitignore

Note that because TwinCAT is using visual studio as development environment (it integrates itself into VS during installation), all visual studio files that are normally ignored shall be ignored as well (therefore the comment # Recommended: VisualStudio.gitignore).

Update 2019-12-05: I've published a blog post that goes through these files and the reason for having a gitignore-file for TwinCAT3 in a much greater detail now which is accessible here:
https://alltwincat.com/2019/12/02/gitignore-for-twincat/

**Explain why you’re making a change:**
Unfortunately version control by modern VCS is yet quite uncommon in industrial automation, and therefore proper practices and documentation around it have not yet been fully defined. It's quite common within the world of automation to do version control by simply taking a complete project folder and copying it to a new folder, adding the new date and calling that version control. Now that more and more automation engineers are starting to do version control more properly, and also starting to use GIT, it makes sense to create this file.

**If this is a new template:**
Link to application or projects homepage:
This would be TcUnit, which is a popular unit testing framework for TwinCAT3:
https://tcunit.org/
https://github.com/tcunit
