### PR TITLE
Add .ptc to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -213,6 +213,9 @@ pythontex-files-*/
 *.md5
 *.auxlock
 
+# titletoc
+*.ptc
+
 # todonotes
 *.tdo
 


### PR DESCRIPTION
**Reasons for making this change:**

The titletoc package creates an auxiliary `.ptc` file to store information about partial ToC's.

**Links to documentation supporting these rule changes:**

See **6.3. Partial ToC's** in [the manual](http://tug.ctan.org/tex-archive/macros/latex/contrib/titlesec/titlesec.pdf):

![image](https://user-images.githubusercontent.com/13775259/137156861-503fdd5c-bf72-4054-a7b2-04eb8dca1be8.png)
