### PR TITLE
Adding visual studio code config folder to the visual studio gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -32,6 +32,9 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+#vscode settings
+.vscode/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot


### PR DESCRIPTION
Reasons for making this change:

I always end up adding this to my .gitignore file in all my vscode projects. You may argue that vscode is beyond the scope the visual studio realm. However it still has visual studio on its name.

Links to documentation supporting these rule changes:

A VS Code "workspace" is usually just your project root folder. Workspace settings as well as debugging and task configurations are stored at the root in a .vscode folder.

If this is a new template:

NA

