### PR TITLE
TeX: Ignore REVTeX generated Notes.bib files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -274,3 +274,8 @@ TSWLatexianTemp*
 
 # Makeindex log files
 *.lpz
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib


### PR DESCRIPTION
**Reasons for making this change:**

The REVTeX documentclass [<a href="#footnote1">1</a>,<a href="#footnote2">2</a>] for LaTeX is the default style for submitting papers to the journals published by the American Physical Society (APS).

By default this class is loaded with the option `footinbib` which displays footnotes in the bibliography.  To do so, the class generates a file with the name `<jobname>Notes.bib` in the working directory.  Since this file is generated from footnotes that are present in the input, it essentially duplicates information and should therefore not be placed under version control.

**Links to documentation supporting these rule changes:**

See section VII. “Footnotes” or just search for `Notes.bib`.

> Please note that even if  BibTeX is not being used for the references, you may have to run BibTeX if you are using footnotes without the `nofootinbib` option. The log file will contain errors about missing references such as `Note1` in this case and a file ending in `Notes.bib` will have been produced during the processing of the TeX file.

Source: http://mirrors.ctan.org/macros/latex/contrib/revtex/doc/auguide/auguide4-2.pdf#section*.47

---

[<a id="foonote1">1</a>] https://ctan.org/pkg/revtex
[<a id="foonote2">2</a>] https://journals.aps.org/revtex