### PR TITLE
Update Python.github to include new venv excl

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -104,6 +104,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.python-env/
+.python-venv/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Gaining in popularity in multi-national corps I work at.  Proposed change since projects often include other venvs and need to be name specific.

ex:
./.spack-env
./.python-env

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
