### PR TITLE
Add Docusaurus files to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -104,6 +104,9 @@ dist
 .temp
 .cache
 
+# Docusaurus cache and generated files
+.docusaurus
+
 # Serverless directories
 .serverless/
 


### PR DESCRIPTION
**Reasons for making this change:**

I'm a maintainer for Docusaurus

**Links to documentation supporting these rule changes:**

https://github.com/facebook/docusaurus/blob/main/.gitignore#L16

If this is a new template:

 - **Link to application or project’s homepage**: https://docusaurus.io/
