### PR TITLE
Add further minitoc auxiliary files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -154,6 +154,9 @@ acs-*.bib
 *.maf
 *.mlf
 *.mlt
+*.mtc
+*.mlf[0-9]*
+*.mlt[0-9]*
 *.mtc[0-9]*
 *.slf[0-9]*
 *.slt[0-9]*


### PR DESCRIPTION
**Reasons for making this change:**

Ignore auxiliary files used to generate tables of contents, lists of figures & lists of tables.

**Links to documentation supporting these rule changes:**

See §1.3.1 and §1.3.2 of http://mirrors.ctan.org/macros/latex/contrib/minitoc/minitoc.pdf