### PR TITLE
Added Altium Designer

### DIFF
--- a/Altium.gitignore
+++ b/Altium.gitignore
@@ -1,0 +1,31 @@
+# Exclude temporary Altium Designer files
+*.PrjPCBStructure
+*.SchDocPreview
+*.PcbDocPreview
+__Previews
+*.PrjPcbStructure
+*.Dat
+*.REP 
+*.TLT
+*.htm
+*.$$$
+
+# Exclude logs
+*.LOG
+*.log
+*.err
+
+# Exclude build directories
+Project\ Outputs
+Project\ Logs
+Project Outputs for*
+
+# Exclude History directory
+History
+
+
+# Exclude libraries autosaves
+*.PvLib.Zip
+*.Schlib.Zip
+*.DbLib.Zip
+*.PcbLib.Zip


### PR DESCRIPTION
**Reasons for making this change:**

Introduce gitignore for altium designer, a popular ECAD software.

**Links to documentation supporting these rule changes:**

https://techdocs.altium.com/display/ADOH/Importing%2Band%2BExporting%2BDesign%2BFiles
The .gitignore was developed over 5 years of experience using Altium Designer on git


 - **Link to application or project’s homepage**: https://www.altium.com/altium-designer/
