### PR TITLE
Created Pylint section

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -150,3 +150,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Pylint
+.pylintrc
+pylintrc


### PR DESCRIPTION
**Reasons for making this change:**

Pylint is one of the most popular Python linters, I found that pylint configuration files (pylintrc) were missing from gitignore so added them.

**Links to documentation supporting these rule changes:**

- https://docs.pylint.org/en/1.6.0/run.html