### PR TITLE
Add RStudio Connect folder to R gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -43,3 +43,6 @@ docs/
 
 # translation temp files
 po/*~
+
+# RStudio Connect folder
+rsconnect/


### PR DESCRIPTION

**Reasons for making this change:**

RStudio Connect is a way of publishing R content. The rsconnect folder is created to enable publishing, but is specific to a user.

**Links to documentation supporting these rule changes:**

https://community.rstudio.com/t/should-i-include-the-rsconnect-folder-to-gitignore/98237

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
