### PR TITLE
Fix Unreal Engine plugin binaries on subfolders

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -47,7 +47,7 @@ SourceArt/**/*.tga
 
 # Binary Files
 Binaries/*
-Plugins/*/Binaries/*
+Plugins/**/Binaries/*
 
 # Builds
 Build/*
@@ -68,7 +68,7 @@ Saved/*
 
 # Compiled source files for the engine to use
 Intermediate/*
-Plugins/*/Intermediate/*
+Plugins/**/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*


### PR DESCRIPTION
**Reasons for making this change:**

When I installed the Rider plugin for UE5, I noticed that some subfolders with binaries were not being git ignored

**Links to documentation supporting these rule changes:**

This is the project with which I noticed the issue

https://github.com/Maximetinu/batterycollector-ue5

This is the commit I made to fix it

https://github.com/Maximetinu/batterycollector-ue5/commit/71dad496dd7a15c53103fb2a95be7442bf438feb

I've slightly modified the rule for this PR to make it more specific to this case

**Steps to reproduce**
- Pull down that repository prior to the commit I made to fix it
- Open the project with UE5, enable Rider plugin on the project and open the IDE to see the issue happening
