### PR TITLE
Update Xcode.gitignore

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,26 +1,6 @@
-# Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
-
 ## User settings
 xcuserdata/
 
-## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+## Xcode 8 and earlier
 *.xcscmblueprint
 *.xccheckout
-
-## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
-build/
-DerivedData/
-*.moved-aside
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-
-## Gcc Patch
-/*.gcno


### PR DESCRIPTION
- Remove a reminder to look at files that don't exist anymore
- Remove ignore rules for an IDE from 2007
- Remove an ignore rule for Gcc which is no longer used since 2013

**Reasons for making this change:**

New projects can safely not ignore the files that Xcode before v5 created. 

**Links to documentation supporting these rule changes:**

[Wikipedia](https://en.wikipedia.org/wiki/Xcode#Xcode_3.0_-_Xcode_4.x)
