### PR TITLE
Ignore .idea/ jetbrains rider cache folder

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -25,6 +25,9 @@
 # Visual Studio cache directory
 .vs/
 
+# JetBrains Rider cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 
@@ -60,4 +63,3 @@ sysinfo.txt
 
 # Crashlytics generated file
 crashlytics-build.properties
-


### PR DESCRIPTION
**Reasons for making this change:**
The JetBrains Rider IDE creates a cache folder named as `.idea`, it should be ignored.