### PR TITLE
Ignore .vscode generated folder in Unity project

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -21,6 +21,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
**Reasons for making this change:**

VS Code now generates .vscode folder in the root of project folder containing some custom workspace settings only for that project and it doesn't need to be tracked.

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations

