### PR TITLE
Pytest-Benchmark

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pytest benchmark
+.benchmarks/


### PR DESCRIPTION
Adding pytest-benchmark support

**Reasons for making this change:**
When you run pytest-benchmark, it creates a folder called - ".benchmarks" which is not needed to be in the repository

