### PR TITLE
Ignore default Recordings folder created by Unity Recorder package

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -14,6 +14,9 @@
 # They also could contain extremely sensitive data
 /[Mm]emoryCaptures/
 
+# Recordings can get excessive in size
+/[Rr]ecordings/
+
 # Asset meta data should only be ignored when the corresponding asset is also ignored
 !/[Aa]ssets/**/*.meta
 


### PR DESCRIPTION
**Reasons for making this change:**

Ignores the default `Recordings` folder which is created by the Unity Recorder package `com.unity.recorder` to store recordings of gameplay (such as recordings for game trailers, demos, etc.). This package is a common built-in Unity package and the recordings created can be large video files that don't need to be in the Git repository.

**Links to documentation supporting these rule changes:**

[Unity - Manual: Recorder](https://docs.unity3d.com/Manual/com.unity.recorder.html)
[Unity - Manual: About Recorder](https://docs.unity3d.com/Packages/com.unity.recorder@3.0/manual/index.html)
