### PR TITLE
Update Autotools.gitignore

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -6,6 +6,7 @@ Makefile.in
 /py-compile
 /test-driver
 /ylwrap
+.deps/
 
 # http://www.gnu.org/software/autoconf
 


### PR DESCRIPTION
**Reasons for making this change:**

When generating an hello world project the folder .deps is generated in src/

**Links to documentation supporting these rule changes:**

I can't find in the documentation details about the .deps folder but there are multiple resources on the internet that indeed add to the .gitignore the .deps folder.
