### PR TITLE
Added AWS SAM build folder (Node.js)

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -117,7 +117,7 @@ dist
 .dynamodb/
 
 # AWS SAM
-.aws-sam
+.aws-sam/
 
 # TernJS port file
 .tern-port

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -116,6 +116,9 @@ dist
 # DynamoDB Local files
 .dynamodb/
 
+# AWS SAM
+.aws-sam
+
 # TernJS port file
 .tern-port
 


### PR DESCRIPTION
Added the AWS SAM build folder (`.aws-sam`) to the node ignore list.

**Reasons for making this change:**
AWS SAM has a growing popularity for deploying simple Node.js applications to AWS. `.aws-sam` is the folder that is created whenever the application is built locally, and this folder shouldn't be committed into repositories. I believe that this folder should be added to the default list of ignored Node folders/files.

