### PR TITLE
Added aar file type to gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,5 +1,6 @@
 # Built application files
 *.apk
+*.aar
 *.ap_
 
 # Files for the ART/Dalvik VM


### PR DESCRIPTION
Instead of regular APK, we can build AAR that are library modules. They are similar to the APK, but they are used by them as dependency modules that contain resources.

Link:

https://developer.android.com/studio/projects/android-library