### PR TITLE
Update Autotools.gitignore.

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -7,6 +7,7 @@ Makefile.in
 /test-driver
 /ylwrap
 .deps/
+.dirstamp
 
 # http://www.gnu.org/software/autoconf
 


### PR DESCRIPTION
Ignore .dirstamp files from automake used for non-existing directory dependencies.

**Reasons for making this change:**

Using automake with subdir-objects the existence of the subdirs is enforced by a dependence to empty .dirstamp files in those directories. The .dirstamp files are of no interest for packaging or versioning and can therefore be ignored.

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/a/9611660/10371948

