### PR TITLE
Remove pointless blank line from the beginning of the Godot file

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,4 +1,3 @@
-
 # Godot-specific ignores
 .import/
 export.cfg


### PR DESCRIPTION
**Reasons for making this change:**

The line is pointless and no other file begins with a line.

**Links to documentation supporting these rule changes:**

Unnecessary.