### PR TITLE
Ignore visual studio 'enc_temp_folder' in UnrealEngine

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,5 +1,6 @@
-# Visual Studio 2015 user specific files
+# Visual Studio 2015+ user specific files
 .vs/
+enc_temp_folder/
 
 # Compiled Object files
 *.slo


### PR DESCRIPTION
**Reasons for making this change:**

It's usual to have files inside the folder when working with hot-reload. Visual Studio will delete it most of the times, but sometimes if a crash occurs or something similar happens the folder won't be deleted.
