### PR TITLE
Added tern-port

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -96,3 +96,6 @@ public
 
 # DynamoDB Local files
 .dynamodb/
+
+# TernJS port file
+.tern-port


### PR DESCRIPTION
**Reasons for making this change:**

[TernJS](https://ternjs.net) addon for many editors (vim, emacs, sublime,...) adds a file to manage its existing process.
