### PR TITLE
.gitignore for IntelliJ

### DIFF
--- a/IntelliJ.gitignore
+++ b/IntelliJ.gitignore
@@ -1,0 +1,50 @@
+# Log Files
+*.log
+
+# IntelliJ
+*.iml
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/gradle.xml
+.idea/**/assetWizardSettings.xml
+.idea/**/libraries
+.idea/**/dictionaries
+.idea/**/shelf
+.idea/**/caches
+.idea/**/modules.xml
+.idea/**/navEditor.xml
+.idea/**/usage.statistics.xml
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+out/
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Version control
+vcs.xml
+
+# Markdown Navigator plugin https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# CodeStream plugin https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# SonarQube Plugin https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml


### PR DESCRIPTION
The ignored files there are files from plugins, logs and JetBrains IDE configs in .idea folder unnecesary for version control

**Reasons for making this change:**

In github .gitignore templates i not found ignore unnecesary files for IntelliJ IDE

**Links to documentation supporting these rule changes:**

https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-
https://intellij-support.jetbrains.com/hc/en-us/community/posts/360004129760-Untracked-idea-folder-won-t-be-ignored-

If this is a new template:

 - **Link to application or project’s homepage**: https://www.jetbrains.com/idea/
