### PR TITLE
Update Android.gitignore to support Split apk's.

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,5 +1,6 @@
 # Built application files
 *.apk
+*.apks
 *.aar
 *.ap_
 *.aab


### PR DESCRIPTION
As the split APK's are getting more popular and prevalent in the Play Store there should be support to the .gitingore files of the base Android .gitignore. 
Source : Accidentally pushed my .apks to the repo

I am not 100% sure it's needed but as the popularity of split apk's starts to grow, it would be nice to have them immediately in the base Android .gitignore file. Might be an unnecessary PR if I am mistaken/