### PR TITLE
add pycharm project setting dir to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pycharm project settings
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**
add pycharm project setting dir ".idea/" to the Python.gitignore.