### PR TITLE
VisualStudio: add "out" folder to build results

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -29,6 +29,7 @@ x86/
 bld/
 [Bb]in/
 [Oo]bj/
+[Oo]ut/
 [Ll]og/
 [Ll]ogs/
 


### PR DESCRIPTION
**Reasons for making this change:**

Out is a common folder for output that should not be committed. It is also the default output folder for CMake Projects in Visual Studio. See [supporting feedback ticket at Developer Community](https://developercommunity.visualstudio.com/content/problem/1164532/the-cmake-project-template-puts-build-artifacts-in.html).

**Links to documentation supporting these rule changes:**

See documentation for VS 2019: [CMake projects in Visual Studio - IDE Integration](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019#ide-integration).

> Click the Show All Files button at the top of Solution Explorer to see all the **CMake-generated output in the out/build/<config> folders**.
