### PR TITLE
Actually "ignore everything in the root"

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,5 @@
 # ignore everything in the root except the "wp-content" directory.
+/*
 !wp-content/
 
 # ignore everything in the "wp-content" directory, except:


### PR DESCRIPTION
**Reasons for making this change:**

The existing Wordpress `.gitignore` doesn't "ignore everything in the root". In order to do so, we have to ignore `/*`.

**Links to documentation supporting these rule changes:**

None. Umm, it just doesn't work as currently implemented.
