### PR TITLE
Update Yarn modern gitignore based on documentation

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -109,13 +109,13 @@ dist
 .vscode-test
 
 # Yarn modern
-# Comment for zero-install
-.pnp.*
 .yarn/*
-# Uncomment for zero-install
-# !.yarn/cache
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+# Swap the comments on the following lines if you don't wish to use zero-installs
+# Documentation here: https://yarnpkg.com/features/zero-installs
+!.yarn/cache
+#.pnp.*

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -109,9 +109,11 @@ dist
 .vscode-test
 
 # yarn v2
-.pnp.* # Comment for zero-install
+# Comment for zero-install
+.pnp.*
 .yarn/*
-# !.yarn/cache # Uncomment for zero-install
+# Uncomment for zero-install
+# !.yarn/cache
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -109,10 +109,11 @@ dist
 .vscode-test
 
 # yarn v2
+.pnp.* # Comment for zero-install
 .yarn/*
 # !.yarn/cache # Uncomment for zero-install
-!.yarn/releases
+!.yarn/patches
 !.yarn/plugins
+!.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-.pnp.* # Comment for zero-install

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -109,8 +109,10 @@ dist
 .vscode-test
 
 # yarn v2
-.yarn/cache
-.yarn/unplugged
-.yarn/build-state.yml
-.yarn/install-state.gz
-.pnp.*
+.yarn/*
+# !.yarn/cache # Uncomment for zero-install
+!.yarn/releases
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+.pnp.* # Comment for zero-install

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -108,7 +108,7 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
-# yarn v2
+# Yarn modern
 # Comment for zero-install
 .pnp.*
 .yarn/*


### PR DESCRIPTION
**Reasons for making this change:**

The ignored Yarn modern files are out of date and don't support zero-install.

**Links to documentation supporting these rule changes:**

https://yarnpkg.com/advanced/qa#which-files-should-be-gitignored
