### PR TITLE
Fix for Coverage* filename issue

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -142,7 +142,9 @@ _TeamCity*
 !.axoCover/settings.json
 
 # Coverlet is a free, cross platform Code Coverage Tool
-coverage*[.json, .xml, .info]
+coverage.json
+coverage.info
+coverage*.xml
 
 # Visual Studio code coverage results
 *.coverage


### PR DESCRIPTION
As @phoogenb properly notice, there was issue with Coverlet ignore rules. This PR fix the issue.

![image](https://user-images.githubusercontent.com/5943484/82380143-48dc7c00-9a28-11ea-8525-feffb3da0acf.png)

fix
![image](https://user-images.githubusercontent.com/5943484/82380235-67427780-9a28-11ea-832f-d63fe17becb8.png)

Results received after execution of `dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=\"json,opencover,lcov,cobertura\"`.