### PR TITLE
Added missing ignore on VisualStudio.gitignore.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -360,3 +360,8 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Created by Finder on Mac or JetBrains Rider on Mac.
+# I am sick and tired of cloning .NET Repositories that uses this .gitignore
+# but does not ignore these.
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

When opening an .NET Repository in Finder or even in JetBrains Rider on mac these generated files generate unneeded noise and should be ignored by every repository in the future that uses this .gitignore.

This feels like a common thing to me on this.

Bonus Points: for all the repositories that use this .gitignore for some bot that can autosync their .gitignore with the one from here.

**Links to documentation supporting these rule changes:**

No links to any docs are know, all I do know is that not ignoring .DS_Store generated on a mac recursively inside every directory on the repository is annoying as heck.
