### PR TITLE
Update Swift.gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Finder View Preferences
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**
macOS creates a hidden .DS_Store file that contains user preferences about how to show items in finder, such as icon size and display mode (list/grid).
This file is unnecessary
