### PR TITLE
Delete fixed workaround for Gradle

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -10,6 +10,3 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
-
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties


### PR DESCRIPTION
**Reasons for making this change:**

The workaround for https://youtrack.jetbrains.com/issue/IDEA-116898 is fixed now, so we can remove the workaround.

See: https://github.com/github/gitignore/pull/1856#issuecomment-453354946

**Links to documentation supporting these rule changes:**
* https://youtrack.jetbrains.com/issue/IDEA-116898