### PR TITLE
Ignore Terraform Dependency Lock File

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore Terraform Dependency Lock File
+.terraform.lock.hcl


### PR DESCRIPTION
>When `terraform init` is working on installing all of the providers needed for a configuration, Terraform considers both the version constraints in the configuration and the version selections recorded in the lock file.

Source: https://www.terraform.io/docs/language/dependency-lock.html