### PR TITLE
Fix typo of Perl.gitignore

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -13,7 +13,7 @@ cover_db/
 # Devel::NYTProf
 nytprof.out
 
-# Dizt::Zilla
+# Dist::Zilla
 /.build/
 
 # Module::Build


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Fix spelling. Dist::Zilla is a distribution builder of Perl.

**Links to documentation supporting these rule changes:**

- https://metacpan.org/pod/Dist::Zilla

<!--

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
-->