### PR TITLE
Fixing typo in Terraform.gitignore

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -8,7 +8,7 @@
 # Crash log files
 crash.log
 
-# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
 # password, private keys, and other secrets. These should not be part of version 
 # control as they are data points which are potentially sensitive and subject 
 # to change depending on the environment.


### PR DESCRIPTION
**Reasons for making this change:**
Minor tweak to the comments in the Terraform.gitignore file to correct a spelling mistake.

**Links to documentation supporting these rule changes:**
Not changing any rules in the file, just modifying the comments.