### PR TITLE
add Reason.gitignore option

### DIFF
--- a/Reason.gitignore
+++ b/Reason.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+.merlin
+.bsb.lock
+npm-debug.log
+/lib/bs/
+/node_modules/

--- a/Reason.gitignore
+++ b/Reason.gitignore
@@ -1,6 +1,15 @@
+# other
 .DS_Store
+
+# node
+npm-debug.log
+/node_modules/
+
+# reason
 .merlin
 .bsb.lock
-npm-debug.log
 /lib/bs/
-/node_modules/
+
+# reason-native
+_esy/
+_build/


### PR DESCRIPTION
**Reasons for making this change:**

Adding ReasonML .gitignore option to Desktop new repository workflow. Currently there is no reasonml .gitignore option. Here are the options under languages that start with the letter R for the `.gitignore` menu. These are the current options for the letter `R`:

<img width="362" alt="Screenshot 2020-01-19 at 9 00 16 AM" src="https://user-images.githubusercontent.com/2370391/72682775-d0c47080-3a9e-11ea-802d-aa340210ba3a.png">

This would add a `.gitignore` option for a recognized github language.

This template is the `.gitignore` that comes from the ReasonML/Bucklescript react template which might serve as a base.

```
.DS_Store
.merlin
.bsb.lock
npm-debug.log
/lib/bs/
/node_modules/
```

If this is a new template:

 - **Link to application or project’s homepage**:https://reasonml.github.io
