### PR TITLE
Update Dreamweaver.gitignore

### DIFF
--- a/Global/Dreamweaver.gitignore
+++ b/Global/Dreamweaver.gitignore
@@ -5,3 +5,6 @@ configs/
 dwsync.xml
 dw_php_codehinting.config
 *.mno
+
+# Mac OS X
+.DS_Store


### PR DESCRIPTION
added Mac OS X files

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
