### PR TITLE
Add text editors specific settings (.idea, .vscode) in Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Text editors
+.idea
+.vscode


### PR DESCRIPTION
**Reasons for making this change:**

Different text editors create some hidden files, for example, VS Code creates .vscode folder. These folders should be ignored during a git push.

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

This is not a new template
