### PR TITLE
Adding Terragrunt ignore file.

### DIFF
--- a/Terragrunt.gitignore
+++ b/Terragrunt.gitignore
@@ -1,0 +1,2 @@
+# Terragrunt
+.terragrunt-cache


### PR DESCRIPTION
Terragrunt uses local caching directories as part of the run in their
repo. Ignoring the cache directory.

https://github.com/gruntwork-io/terragrunt