### PR TITLE
Update Godot.gitignore

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -6,3 +6,4 @@ export_presets.cfg
 
 # Mono-specific ignores
 .mono/
+data_*/


### PR DESCRIPTION
**Reasons for making this change:**

The data directory was added with Godot v3.1 and is used to hold temporary Mono files.

**Links to documentation supporting these rule changes:**

https://docs.godotengine.org/en/3.1/development/compiling/compiling_with_mono.html#export-templates

> This directory must be placed with its original name next to the Godot export templates. When exporting a project, Godot will also copy this directory with the game executable but the name will be changed to `data_<APPNAME>`, where `<APPNAME>` is the application name as specified in the project setting `application/config/name`.

