### PR TITLE
Fixed .vscode not being ignored

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,4 +1,4 @@
-.vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json


### PR DESCRIPTION
**Reasons for making this change:**
The `.vscode` directory was not being fully ignored.

🌴 