### PR TITLE
Add Storybook static build directory to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -114,3 +114,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Storybook static build (https://storybook.js.org/)
+storybook-static


### PR DESCRIPTION
**Reasons for making this change:**

Storybook's build command `build-storybook` outputs a static build to this directory, `storybook-static/` by default.

**Links to documentation supporting these rule changes:**

https://storybook.js.org/docs/basics/exporting-storybook/

The documentation refers to setting the static directory to `.out/` using the `-o` flag. The default (`-o` flag is not required) outputs to `storybook-static/`.