### PR TITLE
ignore files generated by Metals, a vscode extension for Scala.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -351,3 +351,8 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Scala extensions
+.bloop/
+.metals/
+.scalafmt.conf

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -353,6 +353,6 @@ MigrationBackup/
 .ionide/
 
 # Scala extensions
-.bloop/
 .metals/
-.scalafmt.conf
+.bloop/
+project/metals.sbt


### PR DESCRIPTION
**Reasons for making this change:**

Metals, an extension for Scala, will create files.

**Links to documentation supporting these rule changes:**

<https://scalameta.org/metals/docs/editors/vscode.html#gitignore-projectmetalssbt-metals-and-bloop>

~~If this is a new template:~~

