### PR TITLE
Create B4X.gitignore

### DIFF
--- a/community/B4X.gitignore
+++ b/community/B4X.gitignore
@@ -1,0 +1,3 @@
+**/Objects
+**/AutoBackups
+*.meta


### PR DESCRIPTION
gitignore file for https://www.b4x.com/ projects including b4a, b4j and more

**Reasons for making this change:**
I had to search forums to find the gitignore file for this development tool

**Links to documentation supporting these rule changes:**

https://www.b4x.com/android/forum/threads/github.127723/#post-800227

If this is a new template:

 - **Link to application or project’s homepage**:  https://www.b4x.com/
