### PR TITLE
Add Lighthouse CI gitignore

### DIFF
--- a/LighthouseCI.gitignore
+++ b/LighthouseCI.gitignore
@@ -1,0 +1,2 @@
+# Lighthouse reports
+.lighthouseci/


### PR DESCRIPTION
**Reasons for making this change:**

Adds gitignore for the lighthouse CI report folder.

**Links to documentation supporting these rule changes:**

https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md#collect

If this is a new template:

 - **Link to application or project’s homepage**: https://github.com/GoogleChrome/lighthouse-ci
