### PR TITLE
Revert "[Python] .python-version should NOT be ignored (#3274)"

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -83,9 +83,7 @@ profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.


### PR DESCRIPTION
This reverts commit 583f11eddde230f6df9f1cece498be98c3a90773.

**Reasons for making this change:**

I strongly disagree with the change made in #3274. `.python-version` is a detail of a specific local environment and is far from being flexible enough to be checked in to a project to determine the Python version to be used.

* It cannot contain a version like `3.6`, let alone `>=3.6`. It must be an exact Python version number down to the patch level, such as `3.6.10`.
* The other option for its value is either `system` or the name of a pyenv virtualenv, which is equally nonsensical to check in to VCS.

This makes it extremely error-prone, as attempting to run Python in the project's directory will simply fail if you don't have the exact required version down to the patch level, which becomes an unnecessary maintenance burden for both the maintainer and every individual developer.

There are far better solutions for checking in supported Python versions to a project, such as `pyproject.toml` (Poetry) or `Pipfile` (Pipenv). The former allows specifying arbitrary ranges, while the latter at least allows specifying a less granular version like `3.6` or `3`.

Therefore `.python-version` **SHOULD** be ignored by default. Even for something that's not meant to be an imported library, the only reason I see for checking it in is if you're only ever working in environments where every version (including Python itself) is strictly controlled down to the patch level. I know we're in the age of Docker and all, but realistically not everyone will exclusively use Docker, and generally there's no reason to hold back on patch updates if a guarantee is provided to not break things, so I consider wanting to check this file in a very niche use case that should not be the default.

(There are some cases where you may need a minimum of something like 3.7.1 due to a bugfix, but the same generally doesn't hold the other way around - a newer patch release is extremely unlikely to break things.)