### PR TITLE
Ignore everything in root directory for WordPress.gitignore

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,3 +1,4 @@
+/*
 # ignore everything in the root except the "wp-content" directory.
 !wp-content/
 

--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,5 +1,5 @@
-/*
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
**Reasons for making this change:**
I think that first line was missing in the .gitignore, am I wrong?


**Links to documentation supporting these rule changes:**

This first line in the current repository points to this ignoring everything in the root directory:
https://github.com/github/gitignore/blob/master/WordPress.gitignore#L1

Thanks
