### PR TITLE
added file extensions when glossaries is loaded with "symbols" option

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -111,6 +111,9 @@ acs-*.bib
 *.glsdefs
 *.lzo
 *.lzs
+*.slg
+*.slo
+*.sls
 
 # uncomment this for glossaries-extra (will ignore makeindex's style files!)
 # *.ist


### PR DESCRIPTION
**Reasons for making this change:**

Files created when the `glossaries` package is loaded with the `symbols` option (see section 2.6 of the manual)

_TODO_

**Links to documentation supporting these rule changes:**

From the [`glossaries`](http://ctan.mirror.garr.it/mirrors/CTAN/macros/latex/contrib/glossaries/glossaries-user.pdf) manual:

> **2.6 Other Options**
> [...]
> Other available options that don’t fit any of the above categories are:
> `symbols` This option defines a new glossary type with the label symbols via
> ```\newglossary[slg]{symbols}{sls}{slo}{\glssymbolsgroupname}```

_TODO_