### PR TITLE
Added Django gitignore template

### DIFF
--- a/community/Python/django.gitignore
+++ b/community/Python/django.gitignore
@@ -1,0 +1,19 @@
+### Django gitignore template###
+### [Official Website](https://www.djangoproject.com/) ###
+*.log
+*.pot
+*.pyc
+__pycache__/
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+media
+
+# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
+# in your Git repository. Update and uncomment the following line accordingly.
+# <django-project-name>/staticfiles/
+
+### Django.Python Stack ###
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class


### PR DESCRIPTION
**Reasons for making this change:**

To help beginners to track only necessary files via Git while they are using the Django framework

If this is a new template:

 - **Link to application or project’s homepage**: [Official Website](https://www.djangoproject.com/)
