### PR TITLE
Update Drupal.gitignore with upstream conventions: prefix /web for dr…

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -1,49 +1,62 @@
 # gitignore template for Drupal 8 projects
 #
 # earlier versions of Drupal are tracked in `community/PHP/`
+#
+# follows official upstream conventions:
+# https://www.drupal.org/docs/develop/using-composer
 
 # Ignore configuration files that may contain sensitive information
-/sites/*/*settings*.php
-/sites/*/*services*.yml
+/web/sites/*/*settings*.php
+/web/sites/*/*services*.yml
 
 # Ignore paths that may contain user-generated content
-/sites/*/files
-/sites/*/public
-/sites/*/private
-/sites/*/files-public
-/sites/*/files-private
+/web/sites/*/files
+/web/sites/*/public
+/web/sites/*/private
+/web/sites/*/files-public
+/web/sites/*/files-private
 
 # Ignore paths that may contain temporary files
-/sites/*/translations
-/sites/*/tmp
-/sites/*/cache
-
-# Ignore testing related files
-/sites/simpletest
+/web/sites/*/translations
+/web/sites/*/tmp
+/web/sites/*/cache
 
 # Ignore drupal core (if not versioning drupal sources)
-/core
+/web/vendor
+/web/core
+/web/modules/README.txt
+/web/profiles/README.txt
+/web/sites/development.services.yml
+/web/sites/example.settings.local.php
+/web/sites/example.sites.php
+/web/sites/README.txt
+/web/themes/README.txt
+/web/.csslintrc
+/web/.editorconfig
+/web/.eslintignore
+/web/.eslintrc.json
+/web/.gitattributes
+/web/.htaccess
+/web/.ht.router.php
+/web/autoload.php
+/web/composer.json
+/web/composer.lock
+/web/example.gitignore
+/web/index.php
+/web/INSTALL.txt
+/web/LICENSE.txt
+/web/README.txt
+/web/robots.txt
+/web/update.php
+/web/web.config
+
+# Ignore vendor dependencies and scripts
 /vendor
-/modules/README.txt
-/profiles/README.txt
-/themes/README.txt
-/sites/README.txt
-/sites/example.sites.php
-/sites/example.settings.local.php
-/sites/development.services.yml
-/.csslintrc
-/.editorconfig
-/.eslintignore
-/.eslintrc.json
-/.gitattributes
-/.ht.router.php
-/.htaccess
-/autoload.php
-/example.gitignore
-/index.php
-/INSTALL.txt
-/LICENSE.txt
-/README.txt
-/robots.txt
-/update.php
-/web.config
+/composer.phar
+/composer
+/robo.phar
+/robo
+/drush.phar
+/drush
+/drupal.phar
+/drupal


### PR DESCRIPTION
# Pull Request

### Update

- [x] Template - Update existing `Drupal.gitignore` template

## Details

Update Drupal.gitignore with upstream conventions:
- prefix /web for drupal code
- remove deprecated simpletest directory
- allow project composer.json|lock at root
- add /vendor, composer, robo, drush and drupal scripts to root

These scripts are all part of project development cycles of Drupal and are all PHP based:
- Composer: https://getcomposer.org/
- Robo: https://robo.li/
- Drush: http://www.drush.org/
- Drupal Console: https://drupalconsole.com/

Not including JavaScript tools like Yarn, NPM, Gulp, Grunt, Bower or Ruby tools like SASS and Compass because although very popular and widely used, they are based on different programming languages and incur in much more complexity than adding a few paths and they are also alternatives to each others.

The rationale behind this is the move to officially support AND recommend Composer in Drupal projects: https://www.drupal.org/docs/develop/using-composer

Relevant links being:
- https://www.drupal.org/docs/develop/using-composer/using-composer-to-install-drupal-and-manage-dependencies#download-core
- https://www.drupal.org/docs/develop/using-composer/starting-a-site-using-drupal-composer-project-templates#s-templates
- https://github.com/drupal/recommended-project

This patch conforms and updates the outdated notions that were based on old Drupal 7 community standards and the provided Drupal 8 .gitignore for non-composer installs.

Drupal 8 still includes and maintains a .gitignore for simplified non-composer installs inside the tarball file, however this is since many years (since Drupal 6 times, back then recommending Drush, then later composer in late Drupal 7 cycle) the non-preferred method of using and deploying Drupal.