### PR TITLE
Update Bazel.gitignore

### DIFF
--- a/community/Bazel.gitignore
+++ b/community/Bazel.gitignore
@@ -1,6 +1,11 @@
-# gitignore template for Bazel build system
+# gitignore template for the Bazel build system
 # website: https://bazel.build/
 
-# Ignore all bazel-* symlinks. There is no full list since this can change
-# based on the name of the directory bazel is cloned into.
-/bazel-*
+# Ignore all bazel-* symlinks. 
+bazel-*
+
+# If you use [Gazelle](https://github.com/bazelbuild/bazel-gazelle),
+# and you do not want newly-generated files to be saved in the repo,
+# use this Gazelle option and the corresponding ignore rule.
+# `# gazelle:build_file_name BUILD.gazelle BUILD.bazel BUILD`
+BUILD.gazelle


### PR DESCRIPTION
* The `bazel-*` line should not start with a `/`, as the root of the bazel source tree is not necessarily the root of the repo.
* Gazelle-specific rule: Gazelle has an option to accept several different filenames as BUILD files; they don't even have to be named BUILD.*. It will use the first name in the rule for the files it *generates*. Some people prefer not to store generated files in the repo, hence this rule.

**Reasons for making this change:**

Better rules for bazel

**Links to documentation supporting these rule changes:**

https://bazel.build/ and https://github.com/bazelbuild/bazel-gazelle


If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
