### PR TITLE
add .esbuild directory to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# esbuild directories
+.esbuild


### PR DESCRIPTION
**Reasons for making this change:**

I am not an esbuild maintainer. However it would be nice when people are not missing for it on their .gitignore.

**Links to documentation supporting these rule changes:**

https://github.com/evanw/esbuild/blob/d4a7cd3/.gitignore#L5

If this is a new template:

 - **Link to application or project’s homepage**: https://esbuild.github.io
