### PR TITLE
Scrivener: Added new checksums and allows for relative directories

### DIFF
--- a/Scrivener.gitignore
+++ b/Scrivener.gitignore
@@ -1,7 +1,8 @@
-/Files/binder.autosave
-/Files/binder.backup
-/Files/search.indexes
-/Files/user.lock
-/Files/Docs/docs.checksum
-/QuickLook/
-/Settings/ui.plist
+*/Files/binder.autosave
+*/Files/binder.backup
+*/Files/search.indexes
+*/Files/user.lock
+*/Files/Docs/docs.checksum
+*/Files/Data/docs.checksum
+*/QuickLook/
+*/Settings/ui.plist


### PR DESCRIPTION
**Reasons for making this change:**

Found that when I had the Scrivener file in the same root directory as my README, I needed relative paths to the gitignore files

Also noticed that Scrivener 3 has slightly different paths then Scrivener 2

**Links to documentation supporting these rule changes:**


If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
