### PR TITLE
ReactJS

### DIFF
--- a/ReactJS.gitignore
+++ b/ReactJS.gitignore
@@ -1,40 +1,35 @@
-# Logs
-logs
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-/.changelog
-
-# Runtime
-*.seed
-pids
-*.pid*
-
-# Testing (jscover, istanbul etc.)
-lib-cov
-coverage
-.nyc_output
-
-# Dependency directories (node, bower and etc.)
+# Dependency directories (node, bower, jspm and etc.)
 node_modules/
 bower_components/
 jspm_packages/
+
+# Package managers (yarn, npm and etc.)
+package-lock.json
+.module-cache
+.yarn-integrity
+yarn.lock
+yarn-debug.log*
+yarn-error.log*
+.npm
+npm-debug.log*
+
+# Testing (jscoverage, jscover, istanbul etc.)
+lib-cov
+coverage
+.nyc_output
 
 # Binaries and distribution directories
 dist/
 lib/
 bin/
 
+# Runtime
+*.seed
+pids
+*.pid*
+
 # Production
 build/
-
-# Package managers (yarn, npm and etc.)
-package-lock.json
-.yarn-integrity
-yarn.lock
-.npm
-.module-cache
 
 # Environment variables
 .env
@@ -42,6 +37,24 @@ yarn.lock
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Logs
+logs
+*.log
+/.changelog
+
+# Backups
+*.backup.*
+*.back.*
+
+# ESLint
+.eslintcache
+
+# Typescript
+typings/
+
+# Grunt
+.grunt
 
 # Editors
 .DS_STORE
@@ -54,29 +67,10 @@ yarn.lock
 .idea/
 .vscode/
 
-# Grunt
-.grunt
-
-# ESLint
-.eslintcache
-
-# npm-pack
+# Misc
 *.tgz
-
-# REPL
-.node_repl_history
-
-# Typescript
-typings/
-
-# Backups
-*.backup.*
-*.back.*
-
-# node-waf
 .lock-wscript
-
-# Others
+.node_repl_history
 psd
 thumb
 sketch

--- a/ReactJS.gitignore
+++ b/ReactJS.gitignore
@@ -1,0 +1,82 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+/.changelog
+
+# Runtime
+*.seed
+pids
+*.pid*
+
+# Testing (jscover, istanbul etc.)
+lib-cov
+coverage
+.nyc_output
+
+# Dependency directories (node, bower and etc.)
+node_modules/
+bower_components/
+jspm_packages/
+
+# Binaries and distribution directories
+dist/
+lib/
+bin/
+
+# Production
+build/
+
+# Package managers (yarn, npm and etc.)
+package-lock.json
+.yarn-integrity
+yarn.lock
+.npm
+.module-cache
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Editors
+.DS_STORE
+*.sublime*
+*.sublime-project
+*.sublime-workspace
+*.swp
+*.swo
+*.iml
+.idea/
+.vscode/
+
+# Grunt
+.grunt
+
+# ESLint
+.eslintcache
+
+# npm-pack
+*.tgz
+
+# REPL
+.node_repl_history
+
+# Typescript
+typings/
+
+# Backups
+*.backup.*
+*.back.*
+
+# node-waf
+.lock-wscript
+
+# Others
+psd
+thumb
+sketch


### PR DESCRIPTION
**Reasons for making this change:**

Recently I need common gitignores to create and publish my own ReactJS projects. So I tried to find and collect some of them which can be usable for everyone and it can be updated during the time.

**Links to documentation supporting these rule changes:**

https://www.npmjs.com/
https://yarnpkg.com/
http://nodejs.org/api/addons.html
https://nodejs.org/api/modules.html
https://jspm.org/docs/guide
https://bower.io/docs/api/
https://eslint.org/
https://www.typescriptlang.org/
http://gruntjs.com/creating-plugins#storing-task-files
https://www.npmjs.com/package/jscoverage
https://tntim96.github.io/JSCover/
https://istanbul.js.org/
https://www.npmjs.com/package/node-waf

If this is a new template:

 - **Link to application or project’s homepage**: At the moment, there is no public or published application which I can mention it; but in the future it can be turned into a new template.
