### PR TITLE
Ignore GatsbyJS files

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -75,6 +75,10 @@ typings/
 # nuxt.js build output
 .nuxt
 
+# gatsby files
+.cache/
+public
+
 # vuepress build output
 .vuepress/dist
 


### PR DESCRIPTION
**Reasons for making this change:**

Running `gatsby develop` or `gatsby build` generates a `public` directory containing the built output and a `.chache` directory used during development for hot reloading.

Official GatsbyJS starters ignore both `.cache` and `public` in their `.ignore` files.

**Links to documentation supporting these rule changes:**

[gatsby-default-starter `.ignore` file](https://github.com/gatsbyjs/gatsby-starter-default/blob/bcb1bd9a6ec9eded68fade400d96bac67d43ec57/.gitignore#L57)
