### PR TITLE
Added .DS_Store for MacOS

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -116,3 +116,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# MacOS Temporary Files
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

MacOS creates a hidden .DS_Store file that contains attributes and metadata about the application that could be a danger from hackers if pushed to a repo. It's a simple of fix of just putting .DS_Store into a gitignore, but if people are unaware they have to do that, it can cause problems. Adding it to the template would also be nice so MacOS developers don't have to add it to a gitignore for every project. 

**Links to documentation supporting these rule changes:**

https://buildthis.com/ds_store-files-and-why-you-should-know-about-them/

If this is a new template:

 - **Link to application or project’s homepage**:
