### PR TITLE
Ignore IDE files

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -65,3 +65,9 @@ yarn-debug.log*
 # Ignore uploaded files in development
 /storage/*
 !/storage/.keep
+
+# Ignore IDE files
+# TODO: Comment out this line if you need project configurations versioned
+.idea/
+.vscode/
+.atom/


### PR DESCRIPTION
**Reasons for making this change:**

Ignore Ruby on Rails IDE files (RubyMine, VSCode, Atom) 

**Links to documentation supporting these rule changes:**

This is natural in most web development projects.
