### PR TITLE
Unity: Added Mac OS .DS_Store files (folder view cache)

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -62,3 +62,5 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+# MacOS folder attributes cache
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

Excluded file contains folder view for the Finder (folders positioning, sizes, grid, etc.) what is obviously personal settings.

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store (sorry for the wiki, but it's actually legit)
