### PR TITLE
Update .gitignore for Idris 2

### DIFF
--- a/Idris.gitignore
+++ b/Idris.gitignore
@@ -1,2 +1,7 @@
+# Idris 2
+*.ttc
+*.ttm
+
+# Idris 1
 *.ibc
 *.o


### PR DESCRIPTION
**Reasons for making this change:**

Idris 2 creates two artifacts during type checking for each module:

`*.ttm` -- metadata
`*.ttc` -- byte code to speed up loading in future

**Links to documentation supporting these rule changes:**

[`*.ttc`](https://idris2.readthedocs.io/en/latest/tutorial/starting.html)
[`*.ttm`](https://github.com/idris-lang/Idris2/blob/master/src/Core/Metadata.idr)


