### PR TITLE
[Global/macOS] Prevent corruption of "Icon\r" rule

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -3,8 +3,9 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
+# Start of Icon[\r] pattern
+Icon[]
+# End of Icon[\r] pattern
 
 # Thumbnails
 ._*


### PR DESCRIPTION
Fixed #2203 PR.

**Reasons for making this change:**

Make `Icon\r` pattern less vulnerable to editors and to [auto `CRLF` → `LF` conversion on commit](https://github.com/github/gitignore/commit/c02a4743f9c66a1d70d9ffb0da3e2156f5cc797e#commitcomment-25924422). As @spencermathews wrote in #2337 :
> Since this ignore rule may be vulnerable to editors that automatically standardize line endings, it seems imperative that updates to this file be done with care or else this rollercoaster seems likely [to continue](https://github.com/github/gitignore/pulls?q=is%3Apr+Icon+%5Cr).

Note: the Start..End comment has been added because most editors display `Icon[␍]` pattern in two lines:
```
# Start of Icon[\r] pattern
Icon[
]
# End of Icon[\r] pattern
```

**Links to documentation supporting these rule changes:**

- [How to ignore Icon? in git](https://stackoverflow.com/questions/17556250/how-to-ignore-icon-in-git/33974028#33974028) (`Icon[\r]`)