### PR TITLE
Ignore cmake build and JetBrains user specific files in UnrealEngine

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,9 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# JetBrains user specific files
+.idea/
+
 # Compiled Object files
 *.slo
 *.lo
@@ -40,6 +43,7 @@
 *.sdf
 *.VC.db
 *.VC.opendb
+CMakeLists.txt
 
 # Precompiled Assets
 SourceArt/**/*.png


### PR DESCRIPTION
**Reasons for making this change:**

Similar to https://github.com/github/gitignore/pull/3216
Support for CLion IDE in Unreal Engine 4 projects

