### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -24,6 +24,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
Added "vscode" folder for ide Visual Studio Code

**Reasons for making this change:**

Many people use Visual Studio Code to develop on Unity3D


