### PR TITLE
ignore kicad 5.99+ auto-backups

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -26,3 +26,6 @@ fp-info-cache
 # Exported BOM files
 *.xml
 *.csv
+
+# backups
+/*-backups


### PR DESCRIPTION
KiCad 5.99, presumably 6 as well, puts auto-created backups in a <project>-backups directory locate in the root of the project.

**Reasons for making this change:**
update .gitignore for version 5.99+

**Links to documentation supporting these rule changes:**
[settings_manager.cpp](https://gitlab.com/kicad/code/kicad/-/blob/master/common/settings/settings_manager.cpp#L48)

```
/// Project settings path will be <projectname> + this 
#define PROJECT_BACKUPS_DIR_SUFFIX wxT( "-backups" )
```