### PR TITLE
Visual Studio. Ignore ".orig" backup of merge conflict files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -355,3 +355,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Backup of merge conflict files
+*.orig


### PR DESCRIPTION
**Reasons for making this change:**

As mentioned in issue #546, when using Visual Studio with Fork (https://fork.dev) and kdiff3 (http://kdiff3.sourceforge.net), this files remain in version control.