### PR TITLE
Add newpax

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -166,6 +166,9 @@ _minted*
 # morewrites
 *.mw
 
+# newpax
+*.newpax
+
 # nomencl
 *.nlg
 *.nlo


### PR DESCRIPTION
**Reasons for making this change:**

The package [newpax](https://ctan.org/pkg/newpax) is new on CTAN. It creates `.newpax` for collecting information about the PDF.

**Links to documentation supporting these rule changes:**

https://github.com/u-fischer/newpax/blob/16e70917bc687f512bd54f574ebc9394b31c1b9e/doc/newpax.tex#L170

> \pkg{newpax} writes the information to a file with the extension \texttt{pax} or \texttt{newpax}.