### PR TITLE
Create JupyterNotebook.gitignore

### DIFF
--- a/JupyterNotebook.gitignore
+++ b/JupyterNotebook.gitignore
@@ -1,0 +1,13 @@
+### JupyterNotebooks ###
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/

--- a/JupyterNotebook.gitignore
+++ b/JupyterNotebook.gitignore
@@ -1,3 +1,6 @@
+# Created by https://www.gitignore.io/api/jupyternotebooks
+# Edit at https://www.gitignore.io/?templates=jupyternotebooks
+
 ### JupyterNotebooks ###
 # gitignore template for Jupyter Notebooks
 # website: http://jupyter.org/
@@ -11,3 +14,5 @@ ipython_config.py
 
 # Remove previous ipynb_checkpoints
 #   git rm -r .ipynb_checkpoints/
+
+# End of https://www.gitignore.io/api/jupyternotebooks


### PR DESCRIPTION
**Reasons for making this change:**

Making gitignore support for jupyter notebooks' projects i.e. not adding checkpoints and its directory to git

**Links to documentation supporting these rule changes:**

http://gitignore.io/api/jupyternotebooks