### PR TITLE
Add .vscode/ VSCode cache folder

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**

Many Unity developers use Visual Studio Code as their primary code editor for their scripts (C#)
and using Code with projects creates a cache directory called .vscode/ which is not needed like the .vs/ directory.
