### PR TITLE
Update PlayFramework.gitignore

### DIFF
--- a/PlayFramework.gitignore
+++ b/PlayFramework.gitignore
@@ -14,3 +14,7 @@ server.pid
 *.eml
 /dist/
 .cache
+.g8
+/.idea
+/.idea_modules
+/.settings


### PR DESCRIPTION
to ignore idea IDE specific files and new g8 checkout specific

**Reasons for making this change:**

Cannot see intelliJ IDEA specific and g8 specific entries
