### PR TITLE
Changes to PyBuilder 0.12+

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -73,6 +73,7 @@ instance/
 docs/_build/
 
 # PyBuilder
+.pybuilder/
 target/
 
 # Jupyter Notebook


### PR DESCRIPTION
**Reasons for making this change:**

PyB 0.12 uses `$project_root/.pybuilder/` for internal venvs.

**Links to documentation supporting these rule changes:**

Release 0.12 documentation is still in progress.
https://pybuilder.io/articles/news/version-0.12-release.html
https://pybuilder.io/release-notes/v0.12.x.html

If this is a new template:

 - **Link to application or project’s homepage**: https://pybuilder.io