### PR TITLE
Ignore all except wp-contents

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,5 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
    * add ignore all before wp-content exception
@shiftkey 
**Reasons for making this change:**

Since comment says ignore all files except wp-contents the correct rule should also ignore all files except wp-contents.
