### PR TITLE
Update Rails.gitignore to exclude env specific credential keys

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -20,6 +20,7 @@ pickle-email-*.html
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 config/master.key
+config/credentials/*.key
 
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml


### PR DESCRIPTION
**Reasons for making this change:**
Rails 6.0 has added environment specific credentials and its keys. 

**Links to documentation supporting these rule changes:**
https://api.rubyonrails.org/classes/Rails/Application.html#method-i-credentials
