### PR TITLE
R.gitignore: add docs/ directory

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -37,3 +37,6 @@ vignettes/*.pdf
 
 # R Environment Variables
 .Renviron
+
+# pkgdown site
+docs/


### PR DESCRIPTION
**Reasons for making this change:**

[pkgdown](https://github.com/r-lib/pkgdown) has become a quasi standard for R packages in terms of package documentation.
When building the site locally, pkgdown writes a lot of files to docs/.
The canonical process is to build the site during a CI run where docs/ is force added to the index and then deployed.

[pkgdown](https://github.com/r-lib/pkgdown) itself has listed docs/ in their [.gitignore](https://github.com/r-lib/pkgdown/blob/f016582515c195022dcc918c31c76daa3ce01e33/.gitignore).

In theory users could commit docs/ to master manually and let their site being served via "GitHub pages / master branch". However, this approach is rarely used since it involves manual action from time to time.

Not having docs/ in .gitignore is a pain since it results in > 30 untracked files in the index.

**Links to documentation supporting these rule changes:**

- [pkgdown](https://github.com/r-lib/pkgdown)
- https://pkgdown.r-lib.org/reference/deploy_site_github.html
