### PR TITLE
Adding AWS-CDK ignore sample.

### DIFF
--- a/community/AWS/CDK.gitignore
+++ b/community/AWS/CDK.gitignore
@@ -1,0 +1,4 @@
+# CDK asset staging directory.
+# For more information about AWS-CDK, see  https://docs.aws.amazon.com/cdk/
+.cdk.staging/
+cdk.out/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Adding sample `CDK.gitignore` file for ignoring asset staging directories generated by AWS-CDK during the `cdk synth` process _(Disclosure: I do not work on the CDK project but I am an employee of AWS)_.

**Links to documentation supporting these rule changes:**

https://docs.aws.amazon.com/cdk/v2/guide/assets.html

If this is a new template:

 - **Link to application or project’s homepage**: https://docs.aws.amazon.com/cdk/
