### PR TITLE
Add *.zst to ArchLinuxPackages.gitignore

### DIFF
--- a/ArchLinuxPackages.gitignore
+++ b/ArchLinuxPackages.gitignore
@@ -8,6 +8,7 @@
 *.log
 *.log.*
 *.sig
+*.zst
 
 pkg/
 src/


### PR DESCRIPTION
[Arch Linux now uses `.pkg.tar.zst` for packages by default](https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/)