### PR TITLE
Add Visual Studio History directories (`.vshistory`) to `VisualStudio.gitignore`

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -353,6 +353,9 @@ ASALocalRun/
 # Local History for Visual Studio
 .localhistory/
 
+# Visual Studio History (VSHistory) files
+.vshistory/
+
 # BeatPulse healthcheck temp database
 healthchecksdb
 


### PR DESCRIPTION
**Reasons for making this change:**

The Visual Studio History (VSHistory) extension creates versions of files every time they are changed and saved to disk.  This can create a lot of VSHistory files in the local directory that don't need to be saved in the project's repository.

This change simply adds the .vshistory directory to .gitignore.

**Links to documentation supporting these rule changes:**

https://marketplace.visualstudio.com/items?itemName=KenCross.VSHistory
