### PR TITLE
add .idea/ to ignore pycharm folder for python

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Pycharm
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**
Adding this to stop pycharm related files to be uploaded by default to the repository.

**Links to documentation supporting these rule changes:**
None

If this is a new template:

 - **Link to application or project’s homepage**:  None
