### PR TITLE
Create Syncthing.gitignore

### DIFF
--- a/Global/Syncthing.gitignore
+++ b/Global/Syncthing.gitignore
@@ -1,0 +1,1 @@
+.stversions

--- a/Global/Syncthing.gitignore
+++ b/Global/Syncthing.gitignore
@@ -1,1 +1,2 @@
+# Syncthing caches
 .stversions


### PR DESCRIPTION
**Reasons for making this change:**

When you use syncthing versioning, it creates this folder keeping track of all versions.

**Links to documentation supporting these rule changes:**

 

If this is a new template:

 - **Link to application or project’s homepage**:  https://syncthing.net/
