### PR TITLE
Ignore BSP directory

### DIFF
--- a/Global/SBT.gitignore
+++ b/Global/SBT.gitignore
@@ -10,3 +10,4 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bsp/


### PR DESCRIPTION
**Reasons for making this change:**

Ignore the new `.bsp/` directory that is created by sbt 1.4.0 and later.

**Links to documentation supporting these rule changes:**

https://www.scala-sbt.org/1.x/docs/Combined+Pages.html#Build+server+protocol+%28BSP%29+support
> sbt 1.4.0 adds build server protocol (BSP) support, contributed by Scala Center. Main implementation was done by Adrien Piquerez (@adpi2) based on @eed3si9n’s prototype.
> 
> When sbt 1.4.0 starts, it will create a file named .bsp/sbt.json containing a machine-readable instruction on how to run sbt -bsp, which is a command line program that uses standard input and output to communicate to sbt server using build server protocol.

Confirmation from Adrien (the main implementer) that `.sbt` should be ignored: https://gitter.im/sbt/sbt?at=5fc34d888c7c4215bb9726ef
