### PR TITLE
Ignore .vscode/ directory files for Unity projects

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -25,6 +25,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
**Reasons for making this change:**

Don't know if vscode has always used this directory name instead of just ".vs" 
I'm assuming that this is a directory used to store metadata files for use with Microsoft Visual Studio Code.

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**:  https://unity.com/
