### PR TITLE
Update global .gitignore template doc ID link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We support a collection of templates, organized in this way:
   unimportant files into your repository.
 - [`Global`](./Global) contains templates for various editors, tools and
   operating systems that can be used in different situations. It is recommended
-  that you either [add these to your global template](https://help.github.com/articles/ignoring-files/#create-a-global-gitignore)
+  that you either [add these to your global template](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer)
   or merge these rules into your project-specific templates if you want to use
   them permanently.
 - [`community`](./community) contains specialized templates for other popular


### PR DESCRIPTION
### **Reasons for making this change:**
- There is no such ID link now available in the docs. I suppose it's because the heading was changed.

### **Links to documentation supporting these rule changes:**
https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
