### PR TITLE
Update VS Code to support *.code-snippets

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -3,6 +3,7 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/


### PR DESCRIPTION
Code snippets are very useful because they make it easy to manage code snippets for each project.

https://github.com/github/gitignore/pull/3507 is the same PR over there, but I suggest it again because it is too old and corrupt.

**Links to documentation supporting these rule changes:**
- https://code.visualstudio.com/docs/editor/userdefinedsnippets#_project-snippet-scope
