### PR TITLE
Fix false positives on Coverage*.cs files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -142,7 +142,9 @@ _TeamCity*
 !.axoCover/settings.json
 
 # Coverlet is a free, cross platform Code Coverage Tool
-coverage*[.json, .xml, .info]
+coverage*.json
+coverage*.xml
+coverage*.info
 
 # Visual Studio code coverage results
 *.coverage


### PR DESCRIPTION
**Reasons for making this change:**

I added this .gitignore to a project that included a file named CoverageSearchModel.cs, and the file was incorrectly ignored by this rule.

The intent of the original rule appears to have been to ignore three specific file extensions, but the range operator `[ ]` doesn't work that way.  This change splits the rule into three lines, one for each extension to be ignored.