### PR TITLE
Create seo.gitignore

### DIFF
--- a/seo.gitignore
+++ b/seo.gitignore
@@ -1,0 +1,5 @@
+# Common SEO files that would jeopardise indexing if unfinished or subject to change repo is made online for demo purposes via github pages or services like netlify
+# Delete this gitignore as the last step and in order to enable proper crawling for your finished website 
+
+robots.txt
+sitemap.xml


### PR DESCRIPTION
Common SEO files that need to be excluded on prototype websites or for demo purposes. Since things like domains, page structure and page linking might be changed a lot and frequently. Serving proper SEO related files with a prototype website risks being indexed too early and with wrong information thus making it harder later to improve search results or even to get flagged by browsers or services since the website structure doesnt fit anymore with whats in the google database. Serving no robots.txt and sitemap.xml is better practice than serving intentionaly bad files. See Google's documents about Crawling for further information.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

see above + I do this automatically when creating a new repo/website
**Links to documentation supporting these rule changes:**

https://developers.google.com/search/docs/beginner/seo-starter-guide

