### PR TITLE
Add crash.log to Packer.gitignore

### DIFF
--- a/Packer.gitignore
+++ b/Packer.gitignore
@@ -1,5 +1,8 @@
 # Cache objects
 packer_cache/
 
+# Crash log
+crash.log
+
 # For built boxes
 *.box


### PR DESCRIPTION
**Reasons for making this change:**
If [Packer](https://www.packer.io/) crashes, it writes the panic output to the file `crash.log` in the current directory. This file should not be tracked in version control as it has the potential to contain sensitive information and is only useful for debugging. This behavior is the same as Terraform, which already includes `crash.log` in its `.gitignore` template

**Links to documentation supporting these rule changes:**

I was unable to find official documentation on this behavior, but it's pretty clear in panic output string in the source code here: https://github.com/hashicorp/packer/blob/master/panic.go


