### PR TITLE
update yarn v2 to reflect documentation

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -111,8 +111,10 @@ dist
 .vscode-test
 
 # yarn v2
-.yarn/cache
-.yarn/unplugged
-.yarn/build-state.yml
-.yarn/install-state.gz
+.yarn/*
+!.yarn/patches
+!.yarn/releases
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
 .pnp.*


### PR DESCRIPTION
**Reasons for making this change:**
This PR assumes yarn users are **NOT** utilizing Zero-Installs.
Reason for not defaulting to Zero-Installs is due to link [2]

**Links to documentation supporting these rule changes:**
[1] https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
[2] https://next.yarnpkg.com/features/zero-installs#does-it-have-security-implications