### PR TITLE
Ignore PDM project-wide config

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -101,7 +101,13 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+# pdm
+#   pdm stores project-wide configurations in .pdm.toml, and it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
 # Celery stuff

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,6 +102,14 @@ ipython_config.py
 #poetry.lock
 
 # pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 #   pdm stores project-wide configurations in .pdm.toml, and it is recommended to not include it
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -110,12 +110,6 @@ ipython_config.py
 .pdm.toml
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-#   pdm stores project-wide configurations in .pdm.toml, and it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
 # Celery stuff


### PR DESCRIPTION
**Reasons for making this change:**

Will make it easier for new users of pdm to get the configuration right from the start. Among other reasons (see below), `pdm init` creates a `.pdm.toml` storing the absolute path of the Python interpreter, which is machine-dependent and therefore should not be tracked in version control.

**Links to documentation supporting these rule changes:**

See https://pdm.fming.dev/#use-with-ide

See also https://github.com/pdm-project/pdm/issues/699
