### PR TITLE
Add the Visual Studio 2019 version in comment

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -32,7 +32,7 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
-# Visual Studio 2015/2017 cache/options directory
+# Visual Studio 2015/2017/2019 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/


### PR DESCRIPTION
**Reasons for making this change:**

The .vs directory (not hidden) is also created on Visual Studio 2019 for CMake projects.

**Links to documentation supporting these rule changes:**

See documentation for Visual Studio 2019: [Tutorial: Create C++ cross-platform projects in Visual Studio](https://docs.microsoft.com/en-us/cpp/build/get-started-linux-cmake?view=msvc-160).