### PR TITLE
doc(readme): master branch is now main

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Here’s how we suggest you go about proposing a change to this project:
 1. [Fork this project][fork] to your account.
 2. [Create a branch][branch] for the change you intend to make.
 3. Make your changes to your fork.
-4. [Send a pull request][pr] from your fork’s branch to our `master` branch.
+4. [Send a pull request][pr] from your fork’s branch to our `main` branch.
 
 Using the web-based interface to make changes is fine too, and will help you
 by automatically forking the project and prompting to send a pull request too.


### PR DESCRIPTION
**Reasons for making this change:**

Seems that someone renamed branch and we should update Readme
Point contribution instructions to ~master~ main branch
