### PR TITLE
add: create template for Tableau Desktop

### DIFF
--- a/community/Tableau.gitignore
+++ b/community/Tableau.gitignore
@@ -3,9 +3,24 @@
 # website: https://help.tableau.com/current/pro/desktop/en-us/environ_filesandfolders.htm
 
 # Workbooks
-.twbx
-.twbr
+*.twbx
+*.twbr
 
 # Data Files
-.tde
-.hyper
+*.tde
+*.hyper
+
+## gitignore reference sites
+# https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files
+# https://git-scm.com/docs/gitignore
+# https://help.github.com/articles/ignoring-files/
+
+## Useful knowledge from stackoverflow
+# Even if you haven't tracked the files so far, git seems to be able to "know" about them even after you add them to .gitignore.
+# WARNING: First commit your current changes, or you will lose them.
+# Then run the following commands from the top folder of your git repo:
+# git rm -r --cached .
+# git add .
+# git commit -m "fixed untracked files"
+
+# author: Kacper Ksieski

--- a/community/Tableau.gitignore
+++ b/community/Tableau.gitignore
@@ -1,0 +1,11 @@
+# gitignore template for Tableau Desktop
+# website: https://www.tableau.com/
+# website: https://help.tableau.com/current/pro/desktop/en-us/environ_filesandfolders.htm
+
+# Workbooks
+.twbx
+.twbr
+
+# Data Files
+.tde
+.hyper


### PR DESCRIPTION
**Reasons for making this change:**
I have been using Tableau Desktop to build dashboards for years. The actual files are XML documents and I have been a champion of using git in my collaborative projects. This is the gitignore file I have used in production and I haven't found anyone else to have produced it. Thank you for considering it.

 - **Link to application or project’s homepage**:
website: https://www.tableau.com/
website: https://help.tableau.com/current/pro/desktop/en-us/environ_filesandfolders.htm
