### PR TITLE
.gitignore .idea/

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -81,6 +81,9 @@ target/
 profile_default/
 ipython_config.py
 
+# PyCharm project directory
+.idea/
+
 # pyenv
 .python-version
 


### PR DESCRIPTION
Git ignore PyCharm project directory `.idea/`

**Reasons for making this change:**

PyCharm is one of the most common IDEs for Python projects.  It's established project directory is always at `project/.idea`.

**Links to documentation supporting these rule changes:**

I've used PyCharm for several years.
