### PR TITLE
[Godot] Ignore imported translations

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -4,6 +4,9 @@
 export.cfg
 export_presets.cfg
 
+# Imported translations (automatically generated from CSV files)
+*.translation
+
 # Mono-specific ignores
 .mono/
 data_*/


### PR DESCRIPTION
**Reasons for making this change:**

The Godot editor automatically creates those binary files from translations in CSV format. There's no need to add them to version control.

**Links to documentation supporting these rule changes:**

https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_translations.html