### PR TITLE
Adding .DS_Store to list

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -83,3 +83,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+# macOS Generated
+**.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

On macOS development environment for android, .DS_Store is created on every folder. **.DS_Store** is a file that stores custom attributes of its containing folder, such as the position of icons or the choice of a background image, which isn't required to be placed in VCS. Many android devs work on mac machine for them it's a must to be placed in gitignore.

**Links to documentation supporting these rule changes:**

https://gist.github.com/iainconnor/8605514
https://coderwall.com/p/piwu4w/gitignore-for-android-studio-projects

