### PR TITLE
Added LensStudio.gitignore (Ted Brown)

### DIFF
--- a/community/LensStudio.gitignore
+++ b/community/LensStudio.gitignore
@@ -1,0 +1,13 @@
+# macOS/IDE #
+.DS_Store
+.idea
+
+# js #
+node_modules
+yarn.lock
+
+# Python #
+__pycache__/
+*.py[cod]
+*$py.class
+[Bb]ackup*

--- a/community/LensStudio.gitignore
+++ b/community/LensStudio.gitignore
@@ -1,3 +1,6 @@
+# gitignore template for LensStudio
+# website: https://lensstudio.snapchat.com/
+
 # macOS/IDE #
 .DS_Store
 .idea


### PR DESCRIPTION
**Reasons for making this change:**

LensStudio lenses do not have a known gitignore. Lens Studio is a Snapchat desktop tool used for building Lenses used in the Snapchat app

**Links to documentation supporting these rule changes:**

No link. These are typical of the language stack (more lens studio specific files may be added at a later time)

If this is a new template:

 - **Link to application or project’s homepage**: https://lensstudio.snapchat.com/guides/getting-started/
