### PR TITLE
Added ignore for blob crash files

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -10,3 +10,4 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+*.blob


### PR DESCRIPTION
**Reasons for making this change:**

I'm sure nobody wants crash reports in their repos :ok_hand: 
