### PR TITLE
Modified comment on Asset meta data ignore to better explain usage.

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -10,7 +10,7 @@
 /[Ll]ogs/
 /[Mm]emoryCaptures/
 
-# Never ignore Asset meta data
+# Asset meta data should only be ignored when the corresponding asset is also ignored
 !/[Aa]ssets/**/*.meta
 
 # Uncomment this line if you wish to ignore the asset store tools plugin


### PR DESCRIPTION
**Reasons for making this change:**

If used as written, the ignore rule in question will include .meta files in the repository even if the corresponding asset is ignored, which will cause issues in the editor. While there is no better ignore rule that applies more generally, at least noting in the comment that all ignored assets should also have their corresponding .meta file ignored as well will help users to avoid trouble.