### PR TITLE
Make Dependencies folder only be excluded in root for Swift.gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -67,7 +67,7 @@ playground.xcworkspace
 Carthage/Build/
 
 # Accio dependency management
-Dependencies/
+/Dependencies
 .accio/
 
 # fastlane


### PR DESCRIPTION
**Reasons for making this change:**

Previously `Dependencies/` folder in exclusion to support Accio for Swift was also excluding any folder across the project with the same name. This change makes it only exclude that folder from root of the repo.

**Links to documentation supporting these rule changes:**

Accio creates a folder called `Dependencies` https://github.com/JamitLabs/Accio that doesn't need to be checked in.

