### PR TITLE
Create Haxe.gitignore

### DIFF
--- a/Haxe.gitignore
+++ b/Haxe.gitignore
@@ -1,0 +1,2 @@
+.haxelib/
+dump/

--- a/Haxe.gitignore
+++ b/Haxe.gitignore
@@ -1,2 +1,3 @@
 .haxelib/
+.haxelsp/recording/
 dump/


### PR DESCRIPTION
**Reasons for making this change:**

Provide a template for Haxe projects.

**Links to documentation supporting these rule changes:**

`.haxelib` folder is used by [haxe library manager](https://lib.haxe.org/) for local installations - [relevant source code](https://github.com/HaxeFoundation/haxelib/blob/443307307eb2ed1aeb576fa2c8c2afc0f896d18e/src/haxelib/client/Main.hx#L160) (have not found direct mention of the folder name in documentation).

`dump` folder is used sometimes by haxe for error logging - [relevant source code](https://github.com/HaxeFoundation/haxe/blob/e8717877aae5a06f75474ac35b1ed5abdd01fdee/src/context/common.ml#L1042-L1043). 

 - **Link to application or project’s homepage**: https://haxe.org/
