### PR TITLE
Allow Directory.Build.rsp

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -386,3 +386,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Human-generated .rsp files
+![Dd]irectory.[Bb]uild.rsp


### PR DESCRIPTION
**Reasons for making this change:**

This would typically be a human-generated file, not one generated by VS. 

**Links to documentation supporting these rule changes:**

https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files?view=vs-2019#directorybuildrsp
