### PR TITLE
Add direnv .envrc to python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -106,6 +106,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/


### PR DESCRIPTION
Reasons for making this change:

The direnv project (https://direnv.net/ ) uses `.envrc` files for dynamically loading environment variables (or other settings) per directory using the user's shell... As it can contain sensitive information, and is similar in goal as to dotenv etc, I think it is a good idea to exclude this by default as well into popular languages that already can use a 'dotenv' `.env` file as well. Adding this to the python `.gitignore`. 

Links to documentation supporting these rule changes:

 * https://direnv.net/
 * https://github.com/direnv/direnv
 * http://manpages.ubuntu.com/manpages/xenial/man1/direnv.1.html