### PR TITLE
Add rc And uic Ignores

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -53,3 +53,4 @@ compile_commands.json
 
 *_qmlcache.qrc
 *_resource.rc
+uic_wrapper.bat

--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -52,3 +52,4 @@ compile_commands.json
 *creator.user*
 
 *_qmlcache.qrc
+*_resource.rc


### PR DESCRIPTION
Ignore auto-generated files on Windows

## *_resource.rc

[qt documentation](https://doc.qt.io/archives/qt-5.5/qmake-platform-notes.html#windows) states circumstances for auto-generating the rc file
> The optional auto-generation of a suitably filled .rc file by qmake is triggered by setting at least one of the system variables VERSION and RC_ICONS...

I could not find the format of the name of the rc file, but on my build the prepend text to `_resource.rc` was a name of a file in my project. Also, [qt/qtpim.git](https://code.qt.io/cgit/qt/qtpim.git/tree/.gitignore?id=b0fc1305f3b7682f33554be1bb0e2051be8113a3) had `*_resource.rc` as an ignore.

## uic_wrapper.bat
I did not find documentation on this one. I did confirm in my own project that it is generated by: renaming the current `uic_wrapper.bat`, rebuilding, seeing a new file named `uic_wrapper.bat`, and confirming the contents of the two files are the same.