### PR TITLE
Add JetBrains note for PyCharm to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,10 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/


### PR DESCRIPTION
**Reasons for making this change:**

First and foremost I think that requiring such a complicated gitignore for JetBrains IDEs is a failure on JetBrains part in structuring their project setting.  I also feel that it should be included in the `Python.gitignore` due to its popularity and due to the frequency of requests.  A quick search for `PyCharm` PRs shows 81 closed PRs requesting it be added and if searching for `.idea` you can see many more have been requested.  However I understand the maintenance burden in including it when a user can manually merge the two files themselves so I understand why the maintainers have opted to maintain it seperately.  

The main problem I see is that with many people adding the `Python.gitignore` at project creation through the Github UI and the `JetBrains.gitignore` being in the Global folder makes it less discoverable than it should be.  

This PR adds a comment to the `Python.gitignore` directing users to the global `JetBrains.gitignore`.  I believe this solves the issue in a way that is acceptable for the maintainers since comment-only sections already exist for `pyenv` and `pipenv`.

**Links to documentation supporting these rule changes:**

Closed [PyCharm](https://github.com/github/gitignore/pulls?q=pycharm) and [.idea](https://github.com/github/gitignore/pulls?q=.idea) PRs
[pyenv comment](https://github.com/github/gitignore/blob/master/Python.gitignore#L85-L88)
[pipenv comment](https://github.com/github/gitignore/blob/master/Python.gitignore#L90-L95)

