### PR TITLE
Create Logos.gitignore

### DIFF
--- a/Logos.gitignore
+++ b/Logos.gitignore
@@ -1,0 +1,14 @@
+# Logos
+#
+
+# theos temporary folder
+.theos
+
+# theos build folder
+packages
+
+# common macOS files
+.DS_Store
+
+# Add this line if you want to avoid checking in the theos folder
+# theos


### PR DESCRIPTION
**Reasons for making this change:**

Most Logos projects use Theos as build chain, but there is no default .gitignore for it

**Links to documentation supporting these rule changes:**

There is a lack of documentation about this folders, but any project created with theos, will contain these folders, here is a template folder: https://github.com/theos/templates/tree/master/ios/library
The folders `.theos` and `packages` are created after building

If this is a new template:

 - **Link to application or project’s homepage**:  https://github.com/theos/theos/
