### PR TITLE
[Terraform] Ignore Terraform CLI configuration files

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -27,3 +27,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc


### PR DESCRIPTION
**Reasons for making this change:**

The Terraform CLI configuration files (`.terraformrc` or `terraform.rc`) contains sensitive credentials data that should be ignored.

**Links to documentation supporting these rule changes:**

https://www.terraform.io/docs/commands/cli-config.html
