### PR TITLE
Ruby: ignore RuboCop remote inherited config files

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -51,3 +51,6 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*


### PR DESCRIPTION
**Reasons for making this change:**

[RuboCop](http://www.rubocop.org) config files support an `inherit_from` directive. 

When one inherits from a remote URL, a local version is download. For example: `.rubocop-https--my-remote-config.com`. 

**Links to documentation supporting these rule changes:**



[From RuboCop's docs](https://docs.rubocop.org/en/stable/configuration/#inheriting-configuration-from-a-remote-url)

> The optional inherit_from directive can contain a full url to a remote file. This makes it possible to have common project settings stored on a http server and shared between many projects.

> The remote config file is cached locally and is only updated if:

> The file does not exist.
> The file has not been updated in the last 24 hours.
> The remote copy has a newer modification time than the local copy.

Given this, is seems appropriate for git to ignore this file. 

