### PR TITLE
Add generated timing files to Coq.gitignore

### DIFF
--- a/Coq.gitignore
+++ b/Coq.gitignore
@@ -31,3 +31,13 @@ lia.cache
 nia.cache
 nlia.cache
 nra.cache
+
+# generated timing files
+*.timing.diff
+*.v.after-timing
+*.v.before-timing
+*.v.timing
+time-of-build-after.log
+time-of-build-before.log
+time-of-build-both.log
+time-of-build-pretty.log


### PR DESCRIPTION
**Reasons for making this change:**

Ignoring more autogenerated files

**Links to documentation supporting these rule changes:**

These generated files were added in https://github.com/coq/coq/pull/745
