### PR TITLE
Add /public/uploads for file upload gem Shrine

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -66,3 +66,4 @@ yarn-debug.log*
 # Ignore uploaded files in development
 /storage/*
 !/storage/.keep
+/public/uploads


### PR DESCRIPTION
**Reasons for making this change:**

When using a file upload gem called Shrine, its file system mode put images under `public/uploads`.

> This storage will upload all files to "public/uploads",
> https://github.com/shrinerb/shrine/blob/053bcf297e092e9695731fb9b67a86780e898203/doc/storage/file_system.md

**Links to documentation supporting these rule changes:**

https://github.com/shrinerb/shrine/blob/053bcf297e092e9695731fb9b67a86780e898203/doc/storage/file_system.md

If this is a new template:

https://github.com/shrinerb/shrine

cc @janko
