### PR TITLE
modify swift.gitignore to have .DS_Store

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -5,6 +5,8 @@
 ## User settings
 xcuserdata/
 
+.DS_Store
+
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout


### PR DESCRIPTION
**Reasons for making this change:**

In mac , .DS_Store file is a hidden files, which is added to the github repo whenever we try to upload our projects on github. We can remove .DS_Store file using the methods expressed in this [link](https://stackoverflow.com/questions/107701/how-can-i-remove-ds-store-files-from-a-git-repository) . But it will be very good and hassel free if we already have .DS_Store file present in .gitignore template of swift.

