### PR TITLE
Reference why to exclude binary jar, fixes #111

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,4 +7,5 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar


### PR DESCRIPTION
**Reasons for making this change:**

Improve documentation

**Links to documentation supporting these rule changes:**

https://github.com/takari/maven-wrapper#usage-without-binary-jar