### PR TITLE
ignore projectSettingsUpdater.xml from Rider

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -10,6 +10,7 @@
 
 # Generated files
 .idea/**/contentModel.xml
+.idea/**/projectSettingsUpdater.xml
 
 # Sensitive or high-churn files
 .idea/**/dataSources/

--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -10,7 +10,6 @@
 
 # Generated files
 .idea/**/contentModel.xml
-.idea/**/projectSettingsUpdater.xml
 
 # Sensitive or high-churn files
 .idea/**/dataSources/
@@ -70,3 +69,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+#Rider
+.idea/*/.idea/projectSettingsUpdater.xml


### PR DESCRIPTION
**Reasons for making this change:**

This file is generated by Rider and should never be added to VCS.

**Links to documentation supporting these rule changes:**

To qote @citizenmatt who is one of Rider developers at JetBrains:

> This is a file to record when certain settings migrations have occurred. Right now, it only makes changes to VCS configuration, but could be expanded in the future. The VCS changes are to make it the default to show the diff preview in the Commit tool window, and to clear the initial commit message. Once the changes have been made, this file is updated with the current version (“2”) and as long as the version matches, the settings are not re-applied the next time the project is loaded.
It should not be added to source control - it controls defaults to per-user settings ...
