### PR TITLE
Add .textClipping to exclusions

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -2,9 +2,11 @@
 .DS_Store
 .AppleDouble
 .LSOverride
+.textClipping
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*


### PR DESCRIPTION
I ran into the issue referenced in https://github.com/github/gitignore/pull/3523 and I'm not sure how to fix it.  I want to add the .textClipping exclusion without breaking the other rule so this pull request should not be accepted until the other one is first.


**Reasons for making this change:**

Files with the .textClipping extension should be ignored.

**Links to documentation supporting these rule changes:**

Per https://en.wikipedia.org/wiki/TextClipping this file is created when text is dragged and dropped to a folder.  The file created can't be shared between computers.  

