### PR TITLE
Ignore http client private environment files

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -66,6 +66,8 @@ fabric.properties
 
 # Editor-based Rest Client
 .idea/httpRequests
+http-client.private.env.json
+rest-client.private.env.json
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser


### PR DESCRIPTION
**Reasons for making this change:**

These files contain [sensitive data](https://www.jetbrains.com/help/webstorm/http-client-in-product-code-editor.html#example-working-with-environment-files) and shouldn't be added to VCS.

[gitignore.io](https://gitignore.io) already [does it right](https://github.com/toptal/gitignore/blob/master/templates/JetBrains.gitignore).

**Links to documentation supporting these rule changes:**

https://www.jetbrains.com/help/webstorm/http-client-in-product-code-editor.html#example-working-with-environment-files
https://gitignore.io
https://github.com/toptal/gitignore/blob/master/templates/JetBrains.gitignore