### PR TITLE
Add .pypirc to the Python.gitignore file

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.pypirc
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
.pypirc is a file that stores some information for python package distribution, such as repository URL, username and password.

Definitely this file cannot be uploaded to GitHub, as it contains access credentials for the python packages distribution platform.

See about the .pypirc file at: https://packaging.python.org/en/latest/specifications/pypirc/