### PR TITLE
KiCad extension to ignore backup

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -24,3 +24,7 @@ fp-info-cache
 # Exported BOM files
 *.xml
 *.csv
+
+# Backup (also rescue backup)
+rescue-backup/
+backup/


### PR DESCRIPTION
Now KiCad gitignore bakcup files (also rescue backup)

Reasons for making this change:

In a previous version, gitignore does not contain an entry that ignores the folder of the automatically created backup.
Such a folder is created automatically, e.g. when updating libraries or an element conflict.