### PR TITLE
Add rider cache directory to Unity ignore list

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Rider cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**

Many Unity developers work with JetBrains Rider.
As the Unity.gitignore considers VSCode files it should also consider Rider files.

Riders .idea folder contains a mix of cache, user/shared configuration and settings files.
Similar to Visual Studios .vs folder it should be ignored.
There may be some files (e.g shared dictionaries and settings) in this folders that could be shared.
Sadly JetBrains does not separate local from shared files via folder structure.
Thus it is easier to ignore the folder and later on explicitly state exceptions for files one would consciously share.

**Links to documentation supporting these rule changes:**

This is JetBrains recommendation on which of the files in the .idea folder to ignore:
https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-
The comments are already mentioning though that some files are missing from this official recommendation.
This is their recommended gitigonre file
https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
It is quite complex though and is not future proof as it may miss Rider generated files added in the future.

As long as Rider does not clearly separate their local files from their shared files I would recommend to ignore this folder completely.
