### PR TITLE
Fix (Python.gitignore): Typo

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -46,7 +46,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
+*.py.cover
 .hypothesis/
 .pytest_cache/
 cover/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
We post-process `.gitignore` file for one of our services.   
Noticed a unexpected `,` in one of the filename, which is likely a typo.

