### PR TITLE
added cypress directories to node ignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -26,6 +26,14 @@ coverage
 # nyc test coverage
 .nyc_output
 
+#cypress
+cypress/integration/1-getting-started/
+cypress/integration/2-advanced-examples/
+cypress/videos/
+cypress/screenshots/
+cypress/reports/
+cypress.env.json
+
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 


### PR DESCRIPTION
**Reasons for making this change:**

1. I've seen a lot like mine and my teams projects testing with [Cypress io](https://www.cypress.io/) and thought best to have that included in the Node ignore list. 
    - [>17k Repo](https://github.com/search?q=cypress&type=repositories)
2. I also look around other similar test frameworks like Test cafe and Cypress seems to be the only one creating custom files at runtime. 

**Links to documentation supporting these rule changes:**

- According to the Cypress [official documentation](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests), cypress generates sample tests in the integration folder
- `cypress.env.json` is an alternative to cypress.json which acts as similar to dotenv [Documentation](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file)
- Other asset files "report, videos, screenshots" are mostly ignored but optional. 

If this is a new template:

- Not a new template but there are standalone Cypress projects that may require a Cypress template. Please let me know what you think. 
