### PR TITLE
Add file from common packaging tool.

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# poetry packaging tool
+poetry.lock


### PR DESCRIPTION
Poetry creates poetry.lock - typically it is not checked in.

**Reasons for making this change:**

This is a commonly used tool for creating Python packages.

**Links to documentation supporting these rule changes:**

