### PR TITLE
Wordpress gitignore should ignore everything in root

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,5 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
**Reasons for making this change:**

Comment in file, mentions that everything in root directory should be ignored, but there is no line doing it