### PR TITLE
Added jarRepositories.xml as an optional ignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -30,6 +30,7 @@
 # auto-import.
 # .idea/artifacts
 # .idea/compiler.xml
+# .idea/jarRepositories.xml
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules


### PR DESCRIPTION
Since IntelliJ 2019.3 this file appeared automatically in our git changes. It seems these are just cached information about remote repositories that are defined in Maven/Gradle.

**Reasons for making this change:**
In a Maven/Gradle build, automatically generated files should should not be commited.

**Links to documentation supporting these rule changes:**
I haven't found a documentation or article about this file, but I'm basing my assumption on the following steps:
- in IntelliJ the "Remote Jar Repositories" can be managed in the Settings menu
- I deleted every entry in the list -> file disappeared
- I re-imported the Maven/Gradle project again
- the file appeared again with the same entries present as before
