### PR TITLE
Update VS Code file spec

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,5 +1,6 @@
 # Visual Studio 2015 user specific files
 .vs/
+.vscode/
 
 # Compiled Object files
 *.slo
@@ -40,6 +41,7 @@
 *.sdf
 *.VC.db
 *.VC.opendb
+*.code-workspace
 
 # Precompiled Assets
 SourceArt/**/*.png


### PR DESCRIPTION
**Reasons for making this change:**

The current gitgnore doesn't account for VS Code files generated by the engine.

**Links to documentation supporting these rule changes:**

https://docs.unrealengine.com/4.26/en-US/WhatsNew/Builds/ReleaseNotes/4_18/
Granted it's not as refined as Rider or Visual Studio support, with the [right extensions](https://github.com/boocs/ue4-intellisense-fixes) it works like a charm.

