### PR TITLE
Unity.gitignore update for Rider cache directory

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# JetBrains Rider cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**

Rider creates cache directory called *.idea* in Unity project directory and it was not in the template. I thought it would be good idea to add include it in the template since it's being used by a lot of developers. 

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
