### PR TITLE
Add .DS_Store to Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -86,3 +86,6 @@ lint/tmp/
 
 # Android Profiling
 *.hprof
+
+# macOS file stores custom attributes of its containing folder
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

It is also added to .gitignore by Android Studio.