### PR TITLE
[TeX.gitignore] For `minitoc` and `latexindent` packages

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -139,6 +139,10 @@ acs-*.bib
 # *.tikz
 *-tikzDictionary
 
+# latexindent.pl backup files
+*.bak
+*.bak[0-9]*
+
 # listings
 *.lol
 

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -206,6 +206,9 @@ sympy-plots-for-*.tex/
 *.pytxcode
 pythontex-files-*/
 
+# snapshot
+*.dep
+
 # tcolorbox
 *.listing
 

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -154,6 +154,10 @@ acs-*.bib
 *.maf
 *.mlf
 *.mlt
+*.mtc
+*.slf
+*.slt
+*.stc
 *.mtc[0-9]*
 *.slf[0-9]*
 *.slt[0-9]*


### PR DESCRIPTION
**Reasons for making this change:**

Ignore `.bak`, `.bak0`,`.bak1`... files that created by `latexindent.pl` when formatting `.tex` files.
Ignore `.mtc`, `.slf`, `.slt`, `.stc` files that created by `minitoc` package.
Ignore `.dep` files that created by `snapshot` package.

**Links to documentation supporting these rule changes:**

- [latexindent package, page 24](http://mirror.ctan.org/support/latexindent/documentation/latexindent.pdf)
- [minitoc package documentation, page 207, ](http://texdoc.net/texmf-dist/doc/latex/minitoc/minitoc.pdf)
- [snapshot package](http://mirror.ctan.org/macros/latex/contrib/snapshot/snapshot.pdf)


