### PR TITLE
Xcode for SPM

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## SwiftPM
+.swiftpm
+
 ## User settings
 xcuserdata/
 
@@ -88,3 +91,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# Ever needed
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

The default package manager is SPM. The easy way to open SPM development is ``open Package.swift``. This open XCode and also create the directory ``.swiftpm``. This commit ignore this directory.

