### PR TITLE
Added mono crash logs and dumps to ignored files

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -10,3 +10,5 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+mono_crash.*.json
+*.blob


### PR DESCRIPTION
**Reasons for making this change:**
Removing otherwise huge files related to the local machine only from tracking.
