### PR TITLE
Update WordPress.gitignore

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,5 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
**Reasons for making this change:**

Current version not ignoring all other files.

**Links to documentation supporting these rule changes:**

https://salferrarello.com/wordpress-gitignore/

If this is a new template:

https://salferrarello.com/wordpress-gitignore/
