### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -18,7 +18,7 @@ out/
 
 # Gradle files
 .gradle/
-build/
+/build
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
Fix Gradle buildSrc ignored

**Reasons for making this change:**

The custom local Gradle plugin will use the buildSrc directory, and `build/` will exclude the `buildSrc/src/**` directory and change it to `/build`.

**Links to documentation supporting these rule changes:**

If this is a new template:

