### PR TITLE
Ignore Eclipse .project and .classpath when using build tools Maven or Gradle

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -10,3 +10,9 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath

--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -9,3 +9,9 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath


### PR DESCRIPTION
**Reasons for making this change:**

[Eclipse's documentation](http://wiki.eclipse.org/FAQ_How_do_I_set_up_a_Java_project_to_share_in_a_repository%3F) confusingly recommends `.classpath` and `.project` being under version control. That recommendation makes sense if neither maven or gradle is used. 

However, when using either maven or gradle those files are generated each time based on the maven or gradle configuration - which causes issues when those files are version controlled. That is why I recommended ignoring these files _only_ if using maven or gradle, but _not_ for all Eclipse Java projects.

**Links to documentation supporting these rule changes:**

See #3710 for discussion and additional documentation regarding this change