### PR TITLE
Ignore temporary files generated by JabRef

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -299,3 +299,6 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+
+# Temporary files
+*.tmp


### PR DESCRIPTION
**Reasons for making this change:**
Ignore temporary files generated by JabRef in LaTex projects. The extension is "*.tmp".