### PR TITLE
ignore codestream plugin JetBrains.gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -69,3 +69,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Codestream plugin
+.idea/codestream.xml


### PR DESCRIPTION
**Reasons for making this change:**

If we have installed the codestream plugin makes a codestream.xml file and this not necesary for version control

**Links to documentation supporting these rule changes:**

there aren't documentation about this but the codestream.com is a popular plugin and can help with gitignore file
