### PR TITLE
Ignore .mpf file (project file)

### DIFF
--- a/Global/ModelSim.gitignore
+++ b/Global/ModelSim.gitignore
@@ -1,6 +1,10 @@
 # ignore ModelSim generated files and directories (temp files and so on)
 [_@]*
 
+# ignore the project file, can create errors on different machines 
+# add new files to project manually  
+.mpf
+
 # ignore compilation output of ModelSim
 *.mti
 *.dat


### PR DESCRIPTION
It creates conflicts with different directories

**Reasons for making this change:**

To Avoid conflicts in the directories on different machines 

**Links to documentation supporting these rule changes:**

Happened to us while working on a project
