### PR TITLE
ignore the `.idea` directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Pycharm editor related
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**
`.idea` directory is added by the Pycharm IDE.

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
