### PR TITLE
[SBT] Ignore .bsp directory

### DIFF
--- a/Global/SBT.gitignore
+++ b/Global/SBT.gitignore
@@ -10,3 +10,4 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp/


### PR DESCRIPTION
As documented in the [release notes](https://github.com/sbt/sbt/releases/tag/v1.4.0), as of v1.4.0 sbt generates a .bsp directory for IDE support via the build server protocol.