### PR TITLE
# tensorflow saved model extension

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 
 # pytype static type analyzer
 .pytype/
+# tensorflow saved model extensions
+.h5


### PR DESCRIPTION
**Reasons for making this change:**

I have been learning more on tensor flow and saving the model.
i realized the models are too large to save  in our team repository so i decided how on adding the extension to avoid pushing it
**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
