### PR TITLE
Add .yarn/install-state.gz to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -109,8 +109,8 @@ dist
 .vscode-test
 
 # yarn v2
-
 .yarn/cache
 .yarn/unplugged
 .yarn/build-state.yml
+.yarn/install-state.gz
 .pnp.*


### PR DESCRIPTION
After running `yarn set version berry` and `yarn install`, the file `.yarn/install-state.gz` is created.

The documentation at https://yarnpkg.com/advanced/qa#which-files-should-be-gitignored mentions that this file should be ignored:

> .yarn/install-state.tgz is an optimization file that you shouldn't have to ever commit. It simply stores the exact state of your project so that the next commands can boot without having to resolve your workspaces again.

The documentation has a minor error; the generated file is `.gz` instead of `.tgz` (source: https://github.com/yarnpkg/berry/pull/998/files#diff-23dd4c2e823c25186f1107e88e962032R201)
