### PR TITLE
Remove ignore on *.DotSettings.user since it's covered in *.user and keep publi…

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -130,7 +130,6 @@ $tf/
 # ReSharper is a .NET coding add-in
 _ReSharper*/
 *.[Rr]e[Ss]harper
-*.DotSettings.user
 
 # TeamCity is a build add-in
 _TeamCity*
@@ -182,9 +181,6 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# Note: Comment the next line if you want to checkin your web deploy settings,
-# but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to


### PR DESCRIPTION
…sh settings since private info is in the pubxml.user

**Reasons for making this change:**

Everytime i add a publish profile to a new solution i always get tripped up because pubxml is ignored... this is a huge pain since i want the server name etc in there. Passwords are already stored hidden in the pubxml.user which is ignored.
