### PR TITLE
Windows: Exclude zone identifier files.

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -22,3 +22,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Windows download location security zone metafile
+*:Zone.Identifier


### PR DESCRIPTION
https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/ms537183(v=vs.85)

tl;dr 'where the heck did this file come from'.  
Note the files do not only apply to IE downloads.

**Reasons for making this change:**

Windows adds the files, they are unwanted to be synced/added.
