### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -293,7 +293,7 @@ node_modules/
 *.dsw
 *.dsp
 
-# Visual Studio 6 techical files (their purpose is unknown for me)
+# Visual Studio 6 technical files 
 *.ncb
 *.aps
 

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -286,6 +286,17 @@ node_modules/
 # Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
 *.vbw
 
+# Visual Studio 6 auto-generated project file (contains which files were open etc.)
+*.wbp
+
+# Visual Studio 6 workspace and project file (working project files containing files to include in project)
+*.dsw
+*.dsp
+
+# Visual Studio 6 techical files (their purpose is unknown for me)
+*.ncb
+*.aps
+
 # Visual Studio LightSwitch build output
 **/*.HTMLClient/GeneratedArtifacts
 **/*.DesktopClient/GeneratedArtifacts

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -287,7 +287,7 @@ node_modules/
 *.vbw
 
 # Visual Studio 6 auto-generated project file (contains which files were open etc.)
-*.wbp
+*.vbp
 
 # Visual Studio 6 workspace and project file (working project files containing files to include in project)
 *.dsw


### PR DESCRIPTION
Visual Studio 6.0 files

**Reasons for making this change:**
Visual Studio 6.0 actually contains more technical files than specified. For project transferability, VS workspace and project files should be exluded, as well as automatically generated binary and manifest files.

**Links to documentation supporting these rule changes:**
Screenshots showing the files in Windows 98:
https://ctrlv.cz/vebO
https://ctrlv.cz/ntcW

I have screenshots, because VS 6.0 isn't officially supported anymore and MSDN documentation has been removed from Microsoft sites.
