### PR TITLE
Add OneNote TOC files

### DIFF
--- a/Global/MicrosoftOffice.gitignore
+++ b/Global/MicrosoftOffice.gitignore
@@ -17,3 +17,6 @@ Backup of *.doc*
 
 # Visio autosave temporary files
 *.~vsd*
+
+# OneNote TOC Files; they are auto-generated and change constantly.
+*.onetoc*


### PR DESCRIPTION
**Reasons for making this change:**

OneNote TOC (Table Of Contents) files are pervasive and get generated everywhere OneNote Lives.

