### PR TITLE
Ignore .xsim files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -228,6 +228,9 @@ pythontex-files-*/
 # xindy
 *.xdy
 
+# xsim
+*.xsim
+
 # xypic precompiled matrices and outlines
 *.xyc
 *.xyd


### PR DESCRIPTION
TeX's gitignore should ignore .xsim files, which are created by the xsim package.

See section 5 of [xsim's documentation](https://ftp.gwdg.de/pub/ctan/macros/latex/contrib/xsim/doc/xsim_manual.pdf) for information on the generation of these files.