### PR TITLE
add `.idea/misc.xml` to Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -45,6 +45,7 @@ captures/
 .idea/dictionaries
 .idea/libraries
 .idea/jarRepositories.xml
+.idea/misc.xml
 # Android Studio 3 in .gitignore file.
 .idea/caches
 .idea/modules.xml


### PR DESCRIPTION
**Reasons for making this change:**

`.idea/misc.xml` may contain platform specific paths and even could ship more sensitive data.

**Links to documentation supporting these rule changes:**

* [gitignore - Should we ignore misc.xml and .iml in Pycharm .idea/ folder? - Stack Overflow](https://stackoverflow.com/questions/38590022/should-we-ignore-misc-xml-and-projectfoldername-iml-in-pycharm-idea-folder)
* [How to manage projects under Version Control Systems – IDEs Support (IntelliJ Platform) | JetBrains](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839?page=1#comment_201076815)
