### PR TITLE
Add `.RDataTmp` to R.gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -4,6 +4,7 @@
 
 # Session Data files
 .RData
+.RDataTmp
 
 # User-specific files
 .Ruserdata


### PR DESCRIPTION
**Reasons for making this change:**

When saving `.RData`, all data is initially saved in `.RDataTmp` which
is then renamed to `.RData`.

`.RDataTmp` should be added to `.gitignore` since it will only exist
while a save operation is in progress or something failed on save.

**Links to documentation supporting these rule changes:**

- https://stackoverflow.com/questions/32098036/purpose-of-rdatatmp-temporary-file-r
- https://github.com/wch/r-source/blob/trunk/src/library/base/R/load.R#L145-L154