### PR TITLE
adds VL cache to VVVV gitignore template

### DIFF
--- a/VVVV.gitignore
+++ b/VVVV.gitignore
@@ -4,3 +4,6 @@
 
 # Dynamic plugins .dll
 bin/
+
+# VL cache
+.vl/


### PR DESCRIPTION
**Reasons for making this change:**

VVVV now uses VL, a visual real-time programming language, that compiles dlls on the fly. Those dlls are added to `.vl/` folders and should not be versioned. 

**Links to documentation supporting these rule changes:**

This feature is not explicitly mentioned in the documentation. For more information on what VL is, see :

- [VL](https://betadocs.vvvv.org/using-vvvv/vl.html) in VVVV beta's documentation