### PR TITLE
Update Python.gitignore with .DSStore for macOS

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# macOS exclusions
+.DSStore


### PR DESCRIPTION
**Reasons for making this change:**

Ignore .DS_Store. This file will exist in every folder if working on a Mac. Let's put it in the python.gitignore file so that we can use this one .gitignore file on a Mac.

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store