### PR TITLE
.travis.yml: Trim trailing whitespace and indent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 branches:
   only:
-  - master
-  
+    - master
+
 script:
   - ruby -e "puts 'Hello world!'"


### PR DESCRIPTION
**Reasons for making this change:**

https://github.com/moremoban/pypi-mobans uses this repo as a git submodule, and want to run our yaml lint tools without excluding this repo.  We dont mind if it breaks occasionally; we'll come help fix, like we have in the past https://github.com/github/gitignore/pull/2728.
