### PR TITLE
Ignore Eclipse .project and .classpath when using build tools Maven or Gradle

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -11,5 +11,11 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties

--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -9,3 +9,9 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath


### PR DESCRIPTION
**Reasons for making this change:**

Eclipse `.project` and `.classpath` files should be ignored when using a build tool like Maven or Gradle.  However, when not using a build tool, these files should be under source control.

**Links to documentation supporting these rule changes:**

There has been alot of back and forth on the `.project` and `.classpath` files within Eclipse, but I think [this comment](https://github.com/github/gitignore/pull/2336#commitcomment-22133400) sums it up nicely.

The consensus is that these files should not be ignored in all Eclipse projects.  However, when a build system such as Maven or Gradle is used, these files *should* be ignored because they will be generated by the Eclipse plugin for the build tool.  Therefore, adding these files to the Maven and Gradle gitignore files should cover all scenarios.
