### PR TITLE
Add .dtproj.user

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -267,6 +267,7 @@ ServiceFabricBackup/
 *- [Bb]ackup.rdl
 *- [Bb]ackup ([0-9]).rdl
 *- [Bb]ackup ([0-9][0-9]).rdl
+*.dtproj.user
 
 # Microsoft Fakes
 FakesAssemblies/


### PR DESCRIPTION
Added *.dtproj.user for SSIS projects.

**Reasons for making this change:**

Individual user configuration and settings are not shared among multiple developers.

**Links to documentation supporting these rule changes:**

https://docs.microsoft.com/en-us/sql/integration-services/integration-services-ssis-projects-and-solutions?redirectedfrom=MSDN&view=sql-server-ver15

"The *.dtproj.user file contains information about your preferences for working with the project"