### PR TITLE
[Global/VisualStudioCode] Directories does not require expansion with *

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,4 +1,4 @@
-.vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json


### PR DESCRIPTION
**Reasons for making this change:**

According Git documentation [1], asterisks (`*`) on folders are not necessary. Actually it causes the opposite, not matching the folder but only sub-folders.

**Links to documentation supporting these rule changes:**

[1]  -https://git-scm.com/docs/gitignore