### PR TITLE
Create PlatformIO.gitignore

### DIFF
--- a/Global/PlatformIO.gitignore
+++ b/Global/PlatformIO.gitignore
@@ -1,0 +1,6 @@
+.pio
+.pioenvs
+.piolibdeps
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json


### PR DESCRIPTION
Add default ignores from PlatformIO in VSCode

**Reasons for making this change:**

There currently is not a gitignore template for PlatformIO

**Links to documentation supporting these rule changes:**

Can't find in documentation, but this is the default from the PIO template.

This is a new template:

 - https://platformio.org/
