### PR TITLE
add: create template for Alteryx Designer

### DIFF
--- a/community/Alteryx.gitignore
+++ b/community/Alteryx.gitignore
@@ -3,27 +3,42 @@
 # website: https://help.alteryx.com/current/designer/alteryx-file-types
 
 # Alteryx Data Files
-.yxdb
-.cydb
-.cyidx
-.rptx
-.vvf
-.aws
+*.yxdb
+*.cydb
+*.cyidx
+*.rptx
+*.vvf
+*.aws
 
 # Alteryx Special Files
-.yxwv
-.yxft
-.yxbe
-.bak
-.pcxml
-.log
-.bin
-.yxlang
+*.yxwv
+*.yxft
+*.yxbe
+*.bak
+*.pcxml
+*.log
+*.bin
+*.yxlang
 CASS.ini
 
 # Alteryx License Files
-.yxlc
-.slc
-.cylc
-.alc
-.gzlc
+*.yxlc
+*.slc
+*.cylc
+*.alc
+*.gzlc
+
+## gitignore reference sites
+# https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files
+# https://git-scm.com/docs/gitignore
+# https://help.github.com/articles/ignoring-files/
+
+## Useful knowledge from stackoverflow
+# Even if you haven't tracked the files so far, git seems to be able to "know" about them even after you add them to .gitignore.
+# WARNING: First commit your current changes, or you will lose them.
+# Then run the following commands from the top folder of your git repo:
+# git rm -r --cached .
+# git add .
+# git commit -m "fixed untracked files"
+
+# author: Kacper Ksieski

--- a/community/Alteryx.gitignore
+++ b/community/Alteryx.gitignore
@@ -1,0 +1,29 @@
+# gitignore template for Alteryx Designer
+# website: https://www.alteryx.com/
+# website: https://help.alteryx.com/current/designer/alteryx-file-types
+
+# Alteryx Data Files
+.yxdb
+.cydb
+.cyidx
+.rptx
+.vvf
+.aws
+
+# Alteryx Special Files
+.yxwv
+.yxft
+.yxbe
+.bak
+.pcxml
+.log
+.bin
+.yxlang
+CASS.ini
+
+# Alteryx License Files
+.yxlc
+.slc
+.cylc
+.alc
+.gzlc


### PR DESCRIPTION
**Reasons for making this change:**
I have been using Alteryx Designer to build ETL processes for years. The actual files are XML documents and I have been a champion of using git in my collaborative projects. This is the gitignore file I have used in production and I haven't found anyone else to have produced it. Thank you for considering it.

 - **Link to application or project’s homepage**: _
https://www.alteryx.com/
https://help.alteryx.com/current/designer/alteryx-file-types
