### PR TITLE
Add nix gitignore template

### DIFF
--- a/community/Nix.gitignore
+++ b/community/Nix.gitignore
@@ -1,0 +1,3 @@
+# Ignore build outputs from performing a nix-build or `nix build` command
+result
+result-*


### PR DESCRIPTION
**Reasons for making this change:**

Add nix .gitignore template

**Links to documentation supporting these rule changes:**

https://nixos.org/manual/nix/unstable/command-ref/nix-build.html#description

> The nix-build command builds the derivations described by the Nix expressions in paths. If the build succeeds, it places a symlink to the result in the current directory. The symlink is called result. If there are multiple Nix expressions, or the Nix expressions evaluate to multiple derivations, multiple sequentially numbered symlinks are created (result, result-2, and so on).

If this is a new template:

 - Org Homepage: https://nixos.org/
 - Project: https://github.com/NixOS/nix
