### PR TITLE
[android] Ignoring AVD used during last build

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -48,6 +48,7 @@ captures/
 # Android Studio 3 in .gitignore file.
 .idea/caches
 .idea/modules.xml
+.idea/deploymentTargetDropDown.xml
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
 .idea/navEditor.xml
 


### PR DESCRIPTION
**Reasons for making this change:**
`deploymentTargetDropDown.xml` stores the AVD used in last build and is not portable

**Links to documentation supporting these rule changes:**

https://betterprogramming.pub/exploring-the-idea-folder-790931c19191

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
