### PR TITLE
Ignore the .ionide working folder (VisualStudio.gitignore)

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -347,3 +347,6 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
+
+# Ionide (cross platform F# VS Code tools) working folder
+.ionide/


### PR DESCRIPTION
**Reasons for making this change:**

If you have the [Ionide](http://ionide.io/) tools installed you will get an `.ionide` directory created in each directory that you open with VS Code, regardless of whether or not you are using F#.

**Links to documentation supporting these rule changes:**

Ignored at line 75 of the `ionide-vscode-fsharp` .gitignore: https://github.com/ionide/ionide-vscode-fsharp/blob/cc4fdbf90a33a91b305f74c36ec3634cb5744e95/.gitignore#L75

