### PR TITLE
Adding gitignore for Meson Build system

### DIFF
--- a/Meson.gitignore
+++ b/Meson.gitignore
@@ -1,0 +1,17 @@
+# Meson Directories
+meson-logs
+meson-private
+
+# Meson Files
+meson_benchmark_setup.dat
+meson_test_setup.dat
+sanitycheckcpp.cc
+sanitycheckcpp.exe
+
+# Ninja
+build.ninja
+.ninja_deps
+.ninja_logs
+
+# Misc
+compile_commands.json


### PR DESCRIPTION
**Reasons for making this change:**

Meson is an extremely fast build system used for building projects written in C++; it also uses Ninja backend. While building my projects in C++, I had to get rid of the files created by Meson and since there is no gitignore for it, I'm proposing one.

**Links to documentation supporting these rule changes:**

While there is no concrete documentation regarding the files creating during the build, the following link gives an idea.
https://mesonbuild.com/Running-Meson.html

If this is a new template:

 - **Link to application or project’s homepage**: https://mesonbuild.com/
- **GitHub**: https://github.com/mesonbuild/meson/ 
