### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -40,6 +40,43 @@ doc/api/
 # Obfuscation related
 app.*.map.json
 
+# Android related
+**/android/**/gradle-wrapper.jar
+**/android/.gradle
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/key.properties
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
 
 # IntelliJ related
 *.iml
@@ -58,5 +95,9 @@ lib/generated_plugin_registrant.dart
 # Symbolication related
 app.*.symbols
 
-# Exceptions
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -1,9 +1,26 @@
 # See https://www.dartlang.org/guides/libraries/private-files
 
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
 # Files and directories created by pub
 .dart_tool/
 .packages
 build/
+ios/Flutter/.last_build_id
+.flutter-plugins
+.flutter-plugins-dependencies
+.pub-cache/
+.pub/
+
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 
@@ -20,5 +37,26 @@ doc/api/
 *.js.deps
 *.js.map
 
-.flutter-plugins
-.flutter-plugins-dependencies
+# Obfuscation related
+app.*.map.json
+
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Exceptions
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages


### PR DESCRIPTION
**Links to documentation supporting these rule changes:**

On [StackOverflow](https://stackoverflow.com/questions/61994014/should-last-build-id-be-commited) there was discussion about the necessity of a certain file be committed. A much more usable [gitignore](https://stackoverflow.com/a/62010828/6262464) was shared with the community.

Later, I merged that with a more usable one from [toptal community](https://www.toptal.com/developers/gitignore/api/flutter) for my personal use. It can be useful for more users I think, that's why I am creating a PR.
