### PR TITLE
Ignore Gradle bin directory

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,6 +1,7 @@
 .gradle
 **/build/
 !src/**/build/
+**/bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
Gradle generates `bin/` directories containing `.class` files that shouldn't be checked in to git. This PR ignores these directories
