### PR TITLE
Create JupyterNotebook.gitignore

### DIFF
--- a/JupyterNotebook.gitignore
+++ b/JupyterNotebook.gitignore
@@ -1,0 +1,11 @@
+### JupyterNotebook ###
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/


### PR DESCRIPTION
**Reasons for making this change:**

Jupyter Notebook is nowdays widely used and I felt that a .gitignore file for it should be easily accessible.

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: http://jupyter.org/
