### PR TITLE
Ignore files in directory, not the directory itself

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,4 +1,4 @@
-.vscode/
+.vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json


### PR DESCRIPTION
**Reasons for making this change:**

When directory is ignored using `dir/` pattern, then everything under it will **always** be excluded.

Negation pattern underneath don't work.

When written as `dir/*`, git excludes files from the directory, not the directory itself and the negation patterns work.

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/questions/5533050/gitignore-exclude-folder-but-include-specific-subfolder