### PR TITLE
Added gitignore template for ATS lang

### DIFF
--- a/ATS.gitignore
+++ b/ATS.gitignore
@@ -1,0 +1,9 @@
+# Language: ATS (http://www.ats-lang.org/)
+# Source: adapted from https://github.com/ats-lang/ATS-Postiats-release/edit/master/.gitignore
+
+*~
+\#*
+.\#*
+*_?ats.o
+*_?ats.c
+*.exe


### PR DESCRIPTION
Reasons for making this change:

We already have linguist support for ATS, but we do not have a .gitignore template for ATS projects created under Github. This PR aims to provide support for that.

Links to documentation supporting these rule changes:

Source for .gitignore template - https://github.com/ats-lang/ATS-Postiats-release/edit/master/.gitignore (heavily adapted)

Link to application or project’s homepage:
http://www.ats-lang.org/ (homepage)
https://github.com/ats-lang/ATS-Postiats-release (main repo page)
