### PR TITLE
Use the correct product name for IntelliJ IDEA

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -36,7 +36,7 @@ proguard/
 # Android Studio captures folder
 captures/
 
-# IntelliJ
+# IntelliJ IDEA
 *.iml
 .idea/workspace.xml
 .idea/tasks.xml

--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,4 +1,4 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Covers JetBrains IDEs: IntelliJ IDEA, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
@@ -46,7 +46,7 @@ cmake-build-*/
 # File-based project format
 *.iws
 
-# IntelliJ
+# IntelliJ IDEA
 out/
 
 # mpeltonen/sbt-idea plugin
@@ -58,7 +58,7 @@ atlassian-ide-plugin.xml
 # Cursive Clojure plugin
 .idea/replstate.xml
 
-# Crashlytics plugin (for Android Studio and IntelliJ)
+# Crashlytics plugin (for Android Studio and IntelliJ IDEA)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties


### PR DESCRIPTION
**Reasons for making this change:**

The product's name is "IntelliJ IDEA".

**Links to documentation supporting these rule changes:**

- https://www.jetbrains.org/intellij/sdk/docs/intro/sdk_style.html#terminology
- https://www.jetbrains.com/company/brand/
- https://www.jetbrains.com/idea/
- https://intellij-support.jetbrains.com/hc/en-us/community/posts/206977935-IDEA-product-name?page=1#community_comment_207223929
- https://en.wikipedia.org/wiki/IntelliJ_IDEA
- https://en.wikipedia.org/wiki/JetBrains#IntelliJ_IDEA
- https://www.jetbrains.com/opensource/idea/
- https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html