### PR TITLE
JustCode has been discontinued

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -127,9 +127,6 @@ _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
 
-# JustCode is a .NET coding add-in
-.JustCode
-
 # TeamCity is a build add-in
 _TeamCity*
 


### PR DESCRIPTION
**Reasons for making this change:**

JustCode has been discontinued as the features it provided are now included in Visual Studio 2017 and newer. This is noted in the announcement by Telerik.

https://www.telerik.com/products/justcode-sunsetting