### PR TITLE
[React-Native] Add new template

### DIFF
--- a/react-native.gitignore
+++ b/react-native.gitignore
@@ -1,0 +1,64 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+DerivedData/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/
+
+#*/fastlane/report.xml
+#*/fastlane/Preview.html
+#*/fastlane/screenshots
+
+# Bundle artifact
+*.jsbundle


### PR DESCRIPTION
**Reasons for making this change:**

   When I was developing RN, I was confused that I couldn't find a react native.gitignore file here. I hope to help other developers by adding it

If this is a new template:

 - **Link to application or project’s homepage**:  [react-native-io](https://facebook.github.io/react-native/), [react-native](https://github.com/facebook/react-native)
