### PR TITLE
Add .gitignore support for Anaconda environments

### DIFF
--- a/Anaconda.gitignore
+++ b/Anaconda.gitignore
@@ -1,0 +1,104 @@
+# Editor temporary/working/backup files #
+#########################################
+.#*
+[#]*#
+*~
+*$
+*.bak
+*.diff
+*.org
+.project
+*.rej
+.settings/
+.*.sw[nop]
+.sw[nop]
+*.tmp
+*.coverage.*
+/.idea
+/.vscode
+
+# Compiled source #
+###################
+*.a
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.py[ocd]
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.bz2
+*.bzip2
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.tbz2
+*.tgz
+*.zip
+
+# Python files #
+################
+# setup.py working directory
+/build
+# sphinx build directory
+/_build
+# setup.py dist directory
+/dist
+/doc/build
+/doc/cdoc/build
+/MANIFEST
+# Egg metadata
+*.egg-info
+/.eggs
+# The shelf plugin uses this dir
+./.shelf
+# coverage reports
+.coverage
+# ipython files
+**/.ipynb_checkpoints
+__pycache__
+
+# Logs and databases #
+######################
+*.log
+*.sqlite
+
+# Patches #
+###########
+*.patch
+*.diff
+
+# OS generated files #
+######################
+.DS_Store*
+.VolumeIcon.icns
+.fseventsd
+Icon?
+.gdb_history
+ehthumbs.db
+Thumbs.db
+
+# pytest-cov #
+##############
+/.cache
+*,cover
+htmlcov
+
+# Things specific to this project #
+###################################
+/.anaconda
+/.envs
+/record.txt
+/docs/build
+/examples/movies/movies.db
+*.orig
+CHANGELOG.temp


### PR DESCRIPTION
### Introduction to Anaconda

[**Anaconda**](https://www.anaconda.com/) is a highly popular package manager for python among data scientists. It is an alternative to virtualenv, and is highly sophisticated. Almost across the entire internet, it is considered a bad practice to include Virtual Environment files in **GitHub** commits. Typically **Anaconda** users would need to create their own _.gitignore_ files if they were to commit to **GitHub**. Thus, I am recommending a Pull Request to add support to _.gitignore_ for **Anaconda**.

I have taken this _.gitignore_ [file](https://github.com/Anaconda-Platform/anaconda-project/blob/master/.gitignore) from the [anaconda-project](https://github.com/Anaconda-Platform/anaconda-project) repository.