### PR TITLE
ignore intellij idea generated project settings/build files & directo…

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -21,3 +21,9 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IDE generated files & directories
+.idea
+.iml
+build
+out


### PR DESCRIPTION

**Reasons for making this change:**

IntelliJ IDEA generates project settings related files such as .idea or .iml and output directories such as build or out which are not meant to a be a part of our source code repository.
