### PR TITLE
Add missing extension for GregorioTeX

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -120,6 +120,7 @@ acs-*.bib
 
 # gregoriotex
 *.gaux
+*.glog
 *.gtex
 
 # htlatex


### PR DESCRIPTION
**Reasons for making this change:**

Existing rules cover only two of three temporary file types.

**Links to documentation supporting these rule changes:**

<https://github.com/gregorio-project/gregorio/search?q=glog>
