### PR TITLE
Ignore the .vsconfig file generated by VS

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -46,6 +46,7 @@ ExportedObj/
 *.mdb
 *.opendb
 *.VC.db
+.vsconfig
 
 # Unity3D generated meta files
 *.pidb.meta


### PR DESCRIPTION
**Reasons for making this change:**

The .vsconfig file is automatically generated by VS, it does not need version control, and it will be automatically generated when VS is opened.

**Links to documentation supporting these rule changes:**

https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/