### PR TITLE
style(Autotools): remove trailing whitespaces

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -44,8 +44,8 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 
-# Generated Makefile 
-# (meta build system like autotools, 
+# Generated Makefile
+# (meta build system like autotools,
 # can automatically generate from config.status script
 # (which is called by configure script))
 Makefile


### PR DESCRIPTION
**Reasons for making this change:**

Two trailing whitespaces are present in the comment.
