### PR TITLE
Add gitignore support for the Wolfram Language

### DIFF
--- a/Wolfram.gitignore
+++ b/Wolfram.gitignore
@@ -1,0 +1,5 @@
+# Paclet archive file
+*.paclet
+
+# Serialized package
+*.mx


### PR DESCRIPTION
**Reasons for making this change:**

Provide a template for Wolfram Language projects

**Links to documentation supporting these rule changes:**

* `*.paclet`: the archive file for paclet distribution, see [CreatePacletArchive](https://reference.wolfram.com/language/ref/CreatePacletArchive.html) for more infomation.
* `*.mx`: Wolfram Language serialized package, see [MX (.mx)](https://reference.wolfram.com/language/ref/format/MX.html) for more infomation.

If this is a new template:

 - **Link to application or project’s homepage**: <https://www.wolfram.com/language/>
