### PR TITLE
Added celerybeat.pid

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -91,8 +91,9 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
-# celery beat schedule file
+# Celery stuff
 celerybeat-schedule
+celerybeat.pid
 
 # SageMath parsed files
 *.sage.py


### PR DESCRIPTION
**Reasons for making this change:**
The pidfile stores the process id of the running server... It shouldn't be added to version control. 

**Links to documentation supporting these rule changes:**

> The program won’t start if this file already exists and the pid is still alive.

ref: https://docs.celeryproject.org/en/latest/reference/celery.bin.beat.html#cmdoption-celery-beat-pidfile

