### PR TITLE
Explanation for __pypackages__

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -91,7 +91,7 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
-# pyflow
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 
 # Celery stuff


### PR DESCRIPTION
I was very confused by [this](https://github.com/github/gitignore/blob/cb0c6ef7ac68f2300409ee85501d9ad432cb4c7e/Python.gitignore#L94).  I'd heard of `__pypackages__/` before but not pyflow.

A Google search for "pyflow" found several other projects with the same name ([the project](https://github.com/David-OConnor/pyflow) that `Python.gitignore` was referring to didn't show up until the 5th result for me). I only figured it out after finding [this PR](https://github.com/github/gitignore/pull/3205).

`__pypackages__` comes from [this PEP](https://www.python.org/dev/peps/pep-0582/). It's currently in draft status i.e. the proposal hasn't been accepted and the directory is not used within CPython.

I didn't know if pyflow's use of `__pypackages__` was in conflict with the PEP or if it's trying to be some kind of early implementation of it.  I'm guessing the latter since it [mentions the PEP 
 in its readme](https://github.com/David-OConnor/pyflow#references).

### tl;dr
The `__pypackages__` directory isn't used by Python yet.  But a somewhat obscure package is using the directory. It probably doesn't hurt to leave the ignore rule as is but a comment would be helpful.