### PR TITLE
Added VS Code support to UE4's gitignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,5 +1,6 @@
-# Visual Studio 2015 user specific files
+# Visual Studio & VS Code user specific files
 .vs/
+.vscode/
 
 # Compiled Object files
 *.slo
@@ -35,6 +36,7 @@
 *.xcodeproj
 *.xcworkspace
 *.sln
+*.code-workspace
 *.suo
 *.opensdf
 *.sdf


### PR DESCRIPTION
Simple, safe change.
VS Code creates some files just like its big brother. These files can be safely ignored as they are user specific and can be generated by the engine. It's beneficial to ignore these files as they contain lots of absolute directory paths that will likely be different across computers, meaning that whenever someone loads up the project, VS code will "fix" them, causing a bunch of unnecessary changes.

I also changed "VS 2015" to just "VS" since it applies to all versions of VS supported by UE4.

**Reasons for making this change:**

 - Increase feature parity / consistency between VS and VS Code
 - Save others from having to make this change every time


