### PR TITLE
feat(node): added `.stylelintcache` for stylelint

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -54,6 +54,9 @@ web_modules/
 # Optional eslint cache
 .eslintcache
 
+# Optional stylelint cache
+.stylelintcache
+
 # Microbundle cache
 .rpt2_cache/
 .rts2_cache_cjs/


### PR DESCRIPTION
**Reasons for making this change:**

[`stylelint`](https://stylelint.io/), like `eslint`, has it's own cache

**Links to documentation supporting these rule changes:**

https://stylelint.io/user-guide/usage/options#cache