### PR TITLE
Create Katalon.gitignore

### DIFF
--- a/Katalon.gitignore
+++ b/Katalon.gitignore
@@ -1,0 +1,40 @@
+# Katalon Test Suite
+# Compiled class file
+*.class
+*.swp
+output
+!output/.gitkeep
+build
+
+Libs/TempTestCase*
+Libs/TempTestSuite*
+bin/lib/TempTestCase*
+Reports/
+\.classpath
+\.project
+\.settings/
+bin/lib/
+Libs/
+.svn/
+.gradle
+
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*


### PR DESCRIPTION
Compiled config for Katalon Studio

**Reasons for making this change:**
KatalonStudio are an automatation application to run functional tests.


**Links to documentation supporting these rule changes:**
https://www.darraghoriordan.com/2019/06/23/katalon-gitignore/
https://github.com/katalon-studio-samples/tips-and-tricks/blob/master/.gitignore
https://forum.katalon.com/t/gitignore-template-for-katalon-studio/9793


 - **Link to application or project’s homepage**: 
 https://www.katalon.com/

