### PR TITLE
Ignore dotenv in dart

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -11,6 +11,10 @@ pubspec.lock
 # If you don't generate documentation locally you can remove this line.
 doc/api/
 
+# dotenv environment variables file
+.env
+.env.test
+
 # Avoid committing generated Javascript files:
 *.dart.js
 *.info.json      # Produced by the --dump-info flag.


### PR DESCRIPTION
**Reasons for making this change:**
Ignoring dotenv files to avoid leaking secrets on Github

**Links to documentation supporting these rule changes:**
Reason for ignoring the dotenv file on GitHub
https://blog.gitguardian.com/secrets-api-management/#git-ignore
dotenv package on pub.dev
https://pub.dev/packages/flutter_dotenv