### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.code-workspace
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
Added Visual Studio Code workspace files to the user-specific files list.

**Reasons for making this change:**

One might include this somewhere in the git folder while working with Visual Studio Code, but it should never be included with git. It is a core file type, so should be included here.

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-file

