### PR TITLE
Adding a gitignore for the Crystal language

### DIFF
--- a/Crystal.gitignore
+++ b/Crystal.gitignore
@@ -1,0 +1,5 @@
+/docs/
+/lib/
+/bin/
+/.shards/
+*.dwarf


### PR DESCRIPTION
**Reasons for making this change:**

There is no current gitignore option for the [Crystal language](https://crystal-lang.org). 

**Links to documentation supporting these rule changes:**

The [`crystal init`](https://crystal-lang.org/reference/using_the_compiler/#crystal-init) command generates a `.gitignore` file, among others. Out of the box, it looks like the file I've added in this PR. I've copied that `.gitignore` source into here.

The source code for how the `crystal init` file is created is [here](https://github.com/crystal-lang/crystal/blob/a691846bb4b989962ba349a57535079652731a59/src/compiler/crystal/tools/init/template/gitignore.ecr).

If this is a new template:

 - **Link to application or project’s homepage**:  https://crystal-lang.org
