### PR TITLE
Remove Accio after official deprecation

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -66,10 +66,6 @@ playground.xcworkspace
 
 Carthage/Build/
 
-# Accio dependency management
-Dependencies/
-.accio/
-
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo.


### PR DESCRIPTION
**Reasons for making this change:**

[Accio](https://github.com/JamitLabs/Accio) was oficially deprecated in favor of SwiftPM integration within Xcode. I don't think any new project will be opting for it, so it might also be a good idea to clean this up and remove the Accio related entries from the `.gitignore`.

**Links to documentation supporting these rule changes:**

https://github.com/JamitLabs/Accio/issues/88