### PR TITLE
ignore HPROF files

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -83,3 +83,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+#Android Profiling
+*.hprof

--- a/Android.gitignore
+++ b/Android.gitignore
@@ -84,5 +84,5 @@ lint/outputs/
 lint/tmp/
 # lint/reports/
 
-#Android Profiling
+# Android Profiling
 *.hprof


### PR DESCRIPTION
ignore massive file .hprof

**Reasons for making this change:**

.hprof is a massive file that contains the memory profiling info. 

**Links to documentation supporting these rule changes:**

https://developer.android.com/studio/profile/memory-profiler

