### PR TITLE
Added .vscode  in python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# vs code cache
+.vscode 


### PR DESCRIPTION
While using vs code when choosing an interpreter for python, a ".vscode" file is generated and I notice that this is not included in the gitignore file. But I'm recommending to add this to the list. There might be related cache files for other editors, but I just use vs code.

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
