### PR TITLE
exclude compiler.xml and artifacts when using Gradle

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -28,6 +28,8 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules


### PR DESCRIPTION
In our IntelliJ projects where we are using Gradle, the file .idea/compiler.xml and files inside the .idea/artifacts folder are automatically generated by IntelliJ based on the Gradle build model.

**Reasons for making this change:**

Automatically generated files should be ignored in version control.

I did comment out my changes though, as the existing Gradle/Maven related ignore rules are commented out as well.

**Links to documentation supporting these rule changes:**

https://intellij-support.jetbrains.com/hc/en-us/articles/206544839?page=3#comment_360000710180

Answer of Serge Baranov to my comment:
_The files generated on import and not having any manual customizations can be safely excluded from the version control._
