### PR TITLE
first version of Cadence Incisive gitignore files

### DIFF
--- a/Global/Incisive.gitignore
+++ b/Global/Incisive.gitignore
@@ -1,0 +1,20 @@
+################################################################
+# Gitignore for Cadence Incisive
+################################################################
+
+# log / command history
+irun.key
+irun.log
+irun.history
+
+# auto-generated intermediate libraries
+INCA_libs
+
+# generated simulation database
+waves.shm
+
+# generated diagnosis file
+simvision*.diag
+
+# simvision file
+.simvision


### PR DESCRIPTION
**Reasons for making this change:**

Cadence Incisive tool is a common HDL simulator and deserves a dedicated gitignore file (Cadence Virtuoso tool already has one in the same directory), even though it is being replaced by its sucessor Xcelium.

**Links to documentation supporting these rule changes:**

There is no official documentation for these files from Cadence, but the following GitHub repo lists the similar files as well (in Incisive / Xeclium part,as a proof from another person):

https://github.com/cocotb/cocotb/blob/master/.gitignore

If this is a new template:

 - the offical website of its sucessor (Xcelium): https://www.cadence.com/en_US/home/tools/system-design-and-verification/simulation-and-testbench-verification/xcelium-simulator.html
