### PR TITLE
Partial revert of 837181e2f60198de3701a1f87e66aaf8e69d0e07

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -22,9 +22,5 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 
-## Xcode Patch
-*.xcodeproj/*
-!*.xcodeproj/project.pbxproj
-!*.xcodeproj/xcshareddata/
-!*.xcworkspace/contents.xcworkspacedata
+## Gcc Patch
 /*.gcno


### PR DESCRIPTION
**Reasons for making this change:**

Previous commit on this file (#2566) was incorrectly supported by a 10-years old Stack Overflow answer. There aren't any demonstrated extra files (apart from `xcuserdata/` already listed on top) that need to be excluded from the `.xcodeproj/` folder, and as such this folder shouldn't be added to .gitignore.

I'm leaving the change on `/*.gcno`, but updating the description about it. We could note that most Xcode users are using Clang (default compiler) instead of Gcc nowadays.
