### PR TITLE
Adding MigrationBackup/ to VisualStudio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -257,6 +257,7 @@ UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/
 *.rptproj.bak
+MigrationBackup/
 
 # SQL Server files
 *.mdf

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -257,6 +257,7 @@ UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/
 *.rptproj.bak
+# NuGet package rollback directory
 MigrationBackup/
 
 # SQL Server files


### PR DESCRIPTION
**Reasons for making this change:**

This folder is created by the Migrate packages.config to packageReference wizard

**Links to documentation supporting these rule changes:**

https://docs.microsoft.com/en-us/nuget/consume-packages/migrate-packages-config-to-package-reference

> Copy the project file and packages.config from the backup (typically `<solution_root>\MigrationBackup\<unique_guid>\<project_name>\`) to the project folder. Delete the `obj` folder if it exists in the project root directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/github/gitignore/3399)
<!-- Reviewable:end -->
