### PR TITLE
Ignore the logs folder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -37,6 +37,9 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Program logs
+logs/
+
 # Unit test / coverage reports
 htmlcov/
 .tox/


### PR DESCRIPTION
In my opinion i don't see nobody wanting to push log files to their repo or having anything else then log files in it.

**Reasons for making this change:**
It doesn't really make sense to write code in the `logs/` directory, nor does it make sense to upload log files to github.