### PR TITLE
Add MSBuild_Logs/ to ignore list

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -343,6 +343,7 @@ ASALocalRun/
 
 # MSBuild Binary and Structured Log
 *.binlog
+MSBuild_Logs/
 
 # NVidia Nsight GPU debugger configuration file
 *.nvuser


### PR DESCRIPTION
This is a new directory which msbuild creates to store its crash dumps (ref: https://github.com/dotnet/msbuild/commit/cdb5077c451180ab38161e0b5e70f5448e70355b).
