### PR TITLE
ignore new directory added in Android Studio 3.5

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -56,6 +56,7 @@ captures/
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
+.cxx/
 
 # Google Services (e.g. APIs or Firebase)
 # google-services.json


### PR DESCRIPTION
**Reasons for making this change:**

Follow-up from #3155

**Links to documentation supporting these rule changes:**

https://developer.android.com/ndk/guides/cmake#build-command

> Note: Older versions of the Android Gradle Plugin placed these files in the `.externalNativeBuild` directory rather than the `.cxx` directory.

