### PR TITLE
Update Coq.gitignore after coq/coq#11075

### DIFF
--- a/Coq.gitignore
+++ b/Coq.gitignore
@@ -18,6 +18,7 @@
 *.v.d
 *.vio
 *.vo
+*.vok
 *.vos
 .coq-native/
 .csdp.cache


### PR DESCRIPTION
**Reasons for making this change:**

New .vok files are generated by coqc

**Links to documentation supporting these rule changes:**

https://github.com/coq/coq/pull/11075
