### PR TITLE
Updating JetBrains template, adding SonarLint Plugin

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -58,6 +58,9 @@ atlassian-ide-plugin.xml
 # Cursive Clojure plugin
 .idea/replstate.xml
 
+# SonarLint plugin
+.idea/sonarlint/
+
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties


### PR DESCRIPTION
**Reasons for making this change:**

The SonarLint plugin for JetBrains creates an `issuestore` cache (a file `index.pb` and various subdirectories/files sharded based on UUIDs.  These files can cause problems to crop up when shared between machines.

**Links to documentation supporting these rule changes:**

- https://www.sonarlint.org/intellij/
- https://plugins.jetbrains.com/plugin/7973-sonarlint
- https://github.com/SonarSource/sonarlint-intellij/blob/81a2cf004a417217bba9bfd4dc51e603029bcfad/src/main/java/org/sonarlint/intellij/issue/persistence/StringStoreIndex.java#L33

Some repositories that show what happens without a rule like this one:
- https://github.com/GeorgianBadita/Projects/tree/master/Connect4_alpha_beta_search/.idea/sonarlint/issuestore
- https://github.com/MarcinOrlowski/Passay-Android/tree/master/.idea/sonarlint/issuestore
- https://github.com/benslamajihed/android-vision-kotlin-sample/tree/master/.idea/sonarlint/issuestore