### PR TITLE
Add Replit Project Files to Python `.gitignore`

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -117,6 +117,10 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Replit
+.replit
+nix.replit
+
 # Rope project settings
 .ropeproject
 


### PR DESCRIPTION
**Reasons for making this change:**

*[Replit](https://replit.com) is a popular online IDE that has GitHub integration. This will remove the Replit project files from the GitHub repository.*