### PR TITLE
add auctex region

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -28,6 +28,9 @@ tramp
 # AUCTeX auto folder
 /auto/
 
+# AUCTeX region cache
+_region_.tex
+
 # cask packages
 .cask/
 dist/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
The emacs auctex system produces `_region_.tex` files while previewing latex files. These files should not be committed.

**Links to documentation supporting these rule changes:**
These docs and code describe the default location of the cache file.
[auctex docs
](https://www.gnu.org/software/auctex/manual/auctex.html#index-TeX_002dregion)
[source code ref](https://git.savannah.gnu.org/cgit/auctex.git/tree/tex-buf.el#n2269)

**Link to application or project’s homepage**
https://www.gnu.org/software/auctex/
