### PR TITLE
Added PlatformIO settings

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -361,7 +361,7 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 
-### PlatformIO ###
+# PlatformIO for Visual Studio Code
 .pioenvs
 .piolibdeps
 .clang_complete

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -362,8 +362,12 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # PlatformIO for Visual Studio Code
+.pio
 .pioenvs
 .piolibdeps
 .clang_complete
 .gcc-flags.json
-.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -360,3 +360,10 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+### PlatformIO ###
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json
+.pio


### PR DESCRIPTION
# Created by https://www.toptal.com/developers/gitignore/api/platformio
# Edit at https://www.toptal.com/developers/gitignore?templates=platformio

**Reasons for making this change:**

PlatformIO is a widely used plugin for Arduino, ESP32 boards. This change might be very useful.

**Links to documentation supporting these rule changes:**

I trust in the web that is linked in the comments.

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_.
