### PR TITLE
Update Python.gitignore with VSCode extensions

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,9 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# DS Store custom attributes 
+.DS_Store
+
+# VS Code extension 
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**
Adding VS Code file extensions and DS_Store custom attributes.

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
