### PR TITLE
[Python] Ignore coverage annotations reports

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -47,6 +47,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
+*.py,cover
 .hypothesis/
 .pytest_cache/
 


### PR DESCRIPTION
**Reasons for making this change:**

There's no need to include these reports in the repository

**Links to documentation supporting these rule changes:

**https://coverage.readthedocs.io/en/coverage-4.2/cmd.html#text-annotation

If this is a new template:

N/A