### PR TITLE
add new template for EPICS

### DIFF
--- a/EPICS.gitignore
+++ b/EPICS.gitignore
@@ -1,0 +1,48 @@
+# EPICS site : https://epics-controls.org/
+# References : epics-base / epics-modules / @ralphlange / @jeonghanlee
+# Directories built by EPICS building system 
+/cfg/
+/bin/
+/lib/
+/db/
+/dbd/
+/html/
+/include/
+/templates/
+O.*/
+/*Top/cfg/
+/*Top/bin/
+/*Top/lib/
+/*Top/db/
+/*Top/dbd/
+/*Top/html/
+/*Top/include/
+/*Top/templates/
+
+
+# User-specific files for local modifications
+/configure/*.local
+/configure/RELEASE.*
+/configure/CONFIG_SITE.*
+/modules/RELEASE.*.local
+/modules/Makefile.local
+/*Top/configure/*.local
+
+# documents
+/documentation/html
+/documentation/*.tag
+
+# Others for UI, autosave, and so on
+/QtC-*
+envPaths
+cdCommands
+dllPath.bat
+*BAK.adl
+auto_settings.sav*
+auto_positions.sav*
+*.orig
+*.log
+.*.swp
+*~
+.#*
+\#*\#

--- a/EPICS.gitignore
+++ b/EPICS.gitignore
@@ -40,9 +40,3 @@ dllPath.bat
 *BAK.adl
 auto_settings.sav*
 auto_positions.sav*
-*.orig
-*.log
-.*.swp
-*~
-.#*
-\#*\#

--- a/EPICS.gitignore
+++ b/EPICS.gitignore
@@ -27,6 +27,7 @@ O.*/
 /modules/RELEASE.*.local
 /modules/Makefile.local
 /*Top/configure/*.local
+*.local
 
 # documents
 /documentation/html


### PR DESCRIPTION
**Reasons for making this change:**

Add new template for Experimental Physics and Industrial Control System (EPICS)

**Links to documentation supporting these rule changes:**
 - https://epics.anl.gov/base/R3-15/6-docs/AppDevGuide/BuildFacility.html#x5-580004
 - https://github.com/epics-base/epics-base/blob/7.0/.gitignore

If this is a new template:

 - **Link to application or project’s homepage**:   
   - https://epics-controls.org/
   - https://epics.anl.gov/
