### PR TITLE
Create TypeScript.gitignore

### DIFF
--- a/TypeScript.gitignore
+++ b/TypeScript.gitignore
@@ -1,0 +1,8 @@
+#Files for the code
+
+*.ts
+*.typescript
+
+#Executables
+*.exe
+*.app

--- a/TypeScript.gitignore
+++ b/TypeScript.gitignore
@@ -1,8 +1,63 @@
-#Files for the code
+lib-cov
 
-*.ts
-*.typescript
+*.seed
 
-#Executables
-*.exe
-*.app
+*.log
+
+*.csv
+
+*.dat
+
+*.out
+
+*.pid
+
+*.gz
+
+*.swp
+
+pids
+
+logs
+
+results
+
+tmp
+
+# Build
+
+public/css/main.css
+
+# Coverage reports
+
+coverage
+
+# API keys and secrets
+
+.env
+
+# Dependency directory
+
+node_modules
+
+bower_components
+
+# Editors
+
+.idea
+
+*.iml
+
+# OS metadata
+
+.DS_Store
+
+Thumbs.db
+
+# Ignore built ts files
+
+dist/**/*
+
+# ignore yarn.lock
+
+yarn.lock


### PR DESCRIPTION
This PR contains code under the [MIT license](https://choosealicense.com/licenses/mit). To comply with the terms of the license, I must provide the source of the code. The source of the code is from https://github.com/microsoft/TypeScript-Node-Starter/blob/master/.gitignore.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Just because I need TS Gitignore!

**Links to documentation supporting these rule changes:**

https://www.typescriptlang.org/docs/

If this is a new template:

 - **Link to application or project’s homepage**: https://typescriptlang.org
