### PR TITLE
Create StandardML.gitignore

### DIFF
--- a/community/StandardML.gitignore
+++ b/community/StandardML.gitignore
@@ -1,0 +1,5 @@
+# gitignore template for the Standard ML language
+# website: https://smlfamily.github.io/
+
+# SML/NJ Compilation Manager build directories
+.cm/


### PR DESCRIPTION
Similar to #2655.

---

**Reasons for making this change:**

Adds a template for the Standard ML programming language.

**Links to documentation supporting these rule changes:**

- https://www.smlnj.org/doc/CM/index.html

If this is a new template:

 - **Link to application or project’s homepage**: https://smlfamily.github.io/