### PR TITLE
Ignore ._*.sln files generated by MacOS finder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -16,6 +16,9 @@
 # Mono auto generated files
 mono_crash.*
 
+# MacOS generated files
+._*.sln
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
Ignores MacOS generated ._SolutionName.sln files.

"They're created to store file information that would otherwise go into an extended attribute on HFS+ (Apple native) or Unix/UFS volumes; in earlier Mac OS this would be the resource fork. Finder file operations will create them automatically to store the icon information, plus Time Machine stores some information in them so if you copy a file backed up via TM it will have that information copied as well."

https://apple.stackexchange.com/a/14981

**Reasons for making this change:**

This is a binary file, that is not generated by Visual Studio, it is generated by MacOS.

**Links to documentation supporting these rule changes:**

https://apple.stackexchange.com/a/14981
