### PR TITLE
Added gitignore for GNOME Extension

### DIFF
--- a/community/GNOME/GNOMEShellExtension.gitignore
+++ b/community/GNOME/GNOMEShellExtension.gitignore
@@ -1,0 +1,3 @@
+# Ignored files for GNOME extension git repository
+
+*.zip


### PR DESCRIPTION
**Reasons for making this change:**

Added GNOME extension gitignore (it does not commit `zip`s).

**Links to documentation supporting these rule changes:**

The only zip in an extension is the one you [upload](https://extensions.gnome.org/upload/) to GNOME extensions website.

If this is a new template:

 - **Link to application or project’s homepage**: https://gitlab.gnome.org/Infrastructure/extensions-web/
