### PR TITLE
Ignore misc files added by VSCode for Maven

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -9,3 +9,6 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
+.settings/
+.project
+.classpath


### PR DESCRIPTION
**Reasons for making this change:**

VSCode adds some misc files which are not meant to be pushed to source control.

<img width="1077" alt="Screenshot 2021-06-14 at 1 19 50 PM" src="https://user-images.githubusercontent.com/35298207/121857448-458eef00-cd13-11eb-95f4-51d51e854d95.png">

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
