### PR TITLE
update some more type for ansible

### DIFF
--- a/Global/Ansible.gitignore
+++ b/Global/Ansible.gitignore
@@ -1,1 +1,9 @@
+# When a playbook fails by default a .retry file will be created in ~/
 *.retry
+# logging is off by default, unless path defined
+.log
+# files to ignore for both static and dynamic
+.orig
+.bak
+.ini
+.py[co]


### PR DESCRIPTION
**Reasons for making this change:**
Current gitignore for ansible is missing some extension for inventory and log

**Links to documentation supporting these rule changes:**
https://docs.ansible.com/ansible/latest/installation_guide/intro_configuration.html

If this is a new template:

 - **Link to application or project’s homepage**:
https://www.ansible.com/
https://github.com/ansible/ansible
