### PR TITLE
Update ModelSim.gitignore

### DIFF
--- a/Global/ModelSim.gitignore
+++ b/Global/ModelSim.gitignore
@@ -11,6 +11,7 @@
 *.jpg
 *.html
 *.bsf
+*.out
 
 # ignore simulation output of ModelSim
 wlf*


### PR DESCRIPTION
**Reasons for making this change:**

Gets generated by ModelSim PE Student Edition whenever adding and running a .vhd or a .v file 

**Links to documentation supporting these rule changes:**

Couldn't find any...
