### PR TITLE
Add SceneDependencyCache to Unity gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -69,3 +69,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Cache files for ECS subscenes
+/[Aa]ssets/SceneDependencyCache
+/[Aa]ssets/SceneDependencyCache.meta


### PR DESCRIPTION
 **Reasons for making this change:**

This is a cache file that should be ignored.

**Links to documentation supporting these rule changes:**

Here is a forum post confirming it should be ignored (see the answer from Unity employee Joachim_Ante):
https://forum.unity.com/threads/scenedependencycache-shouldnt-be-an-asset.863140/