### PR TITLE
CMake: Add CMakeUserPresets.json

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -9,3 +9,4 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+CMakeUserPresets.json


### PR DESCRIPTION
**Reasons for making this change:**

CMake 3.19 added CMakePresets.json, which is intended to be
version-controlled, and CMakeUserPresets.json, which should NOT
be version-controlled. Add CMakeUserPresets.json to the gitignore.

**Links to documentation supporting these rule changes:**

https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html