### PR TITLE
Ignoring AppCode local configs

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -5,6 +5,9 @@
 ## User settings
 xcuserdata/
 
+## AppCode local configs
+.idea/
+
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -6,6 +6,9 @@
 build/
 DerivedData/
 
+## AppCode local configs
+.idea/
+
 ## Various settings
 *.pbxuser
 !default.pbxuser

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -6,6 +6,9 @@
 build/
 DerivedData/
 
+## AppCode local configs
+.idea/
+
 ## Various settings
 *.pbxuser
 !default.pbxuser


### PR DESCRIPTION
Added .idea/ to Objective-C Xcode and Swift for ignoring AppCode local config files

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
