### PR TITLE
fixes CodeIgniter.gitignore deleting a critical framework file

### DIFF
--- a/CodeIgniter.gitignore
+++ b/CodeIgniter.gitignore
@@ -2,6 +2,7 @@
 */logs/log-*.php
 !*/logs/index.html
 */cache/*
+!system/cache/*
 !*/cache/index.html
 !*/cache/.htaccess
 


### PR DESCRIPTION
* Provide a link to the application or project’s homepage: https://github.com/codeigniter4/CodeIgniter4
* Provide links to documentation supporting the change you’re making : https://codeigniter.com/user_guide/concepts/structure.html#system
  > System : This directory stores the files that make up the framework, itself. While you have a lot of flexibility in how you use the application directory, **the files in the system directory should never be modified**.
* Please consider the scope of your change : ok
* Please only modify one template per pull request : ok

### Explain why you’re making a change : 

After spending a lot of time finding why my app won't run on a clean install of my repository, I just noticed that the gitignore I copied introduced a deletion/ignore rule of an internal folder used by the framework.
The current gitignore file deletes the folder `/system/Cache/*` and causes the following error when running the App from the CLI or the web server : `Class "CodeIgniter\Cache\CacheFactory" not found `; making the app unable to run.

I added the following rule to fix this : `!system/Cache/*`.

Note : this won't fix the bug if the system folder is renamed