### PR TITLE
Improve .meta file pattern

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -15,7 +15,7 @@
 /[Mm]emoryCaptures/
 
 # Asset meta data should only be ignored when the corresponding asset is also ignored
-!/[Aa]ssets/**/*.meta
+!/[Aa]ssets/**/[\w\ \d\.]*.meta
 
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # /[Aa]ssets/AssetStoreTools*


### PR DESCRIPTION
Files can include spaces, which the current pattern doesn't capture.

Example:  `Assets/Plugins/My Plugin.meta`

Git `2.27.0.windows.1`

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
