### PR TITLE
Create Gaml.gitignore

### DIFF
--- a/Gaml.gitignore
+++ b/Gaml.gitignore
@@ -1,0 +1,2 @@
+# Gama project settings
+.project


### PR DESCRIPTION
**Reasons for making this change:**

Provide a template for Gama platform project

**Links to documentation supporting these rule changes:**

.project file is used to manage [Gama project](https://gama-platform.github.io) requirements for models written in Gaml language

If this is a new template:

 - **Link to application or project’s homepage**:  https://github.com/gama-platform