### PR TITLE
[Python] Add poetry.lock

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -94,6 +94,13 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 


### PR DESCRIPTION
Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.  This is especially recommended for binary packages to ensure reproducibility, and is more commonly ignored for libraries.

This is taken from https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control

**Reasons for making this change:**

This is very similar reasoning to the existing Pipenv entry and Poetry is quite popular too (17.4k stars on Github).  As the benefits/cons of including the lock file can vary for each project, the default is left commented out (just as the Pipenv entry).

**Links to documentation supporting these rule changes:**

- https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
