### PR TITLE
Python.gitginore: add configuration directory by pycharm-jetbrains IDE

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# PyCharm/JetBrains IDE project configuration directory
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**
Pycharm/JetBrain IDE on MacOS create .idea/ directory to store its local project configuration which is not required by other developers or to be store on Git repository. So adding this extension in .gitignore file makes sense.

_TODO_

**Links to documentation supporting these rule changes:**
https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
