### PR TITLE
[VisualStudio] Add rule for ScaffoldingReadMe.txt

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -60,6 +60,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+**/ScaffoldingReadMe.txt
 
 # StyleCop
 StyleCopReport.xml

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -60,6 +60,8 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+
+# ASP.NET Scaffolding
 ScaffoldingReadMe.txt
 
 # StyleCop

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -60,7 +60,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/ScaffoldingReadMe.txt
+ScaffoldingReadMe.txt
 
 # StyleCop
 StyleCopReport.xml


### PR DESCRIPTION
Add rule to ignore the auto-generated ScaffoldingReadMe.txt discussed here: 
https://docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
