### PR TITLE
Add *.prl files to Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -29,6 +29,7 @@ ui_*.h
 Makefile*
 *build-*
 *.qm
+*.prl
 
 # Qt unit tests
 target_wrapper.*


### PR DESCRIPTION
**Reasons for making this change:**
prl files are generated by the qmake if the create/link_prl option is set. They should not be tracked by git see the following section at the end of the linked documentation below:

> The .prl files should be created by qmake only, and should not be transferred between operating systems, as they may contain platform-dependent information.

**Links to documentation supporting these rule changes:**

https://doc.qt.io/qt-5/qmake-advanced-usage.html#library-dependencies

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
