### PR TITLE
Unigine .gitignore

### DIFF
--- a/Unigine.gitignore
+++ b/Unigine.gitignore
@@ -1,0 +1,21 @@
+# IDEs
+.idea
+_ReSharper.Caches
+.vs
+.vscode
+
+# Engine
+bin
+.thumbnails
+
+data/.thumbnails
+data/.cache_textures
+data/.runtimes
+
+obj
+junk
+launch_debug.bat
+launch_editor.bat
+launch_release.bat
+*.obj
+*.tlog

--- a/Unigine.gitignore
+++ b/Unigine.gitignore
@@ -7,11 +7,6 @@ _ReSharper.Caches
 # Engine
 bin
 .thumbnails
-
-data/.thumbnails
-data/.cache_textures
-data/.runtimes
-
 obj
 junk
 launch_debug.bat


### PR DESCRIPTION
**Reasons for making this change:**

Now engine is community available

**Links to documentation supporting these rule changes:**

https://developer.unigine.com/en/docs/2.11/editor2/assets_workflow/version_control?rlang=cpp

If this is a new template:

 - **Link to application or project’s homepage**: https://unigine.com/
