### PR TITLE
Remove `*.jar` from Java.gitignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -11,7 +11,6 @@
 .mtj.tmp/
 
 # Package Files #
-*.jar
 *.war
 *.nar
 *.ear


### PR DESCRIPTION
Though it's not a great practice to store dependencies in version
control, it's very common among enterprises to keep jar files in their
source trees.