### PR TITLE
Ignore macOS resource files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -350,3 +350,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# macOS resource files
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

Ignore .DS_Store. If using Visual Studio for Mac, this file will exist every folder, so ignore it!

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store
https://github.com/lijiejie/ds_store_exp

If this is a new template:

 - **Link to application or project’s homepage**: https://www.apple.com/macos/
