### PR TITLE
[Python] .python-version should NOT be ignored

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -82,7 +82,9 @@ profile_default/
 ipython_config.py
 
 # pyenv
-.python-version
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.


### PR DESCRIPTION
The `.python-version` file specifies what's the recommended version of the project. This is extremely important for consistency between the dev team. I want all my devs to use the same Python version (the same that is deployed in production). When a new dev joins the team, they just need to clone the project and do `pyenv install`, and pyenv will take care of picking the correct version for that given project.

I saw that the `.python-version` file was gitignored in [a commit 4 years ago](https://github.com/github/gitignore/commit/76b87217c836fa814e22763dc6b12b09ab86513a)!