### PR TITLE
ignore .xwm generated by xwatermark package in TeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -275,6 +275,9 @@ TSWLatexianTemp*
 # Makeindex log files
 *.lpz
 
+# xwatermark package
+*.xwm
+
 # REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.


### PR DESCRIPTION
**Reasons for making this change:**

The Latex Package [xwatermark](https://ctan.org/pkg/xwatermark) generates files with the ending `.xwm` during compilation. These should be ignored by Git since they are generated.

**Links to documentation supporting these rule changes:**

- https://ctan.org/pkg/xwatermark
- http://mirrors.ctan.org/macros/latex/contrib/xwatermark/doc/xwatermark-guide.pdf
