### PR TITLE
Log files ignore in Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -47,6 +47,9 @@ ExportedObj/
 *.opendb
 *.VC.db
 
+# Log files
+*.log
+
 # Unity3D generated meta files
 *.pidb.meta
 *.pdb.meta


### PR DESCRIPTION
Log Files such as debug.log that are kept in Unity Root Folder should be ignored.
Files such as Debug.log contains this data:
```
[1017/005142.667:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
```