### PR TITLE
[Qt]Add generated translation binaries to the .gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -28,6 +28,7 @@ ui_*.h
 *.jsc
 Makefile*
 *build-*
+*.qm
 
 # Qt unit tests
 target_wrapper.*


### PR DESCRIPTION
The *.qm binary translation files are generated from the translation *.ts files and should not be tracked by git since they are generated.

**Reasons for making this change:**

qm files are autogenerated (on each build if the translation sources are added to the .pro file)

**Links to documentation supporting these rule changes:**

https://wiki.qt.io/Automating_generation_of_qm_files

If this is a new template:

N/A
