### PR TITLE
Update and fix WordPress gitignore

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,23 +1,29 @@
-# ignore everything in the root except the "wp-content" directory.
-!wp-content/
+# Wordpress - ignore core, configuration, examples, uploads and logs.
+# https://github.com/github/gitignore/blob/master/WordPress.gitignore
 
-# ignore everything in the "wp-content" directory, except:
-# "mu-plugins", "plugins", "themes" directory
-wp-content/*
-!wp-content/mu-plugins/
-!wp-content/plugins/
-!wp-content/themes/
+# Core and configuration
+/wp-admin/
+/wp-content/index.php
+/wp-content/plugins/index.php
+/wp-content/themes/index.php
+/wp-includes/
+/index.php
+/license.txt
+/readme.html
+/wp-*.php
+/xmlrpc.php
 
-# ignore these plugins
-wp-content/plugins/hello.php
+# Example themes
+/wp-content/themes/twenty*/
 
-# ignore specific themes
-wp-content/themes/twenty*/
+# Example plugin
+/wp-content/plugins/hello.php
 
-# ignore node dependency directories
-node_modules/
+# Uploads
+/wp-content/uploads/
 
-# ignore log files and databases
+# Log files
 *.log
-*.sql
-*.sqlite
+
+# htaccess
+/.htaccess

--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -7,6 +7,7 @@
 # you can delete this whole section/until Configuration.
 /wp-admin/
 /wp-content/index.php
+/wp-content/languages
 /wp-content/plugins/index.php
 /wp-content/themes/index.php
 /wp-includes/
@@ -33,3 +34,15 @@ wp-config.php
 
 # htaccess
 /.htaccess
+
+# All plugins
+#
+# Note: If you wish to whitelist plugins,
+# uncomment the next line
+#/wp-content/plugins
+
+# All themes
+#
+# Note: If you wish to whitelist themes,
+# uncomment the next line
+#/wp-content/themes

--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,7 +1,10 @@
 # Wordpress - ignore core, configuration, examples, uploads and logs.
 # https://github.com/github/gitignore/blob/master/WordPress.gitignore
 
-# Core and configuration
+# Core
+#
+# Note: if you want to stage/commit WP core files
+# you can delete this whole section/until Configuration.
 /wp-admin/
 /wp-content/index.php
 /wp-content/plugins/index.php
@@ -12,6 +15,9 @@
 /readme.html
 /wp-*.php
 /xmlrpc.php
+
+# Configuration
+wp-config.php
 
 # Example themes
 /wp-content/themes/twenty*/


### PR DESCRIPTION
(**Reasons for making this change:**)

### Background for this PR

#2972 seems to have broken the WordPress gitignore—using this file with a brand new install, allows to add pretty much all the install, because it's missing a catch-all rule, since it operates with excludes mostly. So WordPress gitignore wasn't seemingly working at all.

#3125 it's an update to add configuration file to gitignore, but it doesn't fix all the other underlying issues with this gitignore.

#3093 as noted by @NerdsvilleCEO [here](https://github.com/github/gitignore/pull/3093/files#r322507507) is missing a rule to allow for gitignore itself. (#3293, #3378, #3438 are duplicates.)

#3282, from which this PR is based, is IMHO the better attempt at fixing this gitignore, but I see two potential issues with it:

1. Ignores `*.sql` files, and I'm afraid we might be **over assuming** the ignores, as a typical WordPress install doesn't seem to generate `*.sql` files, and I think it might be more linked to a specific workflow that generates `*.sql` files (see [here](https://github.com/github/gitignore/pull/3093/files#r369312284) and [here](https://github.com/github/gitignore/pull/3282#discussion_r370250802)).

2. Employs a 'catch-all' approach for all root files with exclude rules, and I think that might not be the safest or best approach—it might conflict and break other gitignore files you mix with this one, and force users to **always** exclude other non-WP related paths that otherwise they might want to include in the repository. IMHO, a **declarative approach** of all the paths and files one needs to ignore is the best way to go.

### Proposal/discussion for a WordPress gitignore

This PR adds my proposal for a gitignore for WordPress alongside with a couple questions up for discussion.

But before those, I want to frame my approach.

**Objectives of this gitignore**

Since Git is mostly useful for tracking code, I feel that the uploads folder, usually full of images/binaries should be ignored.

One might have other folders with binaries on their project/workflows (caches, etc), but I consider these files to be starters/base files from which you can expand your own gitignores, so if there are more of these folders on `wp-content` you should maintain them on your own gitignore.

**Q1 — Commit WP Core or not?**

While for some this might be an obvious response, I'm still not convinced of either approach as a base, as I can see both being useful:

- **Committing core.** **Pros:** to have a code-ready deploy of one site and, help lock WP version for a specific site. **Cons:** Committing plugins and WP core code can make repo out-of-sync when one instance is upgraded through Admin, additional repo size.

- **Keeping core out.** **Pros:** smaller repo, WP updates don't need to be committed to have consistency. **Cons:** additional setup for dev workflow, deploys, etc. **Also,** if we keep WP core out shouldn't we also keep third-party plugins and/or parent-themes out of repo too? (Q3)

My proposal ignores WP core, but has a note for those that want to commit it, they can do so by deleting/commenting one section of the gitignore. But I'm still not convinced of which approach this gitignore should take. (Before #2972 the approach was committing core.)

**Q2 — Catch-all or declarative approach?**

Here, I think a **declarative approach** to be the best. Catch-all has a big risk of conflicting with other gitignore files of this repo if you mix several together, as I explained before/above.

**Q3 — Should we allow all themes and plugins, or ignore all and whitelist our own?**

The gist of this proposed gitignore and all the others mentioned before is to **allow all the themes and plugins by default**.

But this can lead to having 3rd party plugins and parent custom themes—that aren't our custom code and of similar nature of WP core code—being added and tracked. Shouldn't these also to be ignored if we go with having the WP core ignored? If so, wasn't better to ignore all themes and plugins, and have each one **whitelist** their own custom themes and plugins on their gitignore files (like [Sal Ferrarello one](https://salferrarello.com/wordpress-gitignore))?

This proposal **continues to allow all themes and plugins by default**, but adds lines one can uncomment if they want to follow an whitelist approach per above.

### Final words

I know we already have several open PRs for the WordPress gitignore, but since we don't have Issues enabled on this repo, I felt it was the best way for me to contribute to the discussion around this gitignore.