### PR TITLE
Update ArchLinuxPackages.gitignore

### DIFF
--- a/ArchLinuxPackages.gitignore
+++ b/ArchLinuxPackages.gitignore
@@ -8,6 +8,7 @@
 *.log
 *.log.*
 *.sig
+*.zst
 
 pkg/
 src/


### PR DESCRIPTION
Added zst package extension

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
