### PR TITLE
Changes the name of Perl 6 to Raku

### DIFF
--- a/Raku.gitignore
+++ b/Raku.gitignore
@@ -1,4 +1,4 @@
-# Gitignore for Perl 6 (http://www.perl6.org)
+# Gitignore for Raku (https://raku.org)
 # As part of https://github.com/github/gitignore
 
 # precompiled files


### PR DESCRIPTION
Since October 2019, Raku is the name of the language formerly known as
Perl 6. This reflects the change. It's the same language, so changes
are mostly cosmetic.

**Reasons for making this change:**

Suggested by #2153, after name was changed

**Links to documentation supporting these rule changes:**

I guess [this article in Slashdot will do](https://developers.slashdot.org/story/19/10/12/2134246/larry-wall-approves-re-naming-perl-6-to-raku). The whole process was carried out [here](https://github.com/Raku/problem-solving/pull/89)

If this is a new template (**it's kinda new, new name, but same language**):

 - **Link to application or project’s homepage**: https://raku.org
