### PR TITLE
Add `.idea/jarRepositories.xml` to Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -44,6 +44,7 @@ captures/
 .idea/assetWizardSettings.xml
 .idea/dictionaries
 .idea/libraries
+.idea/jarRepositories.xml
 # Android Studio 3 in .gitignore file.
 .idea/caches
 .idea/modules.xml


### PR DESCRIPTION
The file `.idea/jarRepositories.xml` should be added to .gitignore. 
It is auto-generated and has only redundant information about remote jar repositories.
* https://www.jetbrains.com/help/idea/library.html#configure-custom-remote-repo