### PR TITLE
Add *.hie to Haskell.gitignore

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -3,6 +3,7 @@ dist-*
 cabal-dev
 *.o
 *.hi
+*.hie
 *.chi
 *.chs.h
 *.dyn_o


### PR DESCRIPTION
This new file type can be generated by GHC 8.8.

https://www.haskell.org/ghc/blog/20190626-HIEFiles.html