### PR TITLE
Add vscode user specific and workspace files to UnrealEngine

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,9 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# Visual Studio Code user specific files
+.vscode/
+
 # Compiled Object files
 *.slo
 *.lo
@@ -40,6 +43,7 @@
 *.sdf
 *.VC.db
 *.VC.opendb
+*.code-workspace
 
 # Precompiled Assets
 SourceArt/**/*.png


### PR DESCRIPTION
**Reasons for making this change:**

Unreal Engine 4 supports vscode project generation since 4.18

**Links to documentation supporting these rule changes:**

https://docs.unrealengine.com/en-US/Support/Builds/ReleaseNotes/4_18/index.html#new:visualstudiocodesupportedonwindows,macandlinux
