### PR TITLE
[Python] Ignore VS Code's 'Container - Remote extension'

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code - Container - Remote
+.devcontainer


### PR DESCRIPTION
**Reasons for making this change:**

Support developers who use Remote - Containers [Preview] extension for VS Code (https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs/remote/containers
https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
