### PR TITLE
Nuitka Compiler build and dist folders ignored for Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Nuitka Compiler
+*.build
+*.dist


### PR DESCRIPTION
Signed-off-by: Javad <ja7adr@gmail.com>

**Reasons for making this change:**

Nuitka is a python compiler library and after compiling python sources make two folders build and dist.
Build folder is for .c files
Dist folder is output and binary files.

**Links to documentation supporting these rule changes:**

I don't have template.
![nuitka](https://user-images.githubusercontent.com/56496801/106382441-e1f3cd00-63d4-11eb-9997-0b9fe0dbc625.jpg)

