### PR TITLE
ROS_gitignore - added install directory

### DIFF
--- a/ROS.gitignore
+++ b/ROS.gitignore
@@ -1,6 +1,7 @@
 devel/
 logs/
 build/
+install/
 bin/
 lib/
 msg_gen/


### PR DESCRIPTION
**Reasons for making this change:**

`catkin_make install` command installs lots of generated files into `install` directory.

**Links to documentation supporting these rule changes:**

http://wiki.ros.org/catkin/commands/catkin_make
