### PR TITLE
Visual Studio - Ignore Subversion source control directory

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -351,3 +351,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Subversion Source Control (for mixed environments i.e. GIT local SVN Remote)
+.svn


### PR DESCRIPTION
Ignore Subversion source control directory.  Helpful when a developer works in an environment with a remote SVN Repository but wants to use a GIT repository for more frequent commits

**Reasons for making this change:**
My team works in a mixed environment (Subversion and GIT).  Currently we have several projects that require a remote SVN commit per feature completion (stable build only).  However, more frequent commits are left to the developer.  We use a local GIT repository for progressive check-ins and sometimes forget to add the ".svn" ignore to the file created by Visual Studio.

**Links to documentation supporting these rule changes:**

n/a

If this is a new template: n/a
