### PR TITLE
Remove pip-wheel-metadata/ from Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -20,7 +20,6 @@ parts/
 sdist/
 var/
 wheels/
-pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
 .installed.cfg


### PR DESCRIPTION
**Reasons for making this change:**

pip generated this folder for a few versions, as part of it's initial
implementation of PEP 517.

pip has not generated this folder for a few versions now, so it should
be OK to remove this from the standard gitignore file.

**Links to documentation supporting these rule changes:**

https://pip.pypa.io/en/latest/news/ I guess?

<sub>If y'all deem this to be "too early" for some reason, I'd appreciate it if you suggest a timeline and keep this PR open till then.</sub>