### PR TITLE
KiCad: add *-backups

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -7,6 +7,7 @@
 *.bck
 *.kicad_pcb-bak
 *.kicad_sch-bak
+*-backups
 *.kicad_prl
 *.sch-bak
 *~


### PR DESCRIPTION
>A note about backup files
One other notable change is that the backup file system has been removed. This was the system that would create kicad_sch-bak and kicad_pcb-bak files every time you save. The short story about why this is removed is that with recent changes to the way file saving works, it should no longer be possible for files to be corrupted if KiCad crashes during a save, and the generation of these backup files was seen by many users as annoying clutter. For more context about this decision, you can read the [thread on the developers mailing list](https://lists.launchpad.net/kicad-developers/msg44067.html).

>An new backup system that properly backs up the whole project (see the [GitLab issue](https://gitlab.com/kicad/code/kicad/-/issues/4763)) has been implemented to replace this feature. As always when using nightly builds, back up your files separately in case a KiCad bug breaks the built-in backup system.

https://forum.kicad.info/t/new-project-file-format/23705
