### PR TITLE
Added tpr extension

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -13,6 +13,7 @@
 #   2. You've created a standalone PLC-project and added events to it, as these are stored in the TMC-file.
 *.tmc
 *.tmcRefac
+*.tpr
 *.library
 *.project.~u
 *.tsproj.bak


### PR DESCRIPTION
**Reasons for making this change:**

After refactoring a *.tmcRefac gets created. Then after a build it gets converted into a *.tpr file. No need to have this file under source control.

**Links to documentation supporting these rule changes:**

There is no Beckhoff documentation on this file extension.

