### PR TITLE
.gitignore is not ignoring root files

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,5 +1,5 @@
 # ignore everything in the root.
-*/
+/*
 
 # except the "wp-content" directory.
 !wp-content/

--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,7 @@
-# ignore everything in the root except the "wp-content" directory.
+# ignore everything in the root.
+*/
+
+# except the "wp-content" directory.
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
Using github, I've created new repo and I've generated .gitignore template. After I clone the repo to start working, I paste the wordpress files in that directory and .gitignore is not ignoring the specified files. 
I have this approach and I think it would do well. At least it solves my issues. Could you please take a look?

**Reasons for making this change:**

.gitignore is not ignoring root files.

**Links to documentation supporting these rule changes:**

The final example at the bottom:
https://git-scm.com/docs/gitignore#_examples

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
