### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.sln
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
@@ -96,6 +97,9 @@ StyleCopReport.xml
 *.pidb
 *.svclog
 *.scc
+*.vcxproj
+*.vcxproj.filters
+
 
 # Chutzpah Test files
 _Chutzpah*


### PR DESCRIPTION
These three files need to be ignored when using Visual Studio 2019.
Here they are: *.sln、*.vcxproj、*.vcxproj.filters
Thanks.

**Reasons for making this change:**

_TODO_ These three files need to be ignored when I using Visual Studio 2019,
they will be uploaded to the repositories


**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
