### PR TITLE
Excluding ood.flag in all folders for Umbraco gitignore

### DIFF
--- a/Umbraco.gitignore
+++ b/Umbraco.gitignore
@@ -15,7 +15,7 @@
 **/App_Data/umbraco.config
 
 ## this [Uu]mbraco/ folder should be created by cmd like `Install-Package UmbracoCms -Version 8.5.3` 
-## you can find your umbraco version at your Web.config. (i.e. <add key="Umbraco.Core.ConfigurationStatus" value="8.5.3" />)
+## you can find your Umbraco version in your Web.config. (i.e. <add key="Umbraco.Core.ConfigurationStatus" value="8.5.3" />)
 ## Uncomment this line if you think it fits the way you work on your project.
 ## **/[Uu]mbraco/ 
 
@@ -29,4 +29,4 @@
 **/App_Data/cache/
 
 # Ignore the Models Builder models out of date flag
-**/App_Data/Models/ood.flag
+**/ood.flag


### PR DESCRIPTION
**Reasons for making this change:**

The `ood.flag` file is generated by Umbraco to indicate it's code-first models need regenerating.

This file is automatically created in the root of the folder where it has been designated Umbraco should generate code-first models. It should never be committed to source control.

By default Umbraco stores these files in `/App_Data/Models/*`, however this is [configurable](https://our.umbraco.com/documentation/reference/templating/modelsbuilder/configuration) via the `Umbraco.ModelsBuilder.ModelsDirectory` app setting. In most cases developers will modify this path as files in `App_Data` are not compiled by default by Visual Studio.

Additionally, the upcoming Umbraco V9 release moves the default location of these files to `/umbraco/models/*`.

This change adjusts the ignore rule to apply broadly regardless of where the `odd.flag` file lives.