### PR TITLE
Exclude VS Code cache directory in Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -22,6 +22,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
Added .vscode/ as a directory that may need to be ignored depending on how C# files are edited.

**Reasons for making this change:**
Aligning the unity.gitignore file with other .NET .gitignore files like [dotnet/corefx/.gitignore](https://github.com/dotnet/corefx/blob/master/.gitignore).