### PR TITLE
Ignore the Ionide symbol cache in the Visual Studio .gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -347,3 +347,7 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
+
+# Symbol cache for Ionide VSCode extension
+.ionide/symbolCache.db
+


### PR DESCRIPTION
**Reasons for making this change:**

Ionide is a Visual Studio Code extension, but many people use it to develop .NET software.