### PR TITLE
Ignore temporal backup folder

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -16,6 +16,9 @@ _autosave-*
 *-save.kicad_pcb
 fp-info-cache
 
+# Temporal backup files
+*-backups/*.zip
+
 # Netlist files (exported from Eeschema)
 *.net
 


### PR DESCRIPTION
The new file formats for v6 was already included at .gitignore file. KiCad v6 or NIgthly v5.99 creates a temporal backup folder that make no sense by sync into git repository.
