### PR TITLE
Exclude *.tfvars files

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -8,11 +8,12 @@
 # Crash log files
 crash.log
 
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
-# .tfvars files are managed as part of configuration and so should be included in
-# version control.
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
 #
-# example.tfvars
+*.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in


### PR DESCRIPTION
**Reasons for making this change:**

Contrary to the current .gitignore explanation about .tfvars files, these are data points abtracted away from the Terraform variables due to the potentially sensitive nature of the values. For example, AWS, Azure, and GCP credentials are oftentimes assigned in the .tfvars files. I personally have had my credentials exposed several times due to the oversight of not excluding the .tfvars files in this particular .gitignore file.

The values in .tfvars files are, by nature, personal to the individual running the script. Data points such as these should not be included by default. If values are to be checked into version control, the variable definition includes a default attribute. 

**Links to documentation supporting these rule changes:**

https://learn.hashicorp.com/terraform/getting-started/variables.html#from-a-file
https://www.linode.com/docs/applications/configuration-management/terraform/secrets-management-with-terraform/#keeping-secrets-out-of-tf-files
https://secrethub.io/blog/secret-management-for-terraform/#secrets-in-tfvars


If this is a new template:

 - **Link to application or project’s homepage**: 

Not new, just a slight but important change


