### PR TITLE
Adding ignore for iCloud Sync

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -4,7 +4,8 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -24,3 +25,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Created by iCloud Sync
+*.icloud


### PR DESCRIPTION
**Reasons for making this change:**

iCloud Sync add's files with an `.icloud` extension

**Links to documentation supporting these rule changes:**

https://www.sync.com/help/why-do-my-files-have-an-icloud-extension/
