### PR TITLE
Hugo: Add new .hugo_build.lock

### DIFF
--- a/community/Golang/Hugo.gitignore
+++ b/community/Golang/Hugo.gitignore
@@ -6,3 +6,6 @@
 hugo.exe
 hugo.darwin
 hugo.linux
+
+# Temporary lock file while building
+/.hugo_build.lock


### PR DESCRIPTION
**Reasons for making this change:**

Version 0.89.0 of Hugo creates a new `.hugo_build.lock` lock file when building the site. The release notes suggest adding this to the `.gitignore`.


**Links to documentation supporting these rule changes:**

https://github.com/gohugoio/hugo/releases/tag/v0.89.0

