### PR TITLE
Added DevExpress to gitignore for Delphi

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -24,7 +24,6 @@
 # C++ object files produced when C/C++ Output file generation is configured.
 # Uncomment this if you are not using external objects (zlib library for example).
 #*.obj
-#
 
 # Delphi compiler-generated binaries (safe to delete)
 *.exe
@@ -67,3 +66,6 @@ __recovery/
 
 # Boss dependency manager vendor folder https://github.com/HashLoad/boss
 modules/
+
+# DevExpress - VCL Components for Delphi and C++Builder
+#*.skincfg


### PR DESCRIPTION
**Reasons for making this change:**

DevExpress is a component suite widely used by Delphi developers.

**Links to documentation supporting these rule changes:**

https://www.devexpress.com/products/vcl/