### PR TITLE
Ignore Cython debug symbols

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # pytype static type analyzer
 .pytype/
+
+# Cython debug symbols
+cython_debug/


### PR DESCRIPTION
Cython extension modules built with `gdb_debug=True` spit out debug symbols in the `cython_debug` directory at the top level of the project. The files in this directory contain hardcoded paths and are not shareable/meaningful across environments, so I think it makes sense to include them in a default Python `.gitignore`.

https://cython.readthedocs.io/en/latest/src/userguide/debugging.html