### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -59,6 +59,7 @@ sysinfo.txt
 *.apk
 *.aab
 *.unitypackage
+*.app
 
 # Crashlytics generated file
 crashlytics-build.properties


### PR DESCRIPTION
**Reasons for making this change:**

When you build and run a game in macOS, the default path is `{ProjectRootFolder}/{SavedName}.app`, that's because I ignored `*.app`.