### PR TITLE
Update Gradle.gitignore

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -8,6 +8,9 @@ gradle-app.setting
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
 # Cache of project
 .gradletasknamecache
 


### PR DESCRIPTION
Unignore gradle-wrapper.properties. For context, see docs

**Reasons for making this change:**
In some projects, other ignore rules meant to target .idea files or files adjacent to gradle-wrapper may accidentally ignore this.  I'm proposing this change to avoid unexpected behaviour in the future. I'm simply a user of .gitignore templates.

This file is user-agnostic, and required for grade wrapper scripts to work correctly. For context, see docs: https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:wrapper_generation