### PR TITLE
Changed TeX to not ignore tikz files by default.

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -135,8 +135,8 @@ acs-*.bib
 
 # knitr
 *-concordance.tex
-# TODO Comment the next line if you want to keep your tikz graphics files
-*.tikz
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
 *-tikzDictionary
 
 # listings


### PR DESCRIPTION
**Reasons for making this change:**
Ignoring tikz files for TeX files was introduced for supporting knitr, see #1286.

However:
- The use case of both Tikz and TeX is much wider than knitr
- Tikz files are often written by hand rather than generated. As such, it makes more sense to treat them (by default) as a source file than an artifact.
- Ignoring such a hand-written tikz file in your .gitignore has much bigger consequences (= the file is gone when the original repo is destroyed) than accidentally committing a generated one (git status will explicitly list it as going to be committed, which gives the user an additional chance to avoid this).

Therefore, it makes more sense to disable ignoring Tikz files by default, allowing users to enable it when using knitr.

As a happy user of both Tikz and TeX (but not using R), this has bitten me already multiple times, resulting in having to recreate tikz images.
