### PR TITLE
added vscode ignore for unity

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -25,6 +25,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
**Reasons for making this change:**
I use gitignore for unity projects. I used vscode and noticed there was no ignore for the .vscode specific folder that's created