### PR TITLE
Add Rider specific files to UnrealEngine.gitignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,9 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# Rider for UE4 specific files
+.idea/
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
**Reasons for making this change:**

Update the UnrealEngine.gitignore for developers using Rider for UE

**Links to documentation supporting these rule changes:**



If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
