### PR TITLE
Update Laravel.gitignore

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -10,6 +10,11 @@ app/storage/
 # Laravel 5 & Lumen specific
 public/storage
 public/hot
+
+# Laravel 5 & Lumen specific with changed public path
+public_html/storage
+public_html/hot
+
 storage/*.key
 .env
 Homestead.yaml


### PR DESCRIPTION
**Reasons for making this change:**
The most of Laravel developers are using dedicated/VPS servers. So it's difficult to have a Laravel project with PUBLIC path there, as apache entry point is PUBLIC_HTML.

Added PUBLIC_HTML/ some folders in gitignore