### PR TITLE
Add *.aab

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -57,6 +57,7 @@ sysinfo.txt
 
 # Builds
 *.apk
+*.aab
 *.unitypackage
 
 # Crashlytics generated file


### PR DESCRIPTION
**Reasons for making this change:**

Unity can build *.aab(Android App Bundle) instead of APK.
