### PR TITLE
Create NetLogo.gitignore

### DIFF
--- a/NetLogo.gitignore
+++ b/NetLogo.gitignore
@@ -1,0 +1,1 @@
+*.tmp.nlogo


### PR DESCRIPTION
**Reasons for making this change:**

When working with NetLogo this gitignore will be useful.

**Links to documentation supporting these rule changes:**

http://ccl.northwestern.edu/netlogo/docs/faq.html#is-there-any-way-to-recover-lost-work-if-netlogo-crashes-or-freezes

If this is a new template:

 - **Link to application or project’s homepage**: https://ccl.northwestern.edu/netlogo/
