### PR TITLE
Add .env.local to Node

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -79,6 +79,7 @@ web_modules/
 # Next.js build output
 .next
 out
+.env.local
 
 # Nuxt.js build / generate output
 .nuxt


### PR DESCRIPTION
**Reasons for making this change:**

Next.js recommends that to add the `.env.local` to the `. gitignore`, as described in the documentation below.

**Links to documentation supporting these rule changes:**

https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables