### PR TITLE
Update Archives.gitignore

### DIFF
--- a/Global/Archives.gitignore
+++ b/Global/Archives.gitignore
@@ -5,12 +5,15 @@
 *.rar
 *.zip
 *.gz
+*.gzip
 *.tgz
 *.bzip
+*.bzip2
 *.bz2
 *.xz
 *.lzma
 *.cab
+*.xar
 
 # Packing-only formats
 *.iso
@@ -26,3 +29,4 @@
 *.msi
 *.msm
 *.msp
+*.txz


### PR DESCRIPTION
**Reasons for making this change:**

Added missing  gzip, bzip2, xar, txz

**Links to documentation supporting these rule changes:**

xar
https://en.wikipedia.org/wiki/Xar_(archiver)

txz/tgz - Slackware Linux package
https://docs.slackware.com/slackbook:package_management

If this is a new template:


