### PR TITLE
Update for PuppeteerSharp

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -360,3 +360,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# PuppeteerSharp users
+.local-chromium
+.local-chromium/


### PR DESCRIPTION
**Reasons for making this change:**

Many developers using PuppeteerSharp may accidentally push their local chrome install up to their git repo (which is like 200mb of files that goes into the commit log).