### PR TITLE
Update Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,5 +1,6 @@
 # Built application files
 *.apk
+*.apks
 *.aar
 *.ap_
 *.aab


### PR DESCRIPTION

**Reasons for making this change:**

*.apks is generated by BundleTools

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/questions/52059339/difference-between-apk-apk-and-app-bundle-aab
