### PR TITLE
Add files to Hugo.gitignore

### DIFF
--- a/community/Golang/Hugo.gitignore
+++ b/community/Golang/Hugo.gitignore
@@ -1,6 +1,9 @@
 # Generated files by hugo
 /public/
 /resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+.hugo_build.lock
 
 # Executable may be added to repository
 hugo.exe

--- a/community/Golang/Hugo.gitignore
+++ b/community/Golang/Hugo.gitignore
@@ -3,7 +3,6 @@
 /resources/_gen/
 /assets/jsconfig.json
 hugo_stats.json
-.hugo_build.lock
 
 # Executable may be added to repository
 hugo.exe


### PR DESCRIPTION
Three new files to ignore for GoHugo repositories:

- `/assets/jsconfig.json` - Quote from [JavaScript Building](https://gohugo.io/hugo-pipes/js/): "Hugo will, by default, generate a assets/jsconfig.json file that maps the imports. This is useful for navigation/intellisense help inside code editors, but if you don’t need/want it, you can turn it off."
- `hugo_stats.json` - Quote from [Post Build Resource Transformations ](https://gohugo.io/news/0.69.0-relnotes/): "The prime current use case for the above is CSS pruning in PostCSS. In simple cases you can use the templates as a base for the content filters, but that has its limitations and can be very hard to setup, especially in themed configurations. So we have added a new writeStats configuration that, when enabled, will write a file named hugo_stats.json to your project root with some aggregated data about the build, e.g. list of HTML entities published, to be used to do CSS pruning."
- `.hugo_build.lock` - Quote from [Fine Grained File Filters ](https://gohugo.io/news/0.89.0-relnotes/): "Hugo now writes an empty file named .hugo_build.lock to the root of the project when building (also when doing hugo new mypost.md and other commands that requires a build). We recommend you just leave this file alone. Put it in .gitignore or similar if you don’t want the file in your source repository."