### PR TITLE
Restructuing README.md contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,36 +59,6 @@ Our aim is to curate a collection of the _most common and helpful_ templates,
 not to make sure we cover every project possible. If we choose not to
 include your language, tool, or project, it’s not because it’s not awesome.
 
-## Contributing guidelines
-
-We’d love for you to help us improve this project. To help us keep this collection
-high quality, we request that contributions adhere to the following guidelines.
-
-- **Provide a link to the application or project’s homepage**. Unless it’s
-  extremely popular, there’s a chance the maintainers don’t know about or use
-  the language, framework, editor, app, or project your change applies to.
-
-- **Provide links to documentation** supporting the change you’re making.
-  Current, canonical documentation mentioning the files being ignored is best.
-  If documentation isn’t available to support your change, do the best you can
-  to explain what the files being ignored are for.
-
-- **Explain why you’re making a change**. Even if it seems self-evident, please
-  take a sentence or two to tell us why your change or addition should happen.
-  It’s especially helpful to articulate why this change applies to _everyone_
-  who works with the applicable technology, rather than just you or your team.
-
-- **Please consider the scope of your change**. If your change is specific to a
-  certain language or framework, then make sure the change is made to the
-  template for that language or framework, rather than to the template for an
-  editor, tool, or operating system.
-
-- **Please only modify _one template_ per pull request**. This helps keep pull
-  requests and feedback focused on a specific project or technology.
-
-In general, the more you can do to help us understand the change you’re making,
-the more likely we’ll be to accept your contribution quickly.
-
 ## Versioned templates
 
 Some templates can change greatly between versions, and if you wish to contribute
@@ -133,6 +103,37 @@ ExportedFiles.xml
 !Model/Portal/*/SupportFiles/[Bb]in/
 !Model/Portal/PortalTemplates/*/SupportFiles/[Bb]in
 ```
+
+## Contributing guidelines
+
+We’d love for you to help us improve this project. To help us keep this collection
+high quality, we request that contributions adhere to the following guidelines.
+
+- **Provide a link to the application or project’s homepage**. Unless it’s
+  extremely popular, there’s a chance the maintainers don’t know about or use
+  the language, framework, editor, app, or project your change applies to.
+
+- **Provide links to documentation** supporting the change you’re making.
+  Current, canonical documentation mentioning the files being ignored is best.
+  If documentation isn’t available to support your change, do the best you can
+  to explain what the files being ignored are for.
+
+- **Explain why you’re making a change**. Even if it seems self-evident, please
+  take a sentence or two to tell us why your change or addition should happen.
+  It’s especially helpful to articulate why this change applies to _everyone_
+  who works with the applicable technology, rather than just you or your team.
+
+- **Please consider the scope of your change**. If your change is specific to a
+  certain language or framework, then make sure the change is made to the
+  template for that language or framework, rather than to the template for an
+  editor, tool, or operating system.
+
+- **Please only modify _one template_ per pull request**. This helps keep pull
+  requests and feedback focused on a specific project or technology.
+
+In general, the more you can do to help us understand the change you’re making,
+the more likely we’ll be to accept your contribution quickly.
+
 
 ## Contributing workflow
 


### PR DESCRIPTION
**Reasons for making this change:**

Making README contents more logically positioned. ( Example : Placing Contributing guide with Contributing Workflow )
