### PR TITLE
Add versioned so files extension to Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -6,6 +6,7 @@
 *.la
 *.lai
 *.so
+*.so.*
 *.dll
 *.dylib
 


### PR DESCRIPTION
Some Qt packages builds versioned shared objects which will generate foobar.so.n style symlinks to the output file. These files should not tracked by git.

**Reasons for making this change:**

Built libmlocale with qmake, which resulted the following output and symlink in the lib dir:

```
libmlocale5.so
libmlocale5.so.0
libmlocale5.so.0.1
libmlocale5.so.0.1.1
```


**Links to documentation supporting these rule changes:**

N/A

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
