### PR TITLE
Dual license (add MIT)

### DIFF
--- a/LICENSE.mit
+++ b/LICENSE.mit
@@ -1,0 +1,7 @@
+Copyright 2021 Brian Douglas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.mit
+++ b/LICENSE.mit
@@ -1,4 +1,4 @@
-Copyright 2021 Brian Douglas
+Copyright 2010-2021 GitHub, Inc. and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -152,4 +152,6 @@ by automatically forking the project and prompting to send a pull request too.
 
 ## License
 
-[CC0-1.0](./LICENSE).
+This work is dual-licensed under [CC0-1.0](./LICENSE) and [MIT](./LICENSE.mit), or any later version of both licenses. You can choose between one of them if you use this work.
+
+`SPDX-License-Identifier: CC0-1.0 OR MIT`


### PR DESCRIPTION
**Reasons for making this change:**

Licensing can be confusing. I'm not sure if I can use the `.gitignore` files in my MIT project, and Google searching is ambiguous. 
Dual licensing allows users to use the `.gitignore` files in their MIT-licensed repos without worrying about license conflicts.

**Links to documentation supporting these rule changes:**

[License_compatibility](https://en.wikipedia.org/wiki/License_compatibility) on Wikipedia. Long, cumbersome - let's avoid it.

