### PR TITLE
Updated C++.gitignore to include *ilk, *pdb files

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -11,6 +11,12 @@
 *.gch
 *.pch
 
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
 # Compiled Dynamic libraries
 *.so
 *.dylib


### PR DESCRIPTION
I have included the incremental linker files (.ilk) and program database files (.pdb), to .gitignore since they are generated by MSVC compiler during developmental builds, so they should be in the version control.

Some Sources ->

From Microsoft, on .ilk [Source](https://docs.microsoft.com/en-us/cpp/build/reference/dot-ilk-files-as-linker-input?view=vs-2019)
> If the .ilk file is missing, LINK performs a full link and creates a new .ilk file. If the .ilk file is unusable, LINK performs a nonincremental link

Microsoft Docs, on .pdb [Source](https://docs.microsoft.com/en-us/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger?view=vs-2019)
>  These mapping files link the debugger to your source code, which enables debugging.
> When you build a project from the Visual Studio IDE with the standard Debug build configuration, the compiler creates the appropriate symbol files


Apart from MS source links, here is a SO question regarding it -> 
https://stackoverflow.com/questions/10867186/why-do-i-need-ilk-pdb-and-exp-files
