### PR TITLE
Ignore .bin3 files for drivers in instr.lib, user.lib

### DIFF
--- a/LabVIEW.gitignore
+++ b/LabVIEW.gitignore
@@ -14,4 +14,5 @@
 # Metadata
 *.aliases
 *.lvlps
+*.bin3
 .cache/


### PR DESCRIPTION
Ignore the bin3 files for LabVIEW projects in instr.lib & user.lib. This file stores task-based browse paths and corrupts lv project files during development

**Reasons for making this change:**

bin3 files were corrupting/causing conflicts while building the lv project files in instr.lib and user.lib. The built example bin3 files can only be stored here (lv only searches for them in these paths). So its better to ignore local bin3 file changes from repo.

**Links to documentation supporting these rule changes:**

[https://zone.ni.com/reference/en-XX/help/371361R-01/lvhowto/prep_vi_for_ni_example_finder/](url)
[https://www.physik.uzh.ch/local/teaching/SPI301/LV-2015-Help/lvdialog.chm/Prepare_VIs_for_NIExFndr_db.html](url)
