### PR TITLE
Update Dart.gitignore

### DIFF
--- a/Dart.gitignore
+++ b/Dart.gitignore
@@ -12,8 +12,7 @@ pubspec.lock
 doc/api/
 
 # dotenv environment variables file
-.env
-.env.test
+.env*
 
 # Avoid committing generated Javascript files:
 *.dart.js


### PR DESCRIPTION
**Reasons for making this change:**

Merged this https://github.com/github/gitignore/pull/3709 earlier today. However, per the docs provided, it is recommended as .env*.

**Links to documentation supporting these rule changes:**

https://pub.dev/packages/flutter_dotenv

If this is a new template:

 - https://pub.dev/
 
