### PR TITLE
Add line to ignore JetBrains IDE cache directory

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# JetBrains cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**

To ignore the `.idea/` directory generated by the use of [JetBrains IDE (mainly JetBrains Rider)](https://www.jetbrains.com/rider/)

The `.idea/` directory is similar to the `.vs/` directory in that it's mainly for settings/configurations. The majority of users will likely ignore this directory entirely. My assumption would be that the number of people ignoring the directory outweighs the number including it. There are minimal benefits to including it in the first place.

I could be wrong, haha but I have used this gitignore for so long and every time, I find myself ignoring the `.idea/` directory and figured I can't be the only one.

**Links to documentation supporting these rule changes:**

[JetBrains Rider (also linked above)](https://www.jetbrains.com/rider/)
[What is the .idea/ folder?](https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-)
