### PR TITLE
This is not Delphi-specific folder

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -64,6 +64,3 @@ __recovery/
 
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
-
-# Boss dependency manager vendor folder https://github.com/HashLoad/boss
-modules/


### PR DESCRIPTION
**Reasons for making this change:**

This is just another extension for Delphi. 
No reason to ignore folder named "modules" for everybody.

**Links to documentation supporting these rule changes:**

Please keep generic gitignore-template as universal as possible. 
You can use specialized template for your extension as written in Readme:
> If you have a small set of rules, or want to support a technology that is not widely in use, and still believe this will be helpful to others, please read the section about specialized templates for more details.
