### PR TITLE
Updated Nim.gitignore

### DIFF
--- a/Nim.gitignore
+++ b/Nim.gitignore
@@ -1,1 +1,3 @@
 nimcache/
+nimblecache/
+htmldocs/


### PR DESCRIPTION
* added further cache directory
* added auto-generated documentation location

**Reasons for making this change:**
Updates to the Nim language.

**Links to documentation supporting these rule changes:**
Create a Nim project and see for yourself. It is basic caching and auto generation. Nothing special or noteworthy.
