### PR TITLE
Create Zig.gitignore

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,0 +1,4 @@
+# This file is for zig-specific build artifacts.
+
+zig-cache/
+zig-out/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Zig is a new, modern take on C with a still growing userbase and active development. The growing userbase means more reporitories for which a Zig gitignore template is a little thing that makes sense in a busy day. 

The Zig compiler includes its own build system, which generates two folders in the project root. This is the recommended system for building Zig projects. 

**Links to documentation supporting these rule changes:**

[Zig build system docs](https://ziglang.org/documentation/master/#Zig-Build-System) 

**Link to application or project’s homepage**:

[Zig language homepage](https://ziglang.org/)  
