### PR TITLE
Ignore .pytype/ directory in Python .gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pytype static type analyzer
+.pytype/


### PR DESCRIPTION
**Reasons for making this change:**

pytype is a static type analyzer for Python code; it generates files of inferred type information, located by default in .pytype/pyi.

**Links to documentation supporting these rule changes:**

https://github.com/google/pytype#quickstart
