### PR TITLE
ignore all without extension,*.out,*.exe for nim

### DIFF
--- a/Nim.gitignore
+++ b/Nim.gitignore
@@ -1,3 +1,11 @@
+# Ignore all
+*
+# Unignore all with extensions
+!*.*
+# Unignore all dirs
+!*/
 nimcache/
 nimblecache/
 htmldocs/
+*.out
+*.exe


### PR DESCRIPTION
**Reasons for making this change:**

Nim is compiled language, so developers usual compile to binary during development or testing.

binary file could be file without extension,.exe or .out


