### PR TITLE
Add exclusions for .venv and .env folders

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -109,6 +109,8 @@ celerybeat.pid
 .venv
 env/
 venv/
+.env/
+.venv/
 ENV/
 env.bak/
 venv.bak/


### PR DESCRIPTION
Add .venv/ and .env/ to exclude .venv and .env folders too.

**Reasons for making this change:**

Got that error when working on my project.
