### PR TITLE
Update PureScript adding .spago

### DIFF
--- a/PureScript.gitignore
+++ b/PureScript.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 .psci_modules
+.spago
 bower_components
 node_modules
 


### PR DESCRIPTION
**Reasons for making this change:**

Recently, [spago](https://github.com/spacchetti/spago) is getting more common as a build tool for PureScript.
This PR adds `.spago` which is to be generated when we use this tool.

**Links to documentation supporting these rule changes:**

https://github.com/spacchetti/spago
