### PR TITLE
[R] Drop renv-defined library from R projects

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -41,5 +41,8 @@ vignettes/*.pdf
 # pkgdown site
 docs/
 
+# renv project-library directory
+renv/library/
+
 # translation temp files
 po/*~


### PR DESCRIPTION
Renv can be used to manage the environment for R projects. The ./renv/library directory that is produced when working with renv should not typically be added to version control. 
Please see: https://rstudio.github.io/renv/articles/renv.html#infrastructure-1

**Reasons for making this change:**

This removes the local library directory generated by the R-specific env-management tool 'renv'.

**Links to documentation supporting these rule changes:**

https://rstudio.github.io/renv/articles/renv.html#infrastructure-1
