### PR TITLE
Unity.gitignore ignore meta files for already ignored unitypackages

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -59,6 +59,7 @@ sysinfo.txt
 *.apk
 *.aab
 *.unitypackage
+*.unitypackage.meta
 
 # Crashlytics generated file
 crashlytics-build.properties


### PR DESCRIPTION
**Reasons for making this change:**
Files that are not tracked should not have tracked metafiles.  
  
With this .gitignore I got a lot of   
![image](https://user-images.githubusercontent.com/8183632/100908009-470d6e00-34cb-11eb-803d-870d2d776e69.png)

