### PR TITLE
Idea creates .iml files on multi module projects

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -69,3 +69,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Module level configuration
+*.iml


### PR DESCRIPTION
I believe *.iml are also part of the Intellij configuration strategies, and should be ignored when present in a module directory.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
