### PR TITLE
Fix ignoring of everything in the root folder (WordPress)

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,6 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
+!.gitignore
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
**Reasons for making this change:**

It appears `!` can only be used to create exclusions for explicit patterns on previous lines and can't infer "all items" when used at the beginning of a document.

Also we want to still commit `.gitignore` itself.

**Links to documentation supporting these rule changes:**

From [`gitignore`'s documentation](https://git-scm.com/docs/gitignore):

> An optional prefix "`!`" which negates the pattern; any matching file excluded by a previous pattern will become included again.

> Example to exclude everything except a specific directory `foo/bar` (note the `/*` - without the slash, the wildcard would also exclude everything within `foo/bar`):
>
> ```
> $ cat .gitignore
> # exclude everything except directory foo/bar
> /*
> !/foo
> /foo/*
> !/foo/bar
> ```