### PR TITLE
Ignore directories from the Bazel IntelliJ plugin

### DIFF
--- a/community/Bazel.gitignore
+++ b/community/Bazel.gitignore
@@ -4,3 +4,10 @@
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 /bazel-*
+
+# Directories for the Bazel IntelliJ plugin containing the generated
+# IntelliJ project files and plugin configuration. Seperate directories are
+# for the IntelliJ, Android Studio and CLion versions of the plugin.
+/.ijwb/
+/.aswb/
+/.clwb/


### PR DESCRIPTION

**Reasons for making this change:**

These directories contain the generated project files from the Bazel IntelliJ plugin.

**Links to documentation supporting these rule changes:**

https://github.com/bazelbuild/intellij/blob/8c92239f41b20dcf88a22dcb3f44b5a9bdf46a95/.gitignore
https://github.com/bazelbuild/intellij/blob/8c92239f41b20dcf88a22dcb3f44b5a9bdf46a95/base/src/com/google/idea/blaze/base/sync/data/BlazeDataStorage.java#L36

