### PR TITLE
ignore *~ files in the po directory

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -40,3 +40,6 @@ vignettes/*.pdf
 
 # pkgdown site
 docs/
+
+# translation temp files
+po/*~


### PR DESCRIPTION
Common IME for `gettext` utilities like `tools::update_pkg_po('.')` to create these temp files (at least on Mac)

**Reasons for making this change:**

A new potential workstream -- translations in the `po` directory creating many temp files

**Links to documentation supporting these rule changes:**

N/A

If this is a new template:

N/A