### PR TITLE
[Python] Add PyCharm and VSCode project/setting folders

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -114,6 +114,12 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm project settings
+.idea/
+
+# VSCode project settings
+.vscode/
+
 # Rope project settings
 .ropeproject
 


### PR DESCRIPTION
**Reasons for making this change:**

PyCharm and VSCode are very popular tools in the Python Community.

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs#vscode
https://www.jetbrains.com/pycharm/

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
