### PR TITLE
VisualStudio.gitignore - Include JetBrains temp directory

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -32,8 +32,11 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
-# Visual Studio 2015/2017 cache/options directory
+# Visual Studio 2015/2017/2019/2022 cache/options directory
 .vs/
+# JetBrains cache/options directory
+.idea/
+
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
added '.idea' folder to include JetBrains cache/options directory
updated Visual Studio Versions in comment


**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
I am proposing this change, since I am using Visual Studio 2022 and JetBrains Rider on a regular basis.

My only relation to this project is that I am using the VisualStudio.gitignore file in almost all my C# projects.

**Links to documentation supporting these rule changes:**

[JetBrains.gitignore](https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore)

[JetBrains Rider support page](https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-)
