### PR TITLE
Add .gitignore for Core Games

### DIFF
--- a/community/CoreGames.gitignore
+++ b/community/CoreGames.gitignore
@@ -2,11 +2,18 @@
 # website: https://www.coregames.com
 # documentation: https://docs.coregames.com
 
-# Exports folder is entirely generated
-Exports/
+# Temporary files used when publishing & to store some preview data like persistent storage
+# No need to synchronize
+Temp/
 
-# User settings are per user
+# Local user settings used to store script breakpoints & hierarchy state (locked/hidden objects)
+# No need to synchronize
 UserSettings/
 
-# Local storage for testing persistent storage
-Storage/
+# Screenshots used when publishing & for project thumbnails in the Create tab
+# Comment out if you want to synchronize screenshots
+Screenshots/
+
+# Directory created when migrating from an old storage format
+# No need to synchronize
+.core_backup/

--- a/community/CoreGames.gitignore
+++ b/community/CoreGames.gitignore
@@ -1,0 +1,12 @@
+# gitignore template for games on the Core platform
+# website: https://www.coregames.com
+# documentation: https://docs.coregames.com
+
+# Exports folder is entirely generated
+Exports/
+
+# User settings are per user
+UserSettings/
+
+# Local storage for testing persistent storage
+Storage/


### PR DESCRIPTION
**Reasons for making this change:**

N/A

**Links to documentation supporting these rule changes:**

N/A

If this is a new template:

 - **Link to application or project’s homepage**: https://www.coregames.com

Core is a platform for creating and playing games. We encourage our users to use GitHub to collaborate on creating games and would love if GitHub could offer a simple way for them to ignore the automatically generated files in their projects.
