### PR TITLE
adds technical note for more info

### DIFF
--- a/community/embedded/IAR_EWARM.gitignore
+++ b/community/embedded/IAR_EWARM.gitignore
@@ -1,5 +1,5 @@
 # gitignore template for the IAR EWARM
-# website: https://www.iar.com/
+# website: https://www.iar.com/knowledge/support/technical-notes/ide/which-files-should-be-version-controlled/
 
 # Some tools will put the EWARM files
 # under a subdirectory with the same name


### PR DESCRIPTION
**Reasons for making this change:**

Replaces the generic link to the IAR Workbench website with a link to a technical note explaining which files are valid for version control. Provides more context for the contents of this gitignore file.

**Links to documentation supporting these rule changes:**

Not documentation, but a relevant technical note

If this is a new template:

 - **Link to application or project’s homepage**: n/a
