### PR TITLE
Ignore Gradle subproject build dir

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,6 +1,6 @@
 .gradle
 **/build/
-!src/**build/
+!src/**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,5 +1,6 @@
 .gradle
-/build/
+**/build/
+!src/**build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
**Reasons for making this change:**

Currently subprojects' `build` folders are not ignored. This change incorporates features from and resolves both #2219 and #2035.

The rule first ignores all directories named `build`, then unignores those directories that are contained anywhere under a `src` directory.

**Links to documentation supporting these rule changes:**

Gradle docs on subprojects: https://docs.gradle.org/current/userguide/multi_project_builds.html
