### PR TITLE
Added Exclusion for OS Thumbnails

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -69,3 +69,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# OS Specific Thumbnail caches
+/**/.DS_store
+/**/[Tt]humbs.db


### PR DESCRIPTION
We should not included these, as they are autogenerated by Unity and the system.

**Reasons for making this change:**

Had to manually adjust the default .gitignore file which was generated by github. This creates issue when working between multiple system, and also triggers unnecessary indexing. Thank you.

**Links to documentation supporting these rule changes:**

https://superuser.com/questions/624897/stop-thumbs-db-files-in-certain-folders
