### PR TITLE
Add PR Labeler GitHub Actions: Triage PRs based on modified files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+java:
+  - Java.gitignore
+
+macos:
+  - Global/macOS.gitignore

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Reasons for making this change:**

Numerous PRs for various languages' gitignore are made every day. Different reviewers know different languages.
It's bothersome for reviewers to sort out ones that they can review.

This PR adds a GitHub-official Action, [Pull Request Labeler](https://github.com/actions/labeler), which triages PRs based on the paths that are modified in the PR.  Namely, when a PR on `Java.gitignore` is made, a label **java** is attached.

This PR is WIP.  If this sounds nice, let me know so I can complete it.