### PR TITLE
Make not to ignore *.code-workspace

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -3,7 +3,6 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-*.code-workspace
 
 # Local History for Visual Studio Code
 .history/


### PR DESCRIPTION
**Reasons for making this change:**

Workspace file can allow you to have an individual VS Code setting file for each project, which is useful for monorepo-based development.

You can find an example on [lit/lit/lit-next.code-workspace](https://github.com/lit/lit/blob/08f60328abf83113fe82c9d8ee43dc71f10a9b77/lit-next.code-workspace).

**Links to documentation supporting these rule changes:**

https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-file
