### PR TITLE
Add *.sch-bak to KiCad.gitignore

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -6,6 +6,7 @@
 *.bak
 *.bck
 *.kicad_pcb-bak
+*.sch-bak
 *~
 _autosave-*
 *.tmp


### PR DESCRIPTION
**Reasons for making this change:**

Newer versions of KiCad call the schematics backup file `.sch-bak`.

**Links to documentation supporting these rule changes:**

https://github.com/KiCad/kicad-source-mirror/commit/7759ad7e2751203337fbf02bce8cda8f6bbd6d72
