### PR TITLE
增加.vsconfig忽略

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -46,6 +46,7 @@ ExportedObj/
 *.mdb
 *.opendb
 *.VC.db
+.vsconfig
 
 # Unity3D generated meta files
 *.pidb.meta


### PR DESCRIPTION
**Reasons for making this change:**

.vsconfig文件为vs2019软件自动生成文件,

**Links to documentation supporting these rule changes:**

unity

