### PR TITLE
Update Coq.gitignore

### DIFF
--- a/Coq.gitignore
+++ b/Coq.gitignore
@@ -10,6 +10,7 @@
 *.glob
 *.ml.d
 *.ml4.d
+*.mlg.d
 *.mli.d
 *.mllib.d
 *.mlpack.d
@@ -20,7 +21,7 @@
 *.vo
 *.vok
 *.vos
-.coq-native/
+.coq-native
 .csdp.cache
 .lia.cache
 .nia.cache
@@ -31,6 +32,7 @@ lia.cache
 nia.cache
 nlia.cache
 nra.cache
+native_compute_profile_*.data
 
 # generated timing files
 *.timing.diff


### PR DESCRIPTION
Coq now uses .mlg rather than .ml4 (since https://github.com/coq/coq/pull/8763), so we have to ignore its generated dependency files.  The `native_compute_profile_*.data` files are generated by `Set NativeCompute Profiling` (see https://github.com/coq/coq/pull/950).  Finally `.coq-native` is a directory that may be generated in any subdirectory, not only at top level, so we should not use absolute paths for it.