### PR TITLE
Ignore .idea And .vscode Folders in Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# IDEs
+.idea/
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**

Ignore the folders created by JetBrains IDEs and VS Code

**Links to documentation supporting these rule changes:**

[What is JetBrains .idea folder?](https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-)
[VS Code setting file location](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations)
