### PR TITLE
Add Pycharm Project Files to Python .gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -117,6 +117,10 @@ venv.bak/
 .spyderproject
 .spyproject
 
+
+# Pycharm
+/.idea
+
 # Rope project settings
 .ropeproject
 

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -119,7 +119,7 @@ venv.bak/
 
 
 # Pycharm
-/.idea
+.idea/
 
 # Rope project settings
 .ropeproject


### PR DESCRIPTION
**Reasons for making this change:**

*[Pycharm](https://www.jetbrains.com/pycharm) is a popular IDE for Python development. It has built-in GitHub integration, but also has a `.idea` folder where it stores project configuration. This doesn't need to be uploaded to GitHub, so I am PRing it to be added to the Python `.gitignore`*