### PR TITLE
Fixed editor specific folder exclusion for subfolders

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -302,17 +302,17 @@ node_modules/
 _Pvt_Extensions
 
 # Paket dependency manager
-.paket/paket.exe
+**/.paket/paket.exe
 paket-files/
 
 # FAKE - F# Make
-.fake/
+**/.fake/
 
 # CodeRush personal settings
-.cr/personal
+**/.cr/personal
 
 # Python Tools for Visual Studio (PTVS)
-__pycache__/
+**/__pycache__/
 *.pyc
 
 # Cake - Uncomment if you are using it
@@ -344,10 +344,10 @@ ASALocalRun/
 *.nvuser
 
 # MFractors (Xamarin productivity tool) working folder
-.mfractor/
+**/.mfractor/
 
 # Local History for Visual Studio
-.localhistory/
+**/.localhistory/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
@@ -356,7 +356,7 @@ healthchecksdb
 MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
-.ionide/
+**/.ionide/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd


### PR DESCRIPTION
**Reasons for making this change:**

If an .sln file is located in a repository subfolder then editor specific folders are not covered by the current gitignore rules