### PR TITLE
added JENKINS_HOME/users as comment at JENKINS_HOME example

### DIFF
--- a/JENKINS_HOME.gitignore
+++ b/JENKINS_HOME.gitignore
@@ -46,5 +46,11 @@ jobs/**/*workspace
 
 #!/secret*
 
+# Security warning: Following includes Jenkins' account settings
+# "user name", "password hash" and so on.
+# So, uncomment when it's not problem the settings are published in Git.
+
+# !/users
+
 # As a result, only Jenkins settings and job config.xml files in JENKINS_HOME
 # will be tracked by git.

--- a/JENKINS_HOME.gitignore
+++ b/JENKINS_HOME.gitignore
@@ -46,7 +46,7 @@ jobs/**/*workspace
 
 #!/secret*
 
-# Security warning: Following includes Jenkins' account settings
+# Security warning: Following includes Jenkins's account settings
 # "user name", "password hash" and so on.
 # So, uncomment when it's not problem the settings are published in Git.
 


### PR DESCRIPTION
**Reasons for making this change:**

Because of improvements after my docker-compose project experience.

* I build [jenkins/jenkins:lts-jdk11](https://hub.docker.com/r/jenkins/jenkins) by `docker-compose build` in machine A.
    * example project is at (*1)
* After built, admin is saved as `id = root, password = mypass` at A.
    * And I pushed source with [current .gitignore](https://github.com/github/gitignore/blob/81ebaeca4185e2e44e589d6cb3e88cbfc7e0895c/JENKINS_HOME.gitignore) on github.
* Then I pulled and built by `docker-compose` in another machine B.
    * B can't login as `root / mypass`, while A can.
* I found the reason because `JENKINS_HOME/users` is not pushed in repository.
    * A has settings files in `JENKINS_HOME/users`, but B does not

<details>
    <summary>(*1) jenkins by docker-compose</summary>

```
+ Dockerfile
+ docker-compose.yml
+ jenkins/home
    + .gitignore(current project version 81ebae)
```

**Dockerfile**

```
FROM ubuntu:20.04
RUN mkdir -p /usr/src/app

RUN apt-get update
WORKDIR /usr/src/app
```

**docker-compose.yml**

```
version: '3'
services:
  jenkins:
    image: jenkins/jenkins:lts-jdk11
    ports:
      - '8080:8080'
      - '50000:50000'
    volumes:
      - './jenkins/home:/var/jenkins_home'
```

</details>

**Links to documentation supporting these rule changes:**

NO Docs. This comes from my experience.