### PR TITLE
VisualStudioCode: ignores built vscode extensions

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -7,3 +7,6 @@
 
 # Local History for Visual Studio Code
 .history/
+
+# Built Visual Studio Code Extensions
+*.vsix


### PR DESCRIPTION
**Reasons for making this change:**
When developing Visual Studio Code extensions, which is almost always done in Visual Studio Code, building it creates a VSIX file.
This file doesn't need to be committed to version control.

**Links to documentation supporting these rule changes:**
Documentation to packaging Visual Studio Code extensions:
https://code.visualstudio.com/api/working-with-extensions/publishing-extension#packaging-extensions
