### PR TITLE
Added more glossaries auxiliary files and makeindex logs to TeX template

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -109,6 +109,8 @@ acs-*.bib
 *.glo
 *.gls
 *.glsdefs
+*.lzo
+*.lzs
 
 # uncomment this for glossaries-extra (will ignore makeindex's style files!)
 # *.ist
@@ -263,3 +265,6 @@ TSWLatexianTemp*
 
 # standalone packages
 *.sta
+
+# Makeindex log files
+*.lpz


### PR DESCRIPTION
**Reasons for making this change:**

Discovered more auxiliary files that don't seem to need tracking: 'lzo' and 'lzs' for glossaries with glossary type=leipzig, and 'lpz' is generated in between by makeindex.
