### PR TITLE
Ignore .xsim files in TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -232,6 +232,9 @@ pythontex-files-*/
 # xindy
 *.xdy
 
+# xsim
+*.xsim
+
 # xypic precompiled matrices and outlines
 *.xyc
 *.xyd


### PR DESCRIPTION
The xsim package generates .xsim files, which should be ignored.

See [section 5 of xsim's documentation](https://ftp.tu-chemnitz.de/pub/tex/macros/latex/contrib/xsim/xsim-manual.pdf#section.5) for information on the generation of these files.