### PR TITLE
Rename Jetbrains Ignore-File and Add Some Symlinks, to Improve Visibility

### DIFF
--- a/Global/AndroidStudio.gitignore
+++ b/Global/AndroidStudio.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/AppCode.gitignore
+++ b/Global/AppCode.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/CLion.gitignore
+++ b/Global/CLion.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/DataGrip.gitignore
+++ b/Global/DataGrip.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/GoLand.gitignore
+++ b/Global/GoLand.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/IntelliJIDEA.gitignore
+++ b/Global/IntelliJIDEA.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/IntelliJPlatform.gitignore
+++ b/Global/IntelliJPlatform.gitignore
@@ -1,4 +1,4 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Covers all JetBrains IDEs, based on the IntelliJ Platform: Android Studio, AppCode, CLion, DataGrip, GoLand, IntelliJ IDEA, PhpStorm, Rider, PyCharm, RubyMine and WebStorm 
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff

--- a/Global/PhpStorm.gitignore
+++ b/Global/PhpStorm.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/PyCharm.gitignore
+++ b/Global/PyCharm.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/Rider.gitignore
+++ b/Global/Rider.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/RubyMine.gitignore
+++ b/Global/RubyMine.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore

--- a/Global/WebStorm.gitignore
+++ b/Global/WebStorm.gitignore
@@ -1,0 +1,1 @@
+IntelliJPlatform.gitignore


### PR DESCRIPTION
**Reasons for making this change:**

The `Jetbrains.gitignore`, actually only covers JetBrains products, that are based on the IntelliJ Platform.
JetBrains also offers other products, that are not base on it (e. g. Resharper) and
therefore would need a totally different gitignore file.

So it seems to be more appropriate to name it according to the platform instead of the company.

Also the names "JetBrains" or "IntelliJ" might not be obvious to somebody looking for "GoLang" or "PhpStorm". I think this is one of the factors, why Pull Requests are created again an again, seeking to add IntelliJ ignore rules to all kinds of other languages or even new ignore files. 

Adding some symlinks will hopefully solve the problem and will make it easier for people to find what they are looking for.