### PR TITLE
Add (Mac) .DS_Store file to .gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -358,3 +358,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Mac - directory attribute file
+.DS_Store


### PR DESCRIPTION

**Reasons for making this change:**

The .DS_Store file is auto generated in directories by the OS on MacOS to hold user specific properties about the directory. 

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store
