### PR TITLE
Update Node.gitignore to incorporate .DS_Store

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -114,3 +114,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# ds_store files
+.DS_Store


### PR DESCRIPTION
.DS_Store is missing from all templates.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
