### PR TITLE
Fixed APT generated tests location

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -48,7 +48,7 @@ local.properties
 
 # Annotation Processing
 .apt_generated/
-.apt_generated_test/
+.apt_generated_tests/
 
 # Scala IDE specific (Scala & Java development for Eclipse)
 .cache-main


### PR DESCRIPTION
By default the APT generated tests location is .apt_generated_tests

**Reasons for making this change:**

Corrected typo in Eclipse git ignore settings.

