### PR TITLE
Ignore Pickle files in Python Projects

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Pickle files
+*.pickle


### PR DESCRIPTION
**Reasons for making this change:**

~~Pickle files are created while the Python project is executed. They aren't needed for the development or the execution of the project.~~
