### PR TITLE
Update Drupal.gitignore

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -23,25 +23,25 @@
 
 # Ignore drupal core (if not versioning drupal sources)
 /core
+/vendor
 /modules/README.txt
 /profiles/README.txt
+/themes/README.txt
 /sites/README.txt
 /sites/example.sites.php
 /sites/example.settings.local.php
 /sites/development.services.yml
-/themes/README.txt
-/vendor
 /.csslintrc
 /.editorconfig
 /.eslintignore
 /.eslintrc.json
 /.gitattributes
+/.ht.router.php
 /.htaccess
 /autoload.php
-/composer.json
-/composer.lock
 /example.gitignore
 /index.php
+/INSTALL.txt
 /LICENSE.txt
 /README.txt
 /robots.txt


### PR DESCRIPTION
Removed: 
/composer.json
/composer.lock

Added:
/.ht.router.php
/INSTALL.txt

Other changes only row position change.

**Reasons for making this change:**

- The "INSTALL.txt" and ".ht.router.php" files are generated by the composer so there is no need to track them.

- Composer was added by default in Drupal 8.8.0 and later. "composer.json" and "composer.lock" files should be removed from gitignore to be able to track packages.

**Links to documentation supporting these rule changes:**

- https://git.drupalcode.org/project/drupal/-/tree/8.8.x/ 
https://git.drupalcode.org/project/drupal/-/tree/8.8.x/core/assets/scaffold/files 
https://github.com/drupal/core-composer-scaffold#examples

- https://www.drupal.org/docs/8/install/add-composer-to-an-existing-site#s-simplified-in-drupal-880 
https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
