### PR TITLE
ignore any git mergetool files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -232,6 +232,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 orleans.codegen.cs
+*.orig
 
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)


### PR DESCRIPTION
**Reasons for making this change:**

Prevent git mergetool files from being added to the git repo

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/questions/1251681/git-mergetool-generates-unwanted-orig-files

or 

https://git-scm.com/docs/git-mergetool
