### PR TITLE
Remove .idea folder from VisualStudio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -384,5 +384,4 @@ FodyWeavers.xsd
 *.msp
 
 # JetBrains Rider
-.idea/
 *.sln.iml


### PR DESCRIPTION
Conflicts with JetBrains.gitignore, which is a lot more detailed. Some files in this directory should be checked in.

Not sure about *.sln.iml, so I'm leaving that. The JetBrains.gitignore file contains commented-out IML stuff with instructions on when to uncomment.