### PR TITLE
Update UnrealEngine.gitignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,10 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# Codelite Generated files
+*.session
+*.tags
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
Update UnrealEngine.gitignore to include Codelite generated files. Codelite workspace files are generated by Unreal Editor. I am a Linux user and primarily use Codelite for developing c++ to use in my Unreal Projects. The *.tags in particular are massive files.

**Reasons for making this change:**

I used this gitignore as a template for my Unreal Project. The *.tags files are so huge that they actually resulted in an error:

```
error: RPC failed; HTTP 413 curl 22 The requested URL returned error: 413 Request Entity Too Large
fatal: The remote end hung up unexpectedly
```