### PR TITLE
added Coverlet result files as a Code Coverage Tool

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -137,6 +137,9 @@ _TeamCity*
 .axoCover/*
 !.axoCover/settings.json
 
+# Coverlet is a free, cross platform Code Coverage Tool
+coverage*[.json, .xml, .info]
+
 # Visual Studio code coverage results
 *.coverage
 *.coveragexml


### PR DESCRIPTION
**Reasons for making this change:**

[Coverlet](https://github.com/tonerdo/coverlet) is cross-platform code coverage for .NET

**Links to documentation supporting these rule changes:**

https://github.com/tonerdo/coverlet/blob/master/Documentation/MSBuildIntegration.md#coverage-output

By default, tool gives such files as a result (`p:CoverletOutputFormat` property):
* coverage.info
* coverage.json
* coverage.cobertura.xml
* coverage.opencover.xml