### PR TITLE
feat: add Deno gitignore

### DIFF
--- a/Deno.gitignore
+++ b/Deno.gitignore
@@ -1,0 +1,14 @@
+# Logs
+*.log
+
+# Files that help ensure VSCode can work but we don't want checked into the
+# repo
+/node_modules
+/tsconfig.json
+
+# Cache 
+.cache
+
+# dotenv environment variables file
+.env
+.env.test


### PR DESCRIPTION
**Reasons for making this change:**

Support new runtime.

Deno is a Javascript/Typescript runtime that is strictly incompatible with Node (otherwise the Node gitignore would work). It would be convenient for developers to have a template that doesn't include unnecessary Node ignore patterns. The project is popular enough (esp. compared to other runtimes in this repo) that it should likely get its own entry.

https://github.com/denoland/deno

**Links to documentation supporting these rule changes:**

https://deno.land/manual

If this is a new template:

 - **Link to application or project’s homepage**: http://deno.land

---

I'm unsure if there are other patterns that should be included in this list.