### PR TITLE
Added wildcard to crash.log because the newer versions of Terraform c…

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -6,7 +6,7 @@
 *.tfstate.*
 
 # Crash log files
-crash.log
+crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sentitive data, such as
 # password, private keys, and other secrets. These should not be part of version 

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -6,6 +6,7 @@
 *.tfstate.*
 
 # Crash log files
+crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sentitive data, such as


### PR DESCRIPTION

**Reasons for making this change:**
 Added wild card to crash.log because the newer versions of Terraform creates crash log with random numbers in between. For example :  crash.105189318.log
