### PR TITLE
Adding AllowList for Go

### DIFF
--- a/Go.allowlist.gitignore
+++ b/Go.allowlist.gitignore
@@ -1,0 +1,17 @@
+# Ignore everything
+*
+
+# But not these files...
+!/.gitignore
+
+!*.go
+!go.sum
+!go.mod
+
+!README.md
+!LICENSE
+
+# !Makefile
+
+# ...even if they are in subdirectories
+!*/


### PR DESCRIPTION
**Reasons for making this change:**

_Whitelisting with .gitignore is a technique for dealing with source trees that can have various different untracked local files such as generated output, packages installed through package managers, “working” files, config for individual developers, etc. Rather than trying to come up with some master list of all possible untracked files and add them to .gitignore, it can be easier to start by ignoring everything and then add specific directories back._
_I think the requirements for software development are changing and there is a need to offer an alternative to the denylist._

- https://jasonstitt.com/gitignore-whitelisting-patterns
- https://github.com/golang/go

Signed-off-by: kuritka <kuritka@gmail.com>
