### PR TITLE
Add template for clasp

### DIFF
--- a/Clasp.gitignore
+++ b/Clasp.gitignore
@@ -1,0 +1,3 @@
+## For clasp settings
+.clasp.json
+appsscript.json


### PR DESCRIPTION
**Reasons for making this change:**

Add new template for Command Line Apps Script Projects(clasp).

clasp generates configs for linking with Google authentication and Google App Script.
These files should not tracked by git.

**Links to documentation supporting these rule changes:**
 - https://github.com/google/clasp