### PR TITLE
Update to Global/VisualStudioCode

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -3,3 +3,4 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+*.code-workspace


### PR DESCRIPTION
Added ignore for workspace files (*.code-workspace). They can be added in any directory, depending on the user's preferences.

**Reasons for making this change:**

One might include this somewhere in the git folder while working with Visual Studio Code, but it should never be included with git. It is a core file type, so should be included here.

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-file

**Further information:** 
This a a follow-up to https://github.com/github/gitignore/pull/3188, as supposed by @shiftkey .
