### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -9,6 +9,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+/Temp
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data


### PR DESCRIPTION
This is just adding the /Temp folder

It is very annoying to work without this addition as you always need to close unity before making commits, I was unaware of why that was a thing for the longest time and it made working with git and Unity quite the pain. Please  accept this change to make the life of some fellow git ignorants (or should I saw gitignore ignorants) easier

KH!

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
