### PR TITLE
Ignore AWS Serverless Application Model build folder

### DIFF
--- a/community/AWS/SAM.gitignore
+++ b/community/AWS/SAM.gitignore
@@ -1,0 +1,5 @@
+# gitignore template for AWS Serverless Application Model project
+# website: https://docs.aws.amazon.com/serverless-application-model
+
+# Ignore build folder
+.aws-sam/


### PR DESCRIPTION
AWS Serverless Application Model (SAM) stores its helper files in the dedicated folder `.aws-sam`. This folder is created in the project's root first time you execute `sam build` command.
As the result, this folder holds project's binaries (similarly to Maven's `target` directory).
This folder must be ignored, so that nobody commits binaries to git.

**Links to documentation supporting these rule changes:**

https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-build.html

> Built artifacts will be written to .aws-sam/build folder

**Project's home page (as it's a new file):**
https://docs.aws.amazon.com/serverless-application-model/