### PR TITLE
Add replay_pid* to Java.gitignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -21,3 +21,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+replay_pid*


### PR DESCRIPTION
**Reasons for making this change:**

`replay_pid<pid>.log` files may be created along with `hs_err_pid<pid>.log` when JVM crashes, they should be ignored

**Links to documentation supporting these rule changes:**

I didn't find any official documentation about these files
Found this SO answer though: https://stackoverflow.com/a/33759890/249230
