### PR TITLE
exclude *.tps files from TeXnicCenter

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -259,6 +259,9 @@ TSWLatexianTemp*
 # KBibTeX
 *~[0-9]*
 
+# TeXnicCenter
+*.tps
+
 # auto folder when using emacs and auctex
 ./auto/*
 *.el


### PR DESCRIPTION

**Reasons for making this change:**
TeXnicCenter produces a status file named *.tps which holds information on currently open *.tex files and window positions. This most likely should not be checked in.

**Links to documentation supporting these rule changes:**

http://texniccenter.sourceforge.net/placeholders.html#placeholder-TXC
