### PR TITLE
Ignore Next.js `next export` result directory

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -78,6 +78,7 @@ web_modules/
 
 # Next.js build output
 .next
+out
 
 # Nuxt.js build / generate output
 .nuxt


### PR DESCRIPTION
**Reasons for making this change:**

Next.js has a feature to export the project as static files. The exported files are located in `out` directory, which is currently not excluded.

I think we should add the directory, just like how the similar directory for Nuxt.js is excluded (`dist`).

**Links to documentation supporting these rule changes:**

- [Next.js documentation on Static HTML Export](https://nextjs.org/docs/advanced-features/static-html-export)
