### PR TITLE
Python: Ignore PyCharm settings folder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# PyCharm project settings
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**

PyCharm is very popular IDE in Python community.
I teach Python and every week there is a new group of around 15 people setting up IDE and cloning brand new repo from Github. Currently PyCharm settings folder is included on commit, which renders conflicts on checkouts.

I believe that for sake of simplicity, the new repository should have this folder excluded by default.
If someone knows why, he/she wants to share it, than this person can remove the entry from `.gitignore` file.

In my experience the majority will benefit from that.
To be honest in 11 years of my Python programming I have never encountered a case, when adding this folder to VCS would be beneficial to product.

**Links to documentation supporting these rule changes:**

* https://stackoverflow.com/a/49238133
* https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-
(note that the last link is for Rider, but has the same problem)

If this is a new template:

* https://www.jetbrains.com/pycharm/
