### PR TITLE
Update JetBrains.gitignore (venv default folder (created by Pycharm) to be ignored)

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -69,3 +69,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Python default folder for virtual environment
+venv/


### PR DESCRIPTION
**Reasons for making this change:**

_Pycharm by default makes folder venv/ to keep there virtual environment_

