### PR TITLE
Create template for .NET

### DIFF
--- a/DotNet.gitignore
+++ b/DotNet.gitignore
@@ -1,0 +1,35 @@
+# Package management
+nupkg/
+packages/
+
+# Visual Studio Code
+.vscode
+
+# Rider
+.idea
+
+# Visual Studio
+.vs/
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+*.sln.DotSettings.user
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn


### PR DESCRIPTION
**Reasons for making this change:**

A template for .NET does not exist at the moment. Since there are so many .NET projects on GitHub, there should be a template.

**Links to documentation supporting these rule changes:**

[This is one `.gitignore` file from the .NET Core team at Microsoft](https://github.com/dotnet/core/blob/main/.gitignore)

If this is a new template:

 - **Link to application or project’s homepage**: https://github.com/dotnet/core/blob/main/.gitignore
