### PR TITLE
update env files ignore only local

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -68,9 +68,9 @@ web_modules/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
-.env
-.env.test
+# Local env files
+.env.local
+.env.*.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
**Reasons for making this change:**

`.env` is necessary.

**Links to documentation supporting these rule changes:**

https://cli.vuejs.org/guide/mode-and-env.html#environment-variables
