### PR TITLE
Create a gitignore for ReactNative lib developer

### DIFF
--- a/ReactNative.gitignore
+++ b/ReactNative.gitignore
@@ -1,0 +1,31 @@
+# gitignore template for React Native
+# website: https://facebook.github.io/react-native/
+
+# Node Folder
+node_modules
+
+# When to use Expo
+# website: https://expo.io/
+# Expo Manager temporary files
+*.expo
+*.expo-shared
+
+# When using the VSCODE Editor
+# website: https://code.visualstudio.com/
+*.vscode
+
+# When using Watchman
+# website: https://facebook.github.io/watchman/
+*.watchmanconfig
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Keystore Files
+*.keystore
+*.jks
+*.p12
+*.key
+
+# Apple Certificates
+*.mobileprovision


### PR DESCRIPTION
**Reasons for making this change:**

The React Native lib is one of the most widely used today for hybrid mobile application development and has a very active community.

**Links to documentation supporting these rule changes:**

[React Native 0.61.x](https://facebook.github.io/react-native/docs/getting-started)
[Expo SDK 36](https://docs.expo.io/versions/latest/)

- **Link to application or project’s homepage**: https://facebook.github.io/react-native/