### PR TITLE
Add .vscode folder for Visual Studio Code users

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -25,6 +25,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
**Reasons for making this change:**
Visual Studio Code is a popular IDE for Mac users who use Unity.
Unity's Package Manager includes a package to deal with the integration, which pushes more users to use it every day.

**Links to documentation supporting these rule changes:**
Package: https://docs.unity3d.com/Packages/com.unity.ide.vscode@1.0/manual/index.html
https://code.visualstudio.com/
