### PR TITLE
Remote typings ignore from node gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -44,9 +44,6 @@ jspm_packages/
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/
 
-# TypeScript v1 declaration files
-typings/
-
 # TypeScript cache
 *.tsbuildinfo
 


### PR DESCRIPTION
Similar to #2608

**Reasons for making this change:**

It's the defacto TypeScript way now for adding typings locally (besides installed 'node_modules/@types').
Further 'typings' is used by TypeScript compiler (tsc) _without_ even specifying any additional typeroots.

**Links to documentation supporting these rule changes:**

TSC docs on `typeroots` show it as the suggested: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types
