### PR TITLE
Add .idea and .vscode

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -21,3 +21,5 @@ Homestead.yaml
 Homestead.json
 /.vagrant
 .phpunit.result.cache
+/.idea
+/.vscode


### PR DESCRIPTION
The .idea folder (hidden on OS X) in the solution root contains IntelliJ’s project-specific settings files. For Vs Code Workspace settings as well as debugging and task configurations are stored at the root in a .vscode folder.

**Reasons for making this change:**

ide settings by default user customization

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
