### PR TITLE
Create Cordova.gitignore

### DIFF
--- a/Cordova.gitignore
+++ b/Cordova.gitignore
@@ -11,5 +11,8 @@ platforms
 # Plugins
 plugins
 
+# Automatically generated files used for updates and builds
+package-lock.json
+
 # OS X
 .DS_Store

--- a/Cordova.gitignore
+++ b/Cordova.gitignore
@@ -1,0 +1,15 @@
+# Cordova gitignore
+
+# The required node_modules, plugins and platforms are saved in package.json and will be installed when running cordova prepare or cordova build. So these directories are not needed to be pushed to git.
+
+# Git is not able handle node_modules because of the many changes.
+node_modules
+
+# Platforms takes up quite some space and includes builds as well
+platforms
+
+# Plugins
+plugins
+
+# OS X
+.DS_Store


### PR DESCRIPTION
Gitignore for the Cordova framework.

**Reasons for making this change:**

There was no gitignore for Cordova yet.

**Links to documentation supporting these rule changes:**

[Cordova Reference](https://cordova.apache.org/docs/en/latest/reference/cordova-cli/)

If this is a new template:

 - **Link to application or project’s homepage**: [https://cordova.apache.org/](https://cordova.apache.org)
