### PR TITLE
Add Rider files to. gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -22,6 +22,9 @@
 # Visual Studio cache directory
 .vs/
 
+# JetBrains Rider cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
It could be a good idea to add project specific files from JetBrains Rider to .gitignore as this IDE is currently supported in Unity for Windows, Linux and iOS
