### PR TITLE
Add Win32/ to Visual Studio gitginore list

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -23,6 +23,7 @@ mono_crash.*
 [Rr]eleases/
 x64/
 x86/
+[Ww][Ii][Nn]32/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/


### PR DESCRIPTION
**Reasons for making this change:**

Visual Studio .Net used Win32/ as one of the default platform directories for C and C++ projects. Later, when 64-bit support was added to the toolchain (circa 2005 or 2008), x64/ was used. Use of x86/ is relatively new.

**Links to documentation supporting these rule changes:**

Win32/ is one of the oldest directories used by Visual Studio. It has been used since at least the early 2000's, and predates both x64/ and x86/. https://docs.microsoft.com/en-us/cpp/build/reference/vcpp-directories-property-page?view=vs-2019 .
