### PR TITLE
feat: Add microbundle cache directories

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -53,6 +53,12 @@ typings/
 # Optional eslint cache
 .eslintcache
 
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
 # Optional REPL history
 .node_repl_history
 


### PR DESCRIPTION
**Reasons for making this change:**

[Microbundle](https://github.com/developit/microbundle) creates cache directories.

**Links to documentation supporting these rule changes:**

[Official microbundle gitignore](https://github.com/developit/microbundle/blob/master/.gitignore#L4-L7)
