### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -71,4 +71,4 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
 # macOS local file
-.DS_Store
+**/.DS_Store

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -69,3 +69,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# macOS local file
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

macOS generates a .DS_Store locally for OS level attributes.

**Links to documentation supporting these rule changes:**

https://www.jeffgeerling.com/blogs/jeff-geerling/stop-letting-dsstore-slow-you

