### PR TITLE
KiCad: add *.kicad_sch-bak and *.kicad_prl

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -6,6 +6,7 @@
 *.bak
 *.bck
 *.kicad_pcb-bak
+*.kicad_sch-bak
 *.sch-bak
 *~
 _autosave-*

--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -7,6 +7,7 @@
 *.bck
 *.kicad_pcb-bak
 *.kicad_sch-bak
+*.kicad_prl
 *.sch-bak
 *~
 _autosave-*


### PR DESCRIPTION
As used by the new file formats for KiCad 6.0
See https://kicad-pcb.org/blog/2020/05/Development-Highlight-New-schematic-and-symbol-library-file-formats-are-now-the-default/

Thanks!
