### PR TITLE
Ignore configuration file

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,3 +1,6 @@
+# ignore configuration file with passwords
+wp-config.php
+
 # ignore everything in the root except the "wp-content" directory.
 !wp-content/
 


### PR DESCRIPTION
Database credentials and security keys should not be commited.

**Reasons for making this change:**

The wp-config.php file should not be commited, otherwise sensitive credentials would be commited too.

**Links to documentation supporting these rule changes:**

https://wordpress.org/support/article/editing-wp-config-php/
