### PR TITLE
Ignore `*~` in Ruby.gitignore

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*~
 /.config
 /coverage/
 /InstalledFiles


### PR DESCRIPTION
This pattern is ignored by projects under the Ruby organization, such as [Ruby itself](https://github.com/ruby/ruby/blob/f31b7f0522e4abfea61f6a74b859205b2b5f8ade/.gitignore#L29) and [Rake](https://github.com/ruby/rake/blob/5c60da8644a9e4f655e819252e3b6ca77f42b7af/.gitignore#L4).

**Reasons for making this change:**

This pattern is used by Ruby completion caches. It appears that, when rake is installed with `apt`, it includes a [completions script that will generate a `.rake_tasks~`](https://git.launchpad.net/ubuntu/+source/rake/tree/debian/bash_completion.d/rake). I initially considered ignoring `.rake_tasks~` specifically, but checked the `.gitignore`s of Ruby's organization and saw that `*~`
was used.

**Links to documentation supporting these rule changes:**

Honestly, I had a lot of trouble finding something relevant. The closest I found is [this obsolete project for rake completions](https://github.com/ai/rake-completion#cache), which states including `*~` to ignore `.rake_tasks~` files.

***

### Disclaimer

I'm still new to Ruby, so this PR should probably get some feedback from the Ruby community first.
I was surprised to find a `.rake_tasks~` file in my repo that was not ignored by the `.gitignore` created
on project init using GitHub's template gitignore. I made this PR because I thought that this observation
was worth discussion.