### PR TITLE
[Qt] Extend Qt.gitignore with qmlcache qrc files

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -50,3 +50,5 @@ compile_commands.json
 
 # QtCreator local machine specific files for imported projects
 *creator.user*
+
+*_qmlcache.qrc


### PR DESCRIPTION
**Reasons for making this change:**

Projects using QML files generating a temporary qrc file if a qrc file present in the project.

**Links to documentation supporting these rule changes:**

![image](https://user-images.githubusercontent.com/1609182/75451046-22023280-5970-11ea-91c1-24dfa3c081d2.png)



