### PR TITLE
Go: Ignore Go workspace file go.work

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Go workspace file
+go.work


### PR DESCRIPTION
**Reasons for making this change:**

With Go 1.18, support for Go workspaces will land. Go workspaces are configured in `go.work`, which contains paths to local development versions of modules and therefore is not expected to be commited.

**Links to documentation supporting these rule changes:**

* https://github.com/golang/go/issues/45713
* https://sebastian-holstein.de/post/2021-11-08-go-1.18-features/
