### PR TITLE
Adding AllowList for Go

### DIFF
--- a/community/Golang/Go.AllowList.gitignore
+++ b/community/Golang/Go.AllowList.gitignore
@@ -1,0 +1,23 @@
+# Allowlisting gitignore template for GO projects prevents us
+# from adding various unwanted local files, such as generated
+# files, developer configurations or IDE-specific files etc.
+#
+# Recommended: Go.AllowList.gitignore
+
+# Ignore everything
+*
+
+# But not these files...
+!/.gitignore
+
+!*.go
+!go.sum
+!go.mod
+
+!README.md
+!LICENSE
+
+# !Makefile
+
+# ...even if they are in subdirectories
+!*/


### PR DESCRIPTION
**Reasons for making this change:**

_Allowlisting with .gitignore is a technique for dealing with source trees that can have various different untracked local files such as generated output, packages installed through package managers, “working” files, config for individual developers, etc. Rather than trying to come up with some master list of all possible untracked files and add them to .gitignore, it can be easier to start by ignoring everything and then add specific directories back._
_I think the requirements for software development are changing and there is a need to offer an alternative to the denylist._

**Links to documentation supporting these rule changes:**

- https://jasonstitt.com/gitignore-whitelisting-patterns
- https://github.com/golang/go

Signed-off-by: kuritka <kuritka@gmail.com>
