### PR TITLE
Ignore .ptc generated by titletoc package in TeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -209,6 +209,11 @@ pythontex-files-*/
 *.md5
 *.auxlock
 
+# titletoc
+*.ptc
+*.plf
+*.plt
+
 # todonotes
 *.tdo
 


### PR DESCRIPTION
**Reasons for making this change:**

The `titletoc` package stores its partial TOCs in a `.ptc` file which is similar to the `.toc` file generated by LaTeX standard class.

**Links to documentation supporting these rule changes:**

http://mirrors.ctan.org/macros/latex/contrib/titlesec/titlesec.pdf (Section 6.3 )
https://github.com/jbezos/titlesec/blob/6ae17b138a18c419bfc695f892899e66c46b41e8/titlesec.tex#L1505-L1506