### PR TITLE
Add rebar3 tool files and directories

### DIFF
--- a/Erlang.gitignore
+++ b/Erlang.gitignore
@@ -8,3 +8,6 @@ ebin/*.beam
 rel/example_project
 .concrete/DEV_MODE
 .rebar
+.rebar3
+_build/
+_checkouts/

--- a/Erlang.gitignore
+++ b/Erlang.gitignore
@@ -1,13 +1,17 @@
 .eunit
-deps
 *.o
 *.beam
 *.plt
 erl_crash.dump
-ebin/*.beam
-rel/example_project
 .concrete/DEV_MODE
+
+# rebar 2.x
 .rebar
+rel/example_project
+ebin/*.beam
+deps
+
+# rebar 3
 .rebar3
 _build/
 _checkouts/


### PR DESCRIPTION
**Reasons for making this change:**

[`rebar3`](https://github.com/erlang/rebar3) has been the most used Erlang build tool for some time now. It is officially endorsed by the project too. 

**Links to documentation supporting these rule changes:**

* The template currently supports older version of `rebar`. This [link](https://www.rebar3.org/docs/from-rebar-2x-to-rebar3) shows the changes from the older version. It also shows that the auto generated build directory is `_build`.
* The documentation for the `_checkouts` directory can be found [here](https://www.rebar3.org/docs/dependencies#checkout-dependencies). It is essentially a directory so you can put libraries/applications you are working on locally while you are developing.
* The `.rebar3` has essentially the same function as the `.rebar` (which is already present) except that it is for `rebar3`.
* **Link to application or project’s homepage**: https://www.rebar3.org/
