### PR TITLE
Ignore gummi previews

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -253,6 +253,9 @@ TSWLatexianTemp*
 # Kile
 *.backup
 
+# gummi
+.*.swp
+
 # KBibTeX
 *~[0-9]*
 


### PR DESCRIPTION
**Reasons for making this change:**

The LaTeX editor [gummi](https://github.com/alexandervdm/gummi) creates hidden files during compilation. This rule ignores these temporary files.


**Links to documentation supporting these rule changes:**

[Documentation in gummi source code](https://github.com/alexandervdm/gummi/blob/master/src/editor.c#L166)
