### PR TITLE
Add in .DS_Store (macOS Specific)

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -25,6 +25,9 @@ DerivedData/
 ## Obj-C/Swift specific
 *.hmap
 
+## macOS specific 
+.DS_Store
+
 ## App packaging
 *.ipa
 *.dSYM.zip


### PR DESCRIPTION
**Reasons for making this change:**
Usually I and other developers need to manually add this line later.
.DS_Store should be specific to everyone and there is almost no value in sharing it in a project.
