### PR TITLE
[Global/Eclipse] Make .project opt-in

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -54,3 +54,7 @@ local.properties
 .cache-main
 .scala_dependencies
 .worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project


### PR DESCRIPTION
The project description file.

**Reasons for making this change:**

The project description file may contain build or dependency configurations, but not always. Default to include the .project file in the repository and let the user decide to ignore. Just by having the quick entry in the Eclipse.gitignore file would avoid explanations or other Pull Request to add it. See #3283, #3076, #3062.
May also apply to .cproject, .settings, .classpath.

**Links to documentation supporting these rule changes:**

#2969 - discussion with @jskelin (stale Pull Request).

