### PR TITLE
GO: Added link to allow list template

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -1,3 +1,6 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
 # Binaries for programs and plugins
 *.exe
 *.exe~


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The .gitignore works like a denylist, this PR just adds a link to the GO .gitgignore header with a link to the allow list. 
 - https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore

Signed-off-by: kuritka <kuritka@gmail.com>