### PR TITLE
Ignore Rails .env according recomendations

### DIFF
--- a/Rails.gitignore
+++ b/Rails.gitignore
@@ -27,7 +27,7 @@ config/master.key
 # dotenv, dotenv-rails
 # TODO Comment out these rules if environment variables can be committed
 .env
-.env.*
+.env*.local
 
 ## Environment normalization:
 /.bundle


### PR DESCRIPTION
**Reasons for making this change:**
Rails dotenv ignore is not following dotenv recommendations as stated in its documentation

**Links to documentation supporting these rule changes:**
https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use