### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -60,7 +60,8 @@ captures/
 .cxx/
 
 # Google Services (e.g. APIs or Firebase)
-# google-services.json
+# **/google-services.json
+# **/google_maps_api.xml
 
 # Freeline
 freeline.py


### PR DESCRIPTION
Updated google-services.json rule to have a wildcard prefix and also added the new google_maps_api file as it contains the development/production key when using maps API.

**Reasons for making this change:**
Uncommenting the rule doesn't exclude it on account of it being inside the app/ folder than the root directory (as clearly mentioned in the google documentation as well). So the wildcard has been appended. The google_maps_api rule is self explanatory.

**Links to documentation supporting these rule changes:**
https://developers.google.com/android/guides/google-services-plugin#adding_the_json_file
https://developers.google.com/maps/documentation/android-sdk/get-api-key#getting-the-certification-information-from-android-studio
