### PR TITLE
Do not ignore possible BOM files

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -22,7 +22,3 @@ fp-info-cache
 # Autorouter files (exported from Pcbnew)
 *.dsn
 *.ses
-
-# Exported BOM files
-*.xml
-*.csv


### PR DESCRIPTION
Not a good idea to ignore BOMs which are often manually edited to conform to SMTA fabrication partner expectations and may include irreplaceable knowledge (painstakingly referenced part numbers, etc.). This type of data is exactly what you want in git.

**Reasons for making this change:**

Personal experience running a robotics firm.

**Links to documentation supporting these rule changes:**

Refer to any and all SMTA operator data format guidelines. Each one is different.
