### PR TITLE
Add Umbraco V8 packages folder location

### DIFF
--- a/Umbraco.gitignore
+++ b/Umbraco.gitignore
@@ -18,6 +18,7 @@
 # Make sure to include details from VisualStudio.gitignore BEFORE this
 !**/App_Data/[Pp]ackages/*
 !**/[Uu]mbraco/[Dd]eveloper/[Pp]ackages/*
+!**/[Uu]mbraco/[Vv]iews/[Pp]ackages/*
 
 # ImageProcessor DiskCache
 **/App_Data/cache/


### PR DESCRIPTION
In Umbraco v8 we have a new packages folder located under Umbraco/views/packages/...

This gets ignored by the current version. Adding this new line prevents this and includes all files and subfolders under this new location.
