### PR TITLE
Added Simulink cache files to MATLAB.gitignore

### DIFF
--- a/Global/MATLAB.gitignore
+++ b/Global/MATLAB.gitignore
@@ -24,5 +24,8 @@ codegen/
 # Simulink autosave extension
 *.autosave
 
+# Simulink cache files
+*.slxc
+
 # Octave session info
 octave-workspace


### PR DESCRIPTION
**Reasons for making this change:**

New Simulink cache files are not yet considered in MATLAB.gitignore. They should be treated like codegen / mex-files.

**Links to documentation supporting these rule changes:**

- https://de.mathworks.com/help/simulink/ug/reuse-simulation-builds-for-faster-simulations.html
- https://www.reddit.com/r/matlab/comments/bw1255/simulinkcache_slxc_files_and_git/
