### PR TITLE
ignore vscode settings in python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VScode settings
+.vscode


### PR DESCRIPTION
**Reasons for making this change:**

Ignore [VS Code](https://code.visualstudio.com/) settings.

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs/getstarted/settings

>A VS Code "workspace" is usually just your project root folder. Workspace settings as well as debugging and task configurations are stored at the root in a .vscode folder. You can also have more than one root folder in a VS Code workspace through a feature called Multi-root workspaces.

If this is a new template:

Not applicable.
