### PR TITLE
Create Hugo.gitignore

### DIFF
--- a/Hugo.gitignore
+++ b/Hugo.gitignore
@@ -1,0 +1,16 @@
+# HUGO
+# https://gohugo.io/
+# https://github.com/gohugoio/hugo
+# Hugo is a static HTML and CSS website generator written in Go. 
+# It is optimized for speed, ease of use, and configurability. 
+# Hugo takes a directory with content and templates and renders them into
+# a full HTML website.
+
+# Hugo build output 
+# https://gohugo.io/getting-started/usage/#the-hugo-command
+/public/
+
+# Resource Cache
+# (Can optionally be committed to Git to cache resource generation)
+# https://discourse.gohugo.io/t/why-does-hugo-create-the-resources-directory/13021/3
+/resources/


### PR DESCRIPTION
Hugo is a popular static website generator written in Go.  
https://github.com/gohugoio/hugo (50k stars)
https://gohugo.io/

This proposal includes two common rules:
1. The `public` folder (rooted) is for build output 
2. The resource cache folder (rooted) (which, as noted, is generated but can be included in a repo as an optimization)

**Reasons for making this change:**

Hugo is a popular site generator where it's common practice for the site content to be managed in a Git repo.

**Links to documentation supporting these rule changes:**

(inline)

If this is a new template:

https://github.com/gohugoio/hugo (50k stars)
