### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm settings
+.idea/
+


### PR DESCRIPTION
**Reasons for making this change:**


This change is for [PyCharm IDE](https://www.jetbrains.com/pycharm/). I feel that **PyCharm IDE**'s project settings should be included in the `Python.gitignore`. The directory `.idea` is automatically generated by PyCharm for its project.


**Links to documentation supporting these rule changes:**

https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-