### PR TITLE
[Unity] Added a comment why MemoryCaptures get excluded

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -8,6 +8,9 @@
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
+
+# MemoryCaptures can get excessive in size.
+# They also could contain extremely sensitive data
 /[Mm]emoryCaptures/
 
 # Asset meta data should only be ignored when the corresponding asset is also ignored


### PR DESCRIPTION
**Reasons for making this change:**

We inform the users why we exclude a specific folder.
This adds a comment why we have excluded MemoryCaptures from git.
The reason for excluding them is due to their size of 500+ MB.
And most importantly due to the users security, because the MemoryProfiler is capturing the complete managed heap, which could contain sensitive data.

**Links to documentation supporting these rule changes:**

https://docs.unity3d.com/Packages/com.unity.memoryprofiler@0.1/manual/index.html
Read the paragraph with the heading: "Data concerns when sharing snapshots".


Best Regards

Fritzs