### PR TITLE
Update Xojo.gitignore for changes to .obsolete

### DIFF
--- a/Xojo.gitignore
+++ b/Xojo.gitignore
@@ -8,4 +8,4 @@ Debug*/Debug*.exe
 Debug*/Debug*\ Libs
 *.rbuistate
 *.xojo_uistate
-*.obsolete
+*.obsolete*


### PR DESCRIPTION
Updates the *.obsolete ignore to match datestamped .obsolete items from newer IDE versions.

**Reasons for making this change:**

Newer versions of Xojo place a timestamp at the end of the obsolete file / folder names. The previous pattern only matched the old style Filename.obsolete files, and would not match "Filename.obsolete_date_time"

**Links to documentation supporting these rule changes:**

Documentation is not a priority for Xojo at this time. Users of the current IDE will find this issue.

If this is a new template:

 - https://xojo.com
 - https://docs.xojo.com
