### PR TITLE
Add `cover/` to Python.gitignore.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+cover/
 
 # Translations
 *.mo


### PR DESCRIPTION
**Reasons for making this change:**

The default coverage report directory for nosetests is `cover/`.

**Links to documentation supporting these rule changes:**

Reference: https://het.as.utexas.edu/HET/Software/Nose/plugins/cover.html#cmdoption--cover-html-dir

The source code implementation is also listed here for easy reference.
```
        parser.add_option('--cover-html-dir', action='store',
                          default=env.get('NOSE_COVER_HTML_DIR', 'cover'),
                          dest='cover_html_dir',
                          metavar='DIR',
                          help='Produce HTML coverage information in dir')
```

If this is a new template:

 - **Link to application or project’s homepage**:  N/A
