### PR TITLE
Update Wordpress.gitignore

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,5 +1,9 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
+
+# ignore Mac OS file that stores custom attributes for its containing folder
+.DS_Store
 
 # ignore everything in the "wp-content" directory, except:
 # "mu-plugins", "plugins", "themes" directory


### PR DESCRIPTION
**Reasons for making this change:**
This file is missing `/*` to begin with ignoring everything. I have also added a line to ignore Mac's `.DS_Store`, several of which appear within the directories that belong to `wp-content`.

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
