### PR TITLE
add scala jvm crash logs

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -1,2 +1,5 @@
 *.class
 *.log
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
**Reasons for making this change:**
add in scala  jvm crash logs

**Links to documentation supporting these rule changes:**

http://www.java.com/en/download/help/error_hotspot.xml
