### PR TITLE
added package-lock.json to ignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -40,6 +40,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+package-lock.json
 
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/


### PR DESCRIPTION
**Reasons for making this change:**

package-lock.json is a very big file that's created while installing the dependencies, so we can ignore this file also.


