### PR TITLE
Update KiCad domain.

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -1,5 +1,5 @@
-# For PCBs designed using KiCad: http://www.kicad-pcb.org/
-# Format documentation: http://kicad-pcb.org/help/file-formats/
+# For PCBs designed using KiCad: https://www.kicad.org/
+# Format documentation: https://kicad.org/help/file-formats/
 
 # Temporary files
 *.000


### PR DESCRIPTION
**Reasons for making this change:**

The old KiCad domain (`kicad-pcb.org`) should no longer be used. Instead, `kicad.org` should be used.

**Links to documentation supporting these rule changes:**

https://www.kicad.org/blog/2021/10/Avoid-links-to-former-kicad-domain/