### PR TITLE
Fix spelling error in Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -145,7 +145,7 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.


### PR DESCRIPTION
Fix a typo: `maintainted` to `maintained`

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

There's a spelling error in a comment. I have no relationship with the project but it seems like a straightforward and reasonable fix to make.
