### PR TITLE
Update KiCad.gitignore to ignore KiCad 6.0 zip backups

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -27,3 +27,6 @@ fp-info-cache
 # Exported BOM files
 *.xml
 *.csv
+
+# Archived Backups (KiCad 6.0)
+**/*-backups/*.zip


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I like having github automatically populate gitignore files for my KiCad projects.

**Links to documentation supporting these rule changes:**

[KiCad 6 Common Preferences](https://docs.kicad.org/6.0/en/kicad/kicad.html#common_preferences)
Note the "Automatically backup projects" option.  In practice, this creates a subfolder with a name similar to the current project, just with "-backups" appended to it.  ZIP files are populated there.

It may be reasonable to more widely ignore ZIP files in KiCad, but it may be useful for people to maintain snapshots of stable manufacturer export files (which are usually packaged as ZIPs).

If this is a new template:

N/A
