### PR TITLE
Add template file

### DIFF
--- a/community/Gretl.gitignore
+++ b/community/Gretl.gitignore
@@ -1,0 +1,11 @@
+# gitignore template for gretl
+# website: gretl.sourceforge.net/
+#
+# Recommended: gretl.gitignore
+
+# Auto-generated log file is overwritten whenever you start a new session
+session.inp
+
+# Auto-generated zemporary string code table
+string_table.txt
+

--- a/community/Gretl.gitignore
+++ b/community/Gretl.gitignore
@@ -6,6 +6,5 @@
 # Auto-generated log file is overwritten whenever you start a new session
 session.inp
 
-# Auto-generated zemporary string code table
+# Auto-generated temporary string code table
 string_table.txt
-

--- a/community/Gretl.gitignore
+++ b/community/Gretl.gitignore
@@ -1,7 +1,5 @@
 # gitignore template for gretl
 # website: gretl.sourceforge.net/
-#
-# Recommended: gretl.gitignore
 
 # Auto-generated log file is overwritten whenever you start a new session
 session.inp

--- a/community/Gretl.gitignore
+++ b/community/Gretl.gitignore
@@ -1,4 +1,4 @@
-# gitignore template for gretl
+# gitignore template for Gretl
 # website: http://gretl.sourceforge.net/
 
 # Auto-generated log file is overwritten whenever you start a new session

--- a/community/Gretl.gitignore
+++ b/community/Gretl.gitignore
@@ -1,5 +1,5 @@
 # gitignore template for gretl
-# website: gretl.sourceforge.net/
+# website: http://gretl.sourceforge.net/
 
 # Auto-generated log file is overwritten whenever you start a new session
 session.inp


### PR DESCRIPTION
**Reasons for making this change:**

Gretl is an open-source statistics and econometrics software. Even though it's a niche and domain-specific language, there exist already 200+ gretl repositories on github.

Having this .gitignore template-file would be useful on general when working with gretl and git.

**Links to documentation supporting these rule changes:**

- Chapter 3.1. in the  [manual](https://sourceforge.net/projects/gretl/files/manual/gretl-guide-a4.pdf/download) mentions the auto-generated ```session.inp``` file which is just a log-file of the current session.
- Unfortunately, I could not find a mentioning of the auto-generated temporary file ```string_table.txt``` file. This file comprises the mapping from string-valued gretl series to numeric codes, and is only valid as long as a dataset is open. Unfortunately, after closing the gretl session, this file remains and may become part of the versioned source code where it does not belong to. 

If this is a new template:

 - **Link to application or project’s homepage**: http://gretl.sourceforge.net/
