### PR TITLE
Allow language files to be committed

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -4,6 +4,8 @@
 # ignore everything in the "wp-content" directory, except:
 # "mu-plugins", "plugins", "themes" directory
 wp-content/*
+!wp-content/languages/
+wp-content/languages/*.mo
 !wp-content/mu-plugins/
 !wp-content/plugins/
 !wp-content/themes/


### PR DESCRIPTION
**Reasons for making this change:**

It is probably a good idea to include localization, except for machine objects.

**Links to documentation supporting these rule changes:**

See [Localization](https://developer.wordpress.org/plugins/internationalization/localization/) for more information.
