### PR TITLE
Include Rider as a supported IDE

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,4 +1,4 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff


### PR DESCRIPTION
As far as I can tell this `.gitignore` also applies to Rider. Looking at the somewhat official `.gitignore` for Rider [here](https://github.com/JetBrains/resharper-rider-samples/blob/master/.gitignore), it seems compatible.

**Reasons for making this change:**

There should be an official and definitive `.gitignore` reference that applies to Rider too.

**Links to documentation supporting these rule changes:**

https://github.com/JetBrains/resharper-rider-samples/blob/master/.gitignore