### PR TITLE
Add PLEXOS.gitignore

### DIFF
--- a/PLEXOS.gitignore
+++ b/PLEXOS.gitignore
@@ -1,0 +1,8 @@
+# gitignore template for PLEXOS Market Simulation Software
+# website: https://energyexemplar.com/solutions/plexos/
+
+# Backup
+*.BAK
+
+# History
+*.his


### PR DESCRIPTION
**Reasons for making this change:**

Add .gitignore for PLEXOS Market Simulation Software, initially including backup and history files.

**Links to documentation supporting these rule changes:**

No public documentation available, best I could find is http://wiki.energyexemplar.com/Uploads/Article/User_Interface_Guide.pdf (Ctrl-F for `BAK` on page 8).

-  `.BAK`: a backup copy of the file that is being edited.
- `.his`: history of items accessed in the GUI and persistence of the last opened state.

If this is a new template:

 - **Link to application or project’s homepage**: https://energyexemplar.com/solutions/plexos/
