### PR TITLE
Update Vim.gitignore

### DIFF
--- a/Global/Vim.gitignore
+++ b/Global/Vim.gitignore
@@ -1,5 +1,6 @@
 # Swap
 [._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
 [._]*.sw[a-p]
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]


### PR DESCRIPTION
**Reasons for making this change:**

.svg files are more often than not vector files. You need to exceed 36 swap files for a .svg file to come from Vim.

**Links to documentation supporting these rule changes:**

Vim source code regarding naming of swap files: https://github.com/vim/vim/blob/8c6173c7d3431dd8bc2b6ffc076ef49512a7e175/src/memline.c#L5076
