### PR TITLE
Added Rider (IDEA) support

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -351,3 +351,7 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains Rider
+.idea/
+*.sln.iml


### PR DESCRIPTION
Adding JetBrains Rider support since the reason why it was removed is false. 

**Reasons for making this change:**

There is no ignore file for Rider. Also since Rider supports .NET and .NET Core why should it not be included in this ignore file. Would just replicate almost all of the entries present in this ignore file.