### PR TITLE
Added .DS_Store to Swift.gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## General
+.DS_Store
+
 ## User settings
 xcuserdata/
 


### PR DESCRIPTION
**Reasons for making this change:**

The Swift.gitignore was not ignoring .DS_Store files.

**Links to documentation supporting these rule changes:**

n.a.
