### PR TITLE
Add ignore for Injection on Mac.

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -66,3 +66,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+OSXInjectionProject/

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -88,3 +88,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+OSXInjectionProject/


### PR DESCRIPTION
**Reasons for making this change:**

There was a reference to the iOSInjectionProject but not for the mac equivalence.