### PR TITLE
Ignore Rider files

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,12 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# Rider for Unreal Engine specific files
+.idea/
+
+# RiderLink plugin
+Plugins/Developer/RiderLink/*
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
# Added ignore statements for .idea/ and the RiderLink plugin.

## Reasons for making this change:

Rider automatically creates the .idea/ folder which contains settings for the IDE. These files are not supposed to be pushed to the repository since everyone uses a different IDE to program in Unreal Engine. (Basically the same reason why .vs/ is in this .gitignore)

For complete support between Rider and Unreal Engine, Rider requires you to install the RiderLink plugin. This plugin contains 500+ files. These files are not supposed to be pushed to the repository since everyone uses a different IDE to program in Unreal Engine. Including these files and getting the project from GitHub also caused some compile errors for me, that is also why I am including this.

## Links to documentation supporting these rule changes:

Link to Rider for Unreal Engine: https://www.jetbrains.com/lp/rider-unreal/ (No documentation)
