### PR TITLE
Ignore .DS_Store

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -351,3 +351,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Mac files
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**
I always have to ignore this when developing .NET applications on Mac.
