### PR TITLE
Ignore `.env.production` in Node.js

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -70,7 +70,7 @@ web_modules/
 
 # dotenv environment variables file
 .env
-.env.test
+.env.*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -70,7 +70,8 @@ web_modules/
 
 # dotenv environment variables file
 .env
-.env.*
+.env.test
+.env.production
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
**Reasons for making this change:**

See https://github.com/search?q=filename%3A.env.production

<img width="782" alt="スクリーンショット 2021-02-16 3 02 47" src="https://user-images.githubusercontent.com/1180335/107980443-a0ce0080-7003-11eb-9a92-cfab7b7b3446.png">

Then I saw some configurations they contain actual DB passwords, AWS secrets... (So I sent 2 PRs and 1 repository is deleted immediately...)

* I don't know other languages use `.env.production` or not.
* As far as I know, JavaScript projects often have these files.  (e.g. https://github.com/gatsbyjs/gatsby/blob/10dfe011c368e28e8de19f0f5569748ebb9a6bc3/benchmarks/source-contentful/README.md#build-a-site)

I 🙏 this change reduces sad accidents. 

---

FYI: `Rails.gitignore` already has same config from another issue https://github.com/github/gitignore/pull/3065