### PR TITLE
Also ignore *.idb (to match C.gitignore)

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -75,6 +75,7 @@ StyleCopReport.xml
 *.ilk
 *.meta
 *.obj
+*.idb
 *.iobj
 *.pch
 *.pdb


### PR DESCRIPTION
**Reasons for making this change:**

*.idb files (of VS2005 and probably other versions, too) should be also ignored.

**Links to documentation supporting these rule changes:**

See C.gitignore.

