### PR TITLE
Android Studio: Ignore .cxx directories in v3.5

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -80,3 +80,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+# .cxx directories created by Android Studio 3.5 (part of C++ support)
+.cxx/


### PR DESCRIPTION
Android Studio 3.5 introduced `.cxx` directories containing CMake configuration
directories, similar to `.externalNativeBuild`.
