### PR TITLE
EditorUserSettings and .vscode directory for Unity template

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -14,6 +14,9 @@
 # They also could contain extremely sensitive data
 /[Mm]emoryCaptures/
 
+#Editor user settings
+/[Uu]serSettings/EditorUserSettings.asset
+
 # Asset meta data should only be ignored when the corresponding asset is also ignored
 !/[Aa]ssets/**/*.meta
 
@@ -25,6 +28,9 @@
 
 # Visual Studio cache directory
 .vs/
+
+#Visual Studio Code directory
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
**Reasons for making this change:**

.vscode is a "cache folder" used by Visual Studio Code and is similar to .vs folder. Currently it is missing from unity template.

EditorUserSettings.asset contains machine specific settings like the most recently used scene. Having this file in the repository results in a stream of clashes, as each individual machine will try to modify it once the project is opened. Supposedly it was introduced in Unity 2020.

**Links to documentation supporting these rule changes:**

EditorUserSettings.asset is not officially documented, but there are people mentioning it online, for example:
https://twitter.com/pux0r3/status/1367972095259410434?lang=en
