### PR TITLE
add libnx gitiginore

### DIFF
--- a/community/libnx.gitignore
+++ b/community/libnx.gitignore
@@ -1,0 +1,27 @@
+# gitignore template for libnx projects 
+# repository: https://github.com/switchbrew/libnx
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.o
+
+# Linker output
+*.map
+*.lst
+
+# Executables
+*.elf
+*.kip
+*.nro
+*.nso
+
+# Metadata
+*.nacp
+*.npdm
+
+# Containers
+*.pfs0
+*.nsp
+*.bz2


### PR DESCRIPTION
**Reasons for making this change:**

gitignore for use with C/C++ projects that are compiling to the Nintendo Switch with libnx (this gitignore may also work with other similar Libraries).

**Links to documentation supporting these rule changes:**

https://github.com/switchbrew/switch-examples
https://switchbrew.github.io/libnx/files.html


Project Homepage:

https://github.com/switchbrew/libnx
