### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -286,6 +286,9 @@ node_modules/
 # Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
 *.vbw
 
+# Visual Studio 6 auto-generated project file (contains which files were open etc.)
+*.vbp
+
 # Visual Studio LightSwitch build output
 **/*.HTMLClient/GeneratedArtifacts
 **/*.DesktopClient/GeneratedArtifacts


### PR DESCRIPTION
Added project file to `.gitignore`

**Reasons for making this change:**
Visual Studio 6.x uses these project files, they too need to be excluded from repository.

**Links to documentation supporting these rule changes:**
_Removed by Microsoft, MSDN no longer supports VS6_
