### PR TITLE
Update CMake.gitignore

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -9,3 +9,4 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+*_autogen*


### PR DESCRIPTION

The cmake generate a ProjectName_autogen folders. For more information see [Cmake documentation](https://cmake.org/cmake/help/v3.8/prop_gbl/AUTOGEN_TARGETS_FOLDER.html)
