### PR TITLE
Add gitignore support for the Zig programming language

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,0 +1,7 @@
+# Language: Zig ()https://ziglang.org/
+# Source: https://github.com/ziglang/zig/blob/master/.gitignore (modified)
+
+**/zig-cache/
+**/build/
+**/build-*/
+**/docgen_tmp/

--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,4 +1,4 @@
-# Language: Zig ()https://ziglang.org/
+# Language: Zig (https://ziglang.org/)
 # Source: https://github.com/ziglang/zig/blob/master/.gitignore (modified)
 
 **/zig-cache/


### PR DESCRIPTION
**Reasons for making this change:**

We already have `linguist` support for Zig, but we do not have a `.gitignore` template for Zig projects created under Github. This PR aims to provide support for that.

**Links to documentation supporting these rule changes:**

Source for `.gitignore` template - https://github.com/ziglang/zig/blob/master/.gitignore

 **Link to application or project’s homepage**:
https://ziglang.org (homepage)
https://github.com/ziglang/zig/ (main repo page)
