### PR TITLE
Add vuepress v2.x temp and cache directory

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -95,6 +95,10 @@ dist
 # vuepress build output
 .vuepress/dist
 
+# vuepress v2.x temp and cache directory
+.temp
+.cache
+
 # Serverless directories
 .serverless/
 


### PR DESCRIPTION
**Reasons for making this change:**

`.temp` and `.cache` should be ignored in VuePress v2.x

**Links to documentation supporting these rule changes:**

https://v2.vuepress.vuejs.org/guide/getting-started.html#manual-installation

Please check **Step 5**
