### PR TITLE
Add direnv .envrc to ignored files.

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -72,6 +72,9 @@ web_modules/
 .env
 .env.test
 
+# Direnv environment file
+.envrc
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -106,6 +106,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/

--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -24,9 +24,10 @@ config/master.key
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml
 
-# dotenv, dotenv-rails
+# dotenv, dotenv-rails, direnv
 # TODO Comment out these rules if environment variables can be committed
 .env
+.envrc
 .env.*
 
 ## Environment normalization:


### PR DESCRIPTION
**Reasons for making this change:**

The direnv project (https://direnv.net/ )  uses `.envrc` files for dynamically loading environment variables (or other settings) per directory using the user's shell... As it can contain sensitive information, and is similar in goal as to .env etc, I think it is a good idea to exclude this by default as well into popular languages that already use a 'dotenv' `.env` file as well.

**Links to documentation supporting these rule changes:**

* https://direnv.net/
* https://github.com/direnv/direnv
* http://manpages.ubuntu.com/manpages/xenial/man1/direnv.1.html
