### PR TITLE
macOS: DS_Store (Unity)

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -69,3 +69,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# macOS filesystem
+**/.DS_Store


### PR DESCRIPTION
Avoid uploading .DS_Store files from macOS filesystem (unity)

Edit: some people may think adding os specific files should go to system level gitignore but, in my opinion, gitignore files are first and foremost used to avoid user mistakes, and a repository level gitignore avoid mistakes from lowly experienced users since it can be mandated by good users.
Anyway, macOS is one of the most used OS and as Apple still don't pre configured, it should be done at least here.