### PR TITLE
Update stale heading anchor

### DIFF
--- a/Global/README.md
+++ b/Global/README.md
@@ -4,7 +4,7 @@ This directory contains globally useful gitignores,
 e.g. OS-specific and editor specific.
 
 For more on global gitignores:
-<https://help.github.com/articles/ignoring-files/#create-a-global-gitignore>
+<https://help.github.com/en/github/using-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer>
 
 And a good blog post about 'em:
 <http://augustl.com/blog/2009/global_gitignores>


### PR DESCRIPTION
**Reasons for making this change:**

The link to the GitHub documentation page includes a non-existent heading anchor. This PR updates the link to reflect the new anchor for the relevant section on global gitignore files.