### PR TITLE
Autotools.gitignore: ignore config.h

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -17,6 +17,7 @@ autom4te.cache
 /aclocal.m4
 /compile
 /config.guess
+/config.h
 /config.h.in
 /config.log
 /config.status


### PR DESCRIPTION
**Reasons for making this change:**

`config.h` is one of the files generated by `configure` and should not be tracked

**Links to documentation supporting these rule changes:**

https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.70/html_node/Configuration-Headers.html#Configuration-Headers
