### PR TITLE
Add OpenSSL-related file extensions

### DIFF
--- a/community/OpenSSL.gitignore
+++ b/community/OpenSSL.gitignore
@@ -1,0 +1,34 @@
+# OpenSSL-related files best not committed
+
+## Certificate Authority
+*.ca
+
+## Certificate
+*.crt
+
+## Certificate Sign Request
+*.csr
+
+## Certificate
+*.der 
+
+## Key database file
+*.kdb
+
+## OSCP request data
+*.org
+
+## PKCS #12
+*.p12
+
+## PEM-encoded certificate data
+*.pem
+
+## Random number seed
+*.rnd
+
+## SSLeay data
+*.ssleay
+
+## S/MIME message
+*.smime


### PR DESCRIPTION
There are a number of OpenSSL-related file extensions (e.g., .pem, .crt,
etc..) that contain data that are generally best not committed to
repositories.  This file contains several common file extensions that
often correlate to these types of files.

**Reasons for making this change:**
Often times keys, certificates, etc., when they're committed, it's on accident.  This file excludes several common extensions used by OpenSSL, a popular tool for working with SSL / TLS certificates and such.  As I couldn't find resources for excluding these files, I'm submitting a new .gitignore file.

**Links to documentation supporting these rule changes:**
https://datatypes.net/openssl-file-types
