### PR TITLE
Added .DS_Store to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -282,3 +282,6 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+
+# DS Store file (for macs)
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

To ignore .DS_Store files

**Links to documentation supporting these rule changes:**

https://buildthis.com/ds_store-files-and-why-you-should-know-about-them/

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
