### PR TITLE
Handle .dll.refresh

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -27,7 +27,8 @@ x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
-[Bb]in/
+**/[Bb]in/*
+!**/[Bb]in/*.refresh
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -27,11 +27,15 @@ x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
-**/[Bb]in/*
-!**/[Bb]in/*.refresh
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+
+# Build results on 'Bin' directories
+**/[Bb]in/*
+# Uncomment if you have tasks that rely on *.refresh files to move binaries
+# (https://github.com/github/gitignore/pull/3736)
+#!**/[Bb]in/*.refresh
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/


### PR DESCRIPTION
While working on a classic **ASP.NET Web Site** I noticed that the `*.dll.refresh` files created by **NuGet package manager** within the `bin` directory were ignored from source control. 

Since these kind of projects don't include a `.vbproj` or `.csproj`, the `*.dll.refresh` files should be included in souce control to instruct the builder to copy the `*.dll` files restaured within the `packages` directory to the `bin` directory inside the website. 

**Links to documentation supporting these rule changes:**

- http://monsur.xanga.com/2006/02/03/dll-refresh-and-asp-net/
- https://stackoverflow.com/questions/5976406/using-nuget-with-dll-refresh-files-in-asp-net-web-site-projects-with-web-dep
- https://forums.asp.net/t/1850739.aspx?dll+refresh+update
