### PR TITLE
ignore vim generated swap files and vim session files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -124,6 +124,10 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# vim
+*.sw*
+*.vim
+
 # Rope project settings
 .ropeproject
 


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I use the Python.gitignore file for python projects and edit in a vim environment. This change would stop me and similar developers from needing to add gitignore lines for vim swap and session files for every python project.

_TODO_

**Links to documentation supporting these rule changes:**
