### PR TITLE
Create hugo.gitignore

### DIFF
--- a/hugo.gitignore
+++ b/hugo.gitignore
@@ -1,0 +1,8 @@
+### Hugo ###
+# Generated files by hugo
+/public/
+/resources/
+# Executable may be added to repository
+hugo.exe
+hugo.darwin
+hugo.linux


### PR DESCRIPTION
**Reasons for making this change:**

It will be beautiful to have a template for Hugo site based on GitHub

**Links to documentation supporting these rule changes:**

[Public and resources is place for generated files so not "source code"](https://gohugo.io/getting-started/configuration/#all-configuration-settings)

If this is a new template:

 - **Link to application or project’s homepage**:  [Hugo](https://gohugo.io/)
