### PR TITLE
add Node.js Diagnostic Report files

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Node.js Diagnostic Report files
+report.*.json


### PR DESCRIPTION
**Reasons for making this change:**

Node.js diagnostic report files can contain sensitive information from the environment (e.g., cloud provider secrets), and should not be committed to version control.

**Links to documentation supporting these rule changes:**

- [Node.js Diagnostic Report](https://nodejs.org/api/report.html#report_diagnostic_report)
- [process.report.writeReport()](https://nodejs.org/api/process.html#process_process_report_writereport_filename_err)

Per the docs,

> If filename is not provided, the default filename includes the date, time, PID, and a sequence number

An example looks like `report.20191115.141412.94056.0.001.json`.  