### PR TITLE
Add snowpack dependency directory

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -41,6 +41,9 @@ build/Release
 node_modules/
 jspm_packages/
 
+# Snowpack dependency directory (https://snowpack.dev/)
+web_modules/
+
 # TypeScript v1 declaration files
 typings/
 


### PR DESCRIPTION
**Reasons for making this change:**

Snowpack is a must-have tool that allows not to use webpack for development.

**Links to documentation supporting these rule changes:**

Snowpack copies modules from `node_modules` directory and puts them into `web_modules`, so they could be imported by a browser. In that sense, it's like bower dependencies. They are autogenerated and should not be tracked by git.

If this is a new template:

 - **Link to application or project’s homepage**: https://www.snowpack.dev/#basic-usage
