### PR TITLE
Gnuplot ignored in TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -115,6 +115,10 @@ acs-*.bib
 # uncomment this for glossaries-extra (will ignore makeindex's style files!)
 # *.ist
 
+# gnuplot
+*.gnuplot
+*.table
+
 # gnuplottex
 *-gnuplottex-*
 


### PR DESCRIPTION
**Reasons for making this change:**

When using `TikZ` (`TeX` package), it is possible to plot function using `Gnuplot`.
During the process, `.gnuplot` and `.table` files will be created.
Same as: #1422 (was closed due to inactivity)


**Links to documentation supporting these rule changes:**

Chapter 22.6: "Plotting a Function Using Gnuplot" of the TikZ documentation.
Available here: [CTAN](http://mirrors.ctan.org/graphics/pgf/base/doc/pgfmanual.pdf)