### PR TITLE
Add svg temporary files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -185,6 +185,9 @@ _minted*
 # scrwfile
 *.wrt
 
+# svg
+svg-inkscape/
+
 # sympy
 *.sout
 *.sympy


### PR DESCRIPTION
**Reasons for making this change:**

The [`svg`](https://ctan.org/pkg/svg) package creates a large number of auxiliary files when used (two for each `.svg` graphic that is included). These are conveniently placed into a folder `svg-inkscape` by default and should be ignored.

**Links to documentation supporting these rule changes:**

[`svg`'s documentation](http://mirrors.ctan.org/graphics/svg/doc/svg.pdf)