### PR TITLE
/web/{modules,profiles,themes}/contrib are extends installed by composer…

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -25,12 +25,15 @@
 /web/vendor
 /web/core
 /web/modules/README.txt
+/web/modules/contrib
 /web/profiles/README.txt
+/web/profiles/contrib
 /web/sites/development.services.yml
 /web/sites/example.settings.local.php
 /web/sites/example.sites.php
 /web/sites/README.txt
 /web/themes/README.txt
+/web/themes/contrib
 /web/.csslintrc
 /web/.editorconfig
 /web/.eslintignore


### PR DESCRIPTION
/web/{modules,profiles,themes}/contrib are extends installed by composer, should be ignored

```
        "installer-paths": {
            "web/core": ["type:drupal-core"],
            "web/libraries/{$name}": ["type:drupal-library"],
            "web/modules/contrib/{$name}": ["type:drupal-module"],
            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
            "web/themes/contrib/{$name}": ["type:drupal-theme"],
            "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
            "web/modules/custom/{$name}": ["type:drupal-custom-module"],
            "web/profiles/custom/{$name}": ["type:drupal-custom-profile"],
            "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
        },
```
https://github.com/drupal/recommended-project/blob/f73ab53907debc04033ffa6926bd347958912b21/composer.json#L43


https://github.com/drupal/recommended-project
