### PR TITLE
Ignore .ionide in VisualStudio gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -301,6 +301,9 @@ paket-files/
 # FAKE - F# Make
 .fake/
 
+# Ionide - VSCode F# extension - https://github.com/ionide/ionide-vscode-fsharp
+.ionide/
+
 # CodeRush personal settings
 .cr/personal
 


### PR DESCRIPTION
**Reasons for making this change:**

Recent version of the Ionide F# extension for VSCode use a `.ionide` folder similar to how Visual Studio itself uses `.vs`.

There is work in progress in the extension to suggest to add it to gitignore (https://github.com/ionide/ionide-vscode-fsharp/issues/1159) but it would be nice if the Visual Studio template used by all .Net languages did it by default

**Links to documentation supporting these rule changes:**

The issue https://github.com/ionide/ionide-vscode-fsharp/issues/1159 contains some details about it, I don't think there is more specific documentation