### PR TITLE
update parcel cache

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -74,6 +74,7 @@ web_modules/
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
+.parcel-cache
 
 # Next.js build output
 .next


### PR DESCRIPTION
**Reasons for making this change:**

In parcel v2 the cache directory is named `.parcel-cache`.

**Links to documentation supporting these rule changes:**

https://github.com/parcel-bundler/parcel/blob/v2/packages/core/core/src/resolveOptions.js#L15
