### PR TITLE
support for `env` and `.idea`

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -19,3 +19,13 @@
 
 # Go workspace file
 go.work
+
+# Environment Variable
+*.env
+
+#  GoLand
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.
+#  You can remove the comment below to include it the entire idea folder.
+# .idea/


### PR DESCRIPTION
**Reasons for making this change:**
Added `.gitignore` support for `.env` - Environment Variables files and `.idea` - Jetbrains.ignore files. 

**Links to documentation supporting these rule changes:**
[https://go.dev/doc/](https://go.dev/doc/)

