### PR TITLE
Upgrate to rails 6.0.0

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -3,7 +3,7 @@ capybara-*.html
 .rspec
 /db/*.sqlite3
 /db/*.sqlite3-journal
-/db/*.sqlite3-[0123456789]*
+/db/*.sqlite3-[0-9]*
 /public/system
 /coverage/
 /spec/tmp

--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -3,6 +3,7 @@ capybara-*.html
 .rspec
 /db/*.sqlite3
 /db/*.sqlite3-journal
+/db/*.sqlite3-[0123456789]*
 /public/system
 /coverage/
 /spec/tmp


### PR DESCRIPTION
**Reasons for making this change:**

Rails 6 generates multiple databases for each test thread.

https://blog.bigbinary.com/2019/04/29/rails-6-adds-parallel-testing.html
