### PR TITLE
Add esp-idf.gitignore

### DIFF
--- a/community/embedded/esp-idf.gitignore
+++ b/community/embedded/esp-idf.gitignore
@@ -1,0 +1,3 @@
+build/
+sdkconfig
+sdkconfig.old

--- a/community/embedded/esp-idf.gitignore
+++ b/community/embedded/esp-idf.gitignore
@@ -1,3 +1,6 @@
+# gitignore template for esp-idf, the official development framework for ESP32
+# https://github.com/espressif/esp-idf
+
 build/
 sdkconfig
 sdkconfig.old


### PR DESCRIPTION
esp-idf is the official development framework for the extremely popular ESP32 family of microcontrollers. It is maintained by the chip's manufacturer, Espressif, at https://github.com/espressif/esp-idf.

The contents of this `.gitignore` are taken directly from the [official template project](https://github.com/espressif/esp-idf-template/blob/master/.gitignore), which align with the [advice](https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/kconfig.html?highlight=gitignore#using-sdkconfig-defaults) given in the official documentation. All build artifacts are generated in the `build` directory.