### PR TITLE
Dart: Ignore .flutter-plugins

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -19,3 +19,6 @@ doc/api/
 *.js_
 *.js.deps
 *.js.map
+
+.flutter-plugins
+.flutter-plugins-dependencies


### PR DESCRIPTION
Generated files that appear when using [google_fonts](https://pub.dev/packages/google_fonts) or other Dart packages designed as Flutter plugins.

**Reasons for making this change:**
Those files are not meant to be versioned in any Flutter project.

**Links to documentation supporting these rule changes:**
![Screenshot from 2020-05-06 15-06-05](https://user-images.githubusercontent.com/115275/81180759-bf4e9800-8fab-11ea-8c0a-c9fa6e6e327a.png)