### PR TITLE
Added file extensions when glossaries is loaded with 'symbols' option

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -111,6 +111,9 @@ acs-*.bib
 *.glsdefs
 *.lzo
 *.lzs
+*.slg
+*.slo
+*.sls
 
 # uncomment this for glossaries-extra (will ignore makeindex's style files!)
 # *.ist

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -279,3 +279,7 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+
+# Sublime Text
+# *.sublime-project
+*.sublime-workspace

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -116,7 +116,7 @@ acs-*.bib
 *.sls
 
 # uncomment this for glossaries-extra (will ignore makeindex's style files!)
-# *.ist
+*.ist
 
 # gnuplottex
 *-gnuplottex-*


### PR DESCRIPTION
**Reasons for making this change:**

files created when the `glossaries` package is loaded with the `symbols` option (see section 2.6 of the manual)

_TODO_

**Links to documentation supporting these rule changes:**

> **2.6 Other Options**
> Other available options that don’t fit any of the above categories are:
> `symbols` This option defines a new glossary type with the label symbols via
> ```\newglossary[slg]{symbols}{sls}{slo}{\glssymbolsgroupname}```

_TODO_