### PR TITLE
Add apt_generated_test/

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -48,6 +48,7 @@ local.properties
 
 # Annotation Processing
 .apt_generated/
+.apt_generated_test/
 
 # Scala IDE specific (Scala & Java development for Eclipse)
 .cache-main


### PR DESCRIPTION
**Reasons for making this change:**

The annotation processing creates a separate sub-directory for test cases.

**Links to documentation supporting these rule changes:**

Did not find it. A developer tested it in Eclipse and manually added that directory.