### PR TITLE
Add .gitignore for Microsoft Business Central

### DIFF
--- a/AL.gitignore
+++ b/AL.gitignore
@@ -1,0 +1,22 @@
+### AL ###
+#Template for AL projects for Dynamics 365 Business Central
+#launch.json folder
+.vscode/
+#Cache folder
+.alcache/
+#Symbols folder
+.alpackages/
+#Snapshots folder
+.snapshots/
+#Testing Output folder
+.output/
+#Extension App-file
+*.app
+#Rapid Application Development File
+rad.json
+#Translation Base-file
+*.g.xlf
+#License-file
+*.flf
+#Test results file
+TestResults.xml


### PR DESCRIPTION
**Reasons for making this change:**

Dynamics 365 Business Central is a Microsoft solution used by thousands of companies.
We as developers have to use external services in order to get a .gitignore template which is outdated or quite simple.

**Links to documentation supporting these rule changes:**

https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-reference-overview
https://gitignore.io/api/AL

If this is a new template:

 - **Link to application or project’s homepage**: 
https://dynamics.microsoft.com/en-us/business-central/overview/
https://github.com/microsoft/AL
