### PR TITLE
Update Drupal.gitignore

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -1,4 +1,4 @@
-# gitignore template for Drupal 8 projects
+# gitignore template for Drupal 8 and 9 projects
 #
 # earlier versions of Drupal are tracked in `community/PHP/`
 


### PR DESCRIPTION
**Reasons for making this change:**

This template is also valid for Drupal 9. As a matter of fact, when starting new projects you _should_ use Drupal 9. And 8 is only supported until November 2021.

**Links to documentation supporting these rule changes:**

https://www.drupal.org/project/drupal