### PR TITLE
Azure Functions local settings should be excluded.

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Azure Functions localsettings file
+local.settings.json
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
During local development of a function app, settings required by your functions are stored in the local.settings.json file. The local.settings.json file also stores settings used by local development tools.

Because the local.settings.json may contain secrets, such as connection strings, you should never store it in a remote repository.

The original article can be found [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-vs?tabs=in-process#local-settings).

**Reasons for making this change:**

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
