### PR TITLE
Os depend

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -1,3 +1,6 @@
+# OS depend
+.DS_Store
+
 # Compiled class file
 *.class
 

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -1,3 +1,6 @@
+# OS depend
+.DS_Store
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore


### PR DESCRIPTION
**Reasons for making this change:**

Operating systems create unwanted files in directory structures. For example macOS create a file .DS_Store when you browse with Finder. This file should not add to GitHub repository

**Links to documentation supporting these rule changes:**

See https://en.wikipedia.org/wiki/.DS_Store 


**Extensions needed**
It seems not a bad idea to integrate same for Windows Thumbs.db and also do it in all gitignore files

