### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -28,7 +28,7 @@ MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+#  before PyInstaller builds the exe file, so as to inject date/other information into it.
 *.manifest
 *.spec
 


### PR DESCRIPTION
I updated the comments thus:

# PyInstaller

 #  Usually these files are written by a Python script from a template

-#  before PyInstaller builds the exe, so as to inject date/other infos into it.

+#  before PyInstaller builds the exe file, so as to inject date/other information into it.

**Reasons for making this change:**

To ensure syntactic correctness.

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
