### PR TITLE
ignoring .aar files may cause to loose the files if libs are manually imported

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,5 +1,6 @@
 # Built application files
 *.apk
+# Comment next line if you have manually imported libs with .aar files.
 *.aar
 *.ap_
 *.aab


### PR DESCRIPTION

Desc: Comment next line if you have manually imported libs with .aar files.

**Reasons for making this change:**

ignoring .aar files may cause to loose the files if libs are manually imported

**Links to documentation supporting these rule changes:**

[https://developer.android.com/studio/projects/android-library](https://developer.android.com/studio/projects/android-library)

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
