### PR TITLE
exclude .Renviron

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -34,3 +34,6 @@ vignettes/*.pdf
 # Temporary files created by R markdown
 *.utf8.md
 *.knit.md
+
+# R Environment Variables
+.Renviron


### PR DESCRIPTION
**Reasons for making this change:**

Many people use `.Renviron` files in the same way that other languages use `.env` files. In R, when you start an interactive session it automatically loads any environment variables found in `.Renviron`. This file should be excluded by default to avoid leaking any secrets or credentials.

**Links to documentation supporting these rule changes:**

What R does at startup
official:
https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html
and the more readable:
https://cran.r-project.org/web/packages/startup/vignettes/startup-intro.html

Specifically, note:

> When R starts, the following user-specific setup takes place:
> 
> The first .Renviron file found on the R startup search path is processed. The search path is (in order): (i) Sys.getenv("R_ENVIRON_USER"), (ii) ./.Renviron, and (iii) ~/.Renviron. The format of this file is one ENV_VAR=VALUE statement per line, cf. ?.Renviron. NOTE: Some environment variables must be set already in this step in order to be acknowledged by R, i.e. it is too late to set some of them in Step 2 and Step 3 below.

Advice from the RStudio (most popular IDE for R) community forum for using API secrets/tokens:
https://community.rstudio.com/t/how-to-set-a-variable-in-renviron/5029
