### PR TITLE
Add local configuration files to Vim.gitignore

### DIFF
--- a/Global/Vim.gitignore
+++ b/Global/Vim.gitignore
@@ -17,3 +17,6 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# Local configuration files
+.vim/


### PR DESCRIPTION
When using coc.nvim (https://github.com/neoclide/coc.nvim), sometimes a
local configuration file is created at .vim/coc-settings.json, so it was
ignored.

I am not sure whether this directory is used by coc only or other
packages as well, so for now I think it is better to just ignore the
whole .vim/ directory.

A link to the documentation of coc's local configuration file:
https://github.com/neoclide/coc.nvim/blob/ba262ef03029c3fd6a5062bebce7d8553e3b1a1f/doc/coc.txt#L2230