### PR TITLE
[Swift] Added DS_Store and GoogleService-Info.plist

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -80,3 +80,13 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# .DS_Store
+#
+# This file records the visual position of the images of the files in the finder window. You don't need this.
+.DS_Store
+
+# GoogleService-Info.plist
+#
+# This is your Google Service Account file. This service account is used to authorize client devices for access to GCP (Google cloud Platform) and/or Firebase. It is bad practice to include this file in your git repositories. You should instead generate this file during your CI/CD process or store it seperately from this Swift project. 
+GoogleService-Info.plist


### PR DESCRIPTION
The DS_Store file isn't necessary to the purpose of most repositories so I remove it. Also, best practices would be to remove sensitive information from source control. Google Service Accounts are often used by iOS engineers as well as Vapor and Kitura engineers building on GCP/Firebase so I remove them from source control as a rule too.

**Reasons for making this change:**

I wanted to be able to use the swift.gitignore file from GitHub out of the box. I have to make these changes every time.

**Links to documentation supporting these rule changes:**

Wait what?

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
