### PR TITLE
Ignoring CodeCoverage folder

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -9,6 +9,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+/[Cc]ode[Cc]overage/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data


### PR DESCRIPTION
**Reasons for making this change:**

The CodeCoverage folder is generated by the Code Coverage Unity package (https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@latest), and since it contains code coverage data and reports users typically won't need to keep these in version control

**Links to documentation supporting these rule changes:**

https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@latest/index.html?subfolder=/manual/CoverageTestRunner.html

