### PR TITLE
Add nuget.config file

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -205,6 +205,9 @@ PublishScripts/
 *.nuget.props
 *.nuget.targets
 
+# Nuget personal access tokens and Credentials
+nuget.config
+
 # Microsoft Azure Build Output
 csx/
 *.build.csdef


### PR DESCRIPTION
Add nuget.config file because it may contain secret data and should be kept localy

This file may contain tokens and passwords which are secret data. They shouldn't be pushed to github.

_TODO_

it can be seen here [in this tutorial](https://docs.github.com/en/packages/guides/configuring-dotnet-cli-for-use-with-github-packages#authenticating-with-a-personal-access-token) that this file may contain secret data.
