### PR TITLE
ignore DS_Store file

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -80,3 +80,12 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# DS_Store Files
+#
+# The .DS_Store file is a file created by OS that holds meta-information about a directory. 
+# You can expect to always find it and can safely ignore it. The file is not shown by the Finder.
+
+*.DS_Store
+*/.DS_Store
+Pods/.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

The .DS_Store file is a file created by OS that holds meta-information about a directory. You can expect to always find it and can safely ignore it. The file is not shown by the Finder.

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store
