### PR TITLE
Ignore the __pypackages__ folder for pyflow users

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -91,6 +91,9 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# pyflow
+__pypackages__/
+
 # celery beat schedule file
 celerybeat-schedule
 


### PR DESCRIPTION
**Reasons for making this change:**

pyflow is a tool for managing Python development workflow and dependencies.
It saves the dependencies locally in the `__pypackages__` folder.

**Links to documentation supporting these rule changes:**

See https://github.com/David-OConnor/pyflow#gotchas