### PR TITLE
Add Unity's Addressables and Android's temp files.

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -62,8 +62,9 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
-# Addressables
+# Packed Addressables
 /[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/*/*.bin*
-/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Aa]sset[Gg]roups/[Ss]chemas/*
-/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Aa]sset[Gg]roups[Tt]emplates/*
-/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Ww]indows/*
+
+# Temporary auto-generated Android Assets
+/[Aa]ssets/[Ss]treamingAssets/aa.meta
+/[Aa]ssets/[Ss]treamingAssets/aa/*

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -62,3 +62,8 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+# Addressables
+/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/*/*.bin*
+/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Aa]sset[Gg]roups/[Ss]chemas/*
+/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Aa]sset[Gg]roups[Tt]emplates/*
+/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Ww]indows/*


### PR DESCRIPTION
**Reasons for making this change:**

Current Unity.gitignore does not compenstate for Unity's new Addressables package and the auto-generated files by an Android platform.

**Links to documentation supporting these rule changes:**

Trail and error.
