### PR TITLE
Added template for Sypder projects

### DIFF
--- a/community/Python/Spyder.gitignore
+++ b/community/Python/Spyder.gitignore
@@ -1,0 +1,40 @@
+# Compiled python files
+*.py[oc]
+
+# gedit files
+*~
+
+# Notepad++ files
+nppBackup/
+
+# Pytest dirs/files
+.pytest_cache/
+
+# Special dirs and files
+build/
+dist/
+bin/
+spyder.egg-info/
+spyder_crash.log
+.spyproject
+.idea/
+.cache
+.coverage*
+MANIFEST
+
+# git .orig files
+*.orig
+
+# log files
+*.log
+
+# Rope project folders
+.ropeproject/
+.vscode/
+result.xml
+
+# Pylint dirs/files
+.pylint.d/
+
+# Ignore setuptools development files in the PyLS subrepo
+external-deps/python-language-server/python_language_server.egg-info/


### PR DESCRIPTION
**Reasons for making this change:**

Spyder projects ignore:

- spyder.egg-info/
- spyder_crash.log
- .spyproject

**Links to documentation supporting these rule changes:**

https://docs.spyder-ide.org/projects.html

If this is a new template:

- Link to application or project’s homepage: https://www.spyder-ide.org/