### PR TITLE
Add in global metals

### DIFF
--- a/Global/Metals.gitignore
+++ b/Global/Metals.gitignore
@@ -1,0 +1,5 @@
+ # Generated Metals (Scala Language Server) files
+ # Reference: https://scalameta.org/metals/
+.metals/
+.bloop/
+project/metals.sbt


### PR DESCRIPTION
**Reasons for making this change:**

This is useful for Scala developers that are using Metals as a language server with various editors. 

**Links to documentation supporting these rule changes:**

You can on various places of our website that we recommend the following to be ignore. I've linked one of those places [here](https://scalameta.org/metals/docs/editors/vscode.html#gitignore-projectmetalssbt-metals-and-bloop).

If this is a new template:

[Homepage of Metals](https://scalameta.org/metals/)

https://github.com/scalameta/metals/issues/1336
