### PR TITLE
Add .bsp directory to SBT.gitignore

### DIFF
--- a/Global/SBT.gitignore
+++ b/Global/SBT.gitignore
@@ -10,3 +10,4 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp/


### PR DESCRIPTION
**Reasons for making this change:**

Since sbt 1.4.0 on every bootstrap sbt will create `.bsp/sbt.json` file that is environment specific.

**Links to documentation supporting these rule changes:**

Reference: https://contributors.scala-lang.org/t/build-server-protocol-in-sbt/4234

If this is a new template:

No.
