### PR TITLE
feat(terraform): adding lock file ignore

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 #
 *.tfvars

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -33,3 +33,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore Terraform lock files
+# .terraform.lock.hcl


### PR DESCRIPTION
**Reasons for making this change:**

Terraform as of version 0.14 supports a local lock file for providers. This PR adds the ability to ignore this file, but leaves it commented out since it highly depends on the team's workflow.

I've also included the fix from PR https://github.com/github/gitignore/pull/3533

**Links to documentation supporting these rule changes:**

- https://www.terraform.io/language/files/dependency-lock
- https://stackoverflow.com/questions/67963719/should-terraform-lock-hcl-be-included-in-the-gitignore-file