### PR TITLE
Add schema plist for different computers.

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -4,6 +4,7 @@
 
 ## User settings
 xcuserdata/
+*.xcuserdatad/xcschemes/xcschememanagement.plist
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint


### PR DESCRIPTION
**Reasons for making this change:**

When you change computers, the plist orderHint value automatically changes. Ie ( from 0 to 1).

 		<key><ProjectName>.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>


**Links to documentation supporting these rule changes:**

https://mgrebenets.github.io/xcode/2014/05/29/share-xcode-schemes

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
