### PR TITLE
Fix problems with Unity projects

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -2,13 +2,13 @@
 #
 # Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore
 #
-/[Ll]ibrary/
-/[Tt]emp/
-/[Oo]bj/
-/[Bb]uild/
-/[Bb]uilds/
-/[Ll]ogs/
-/[Uu]ser[Ss]ettings/
+[Ll]ibrary/
+[Tt]emp/
+[Oo]bj/
+[Bb]uild/
+[Bb]uilds/
+[Ll]ogs/
+[Uu]ser[Ss]ettings/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data


### PR DESCRIPTION
When the repo is created, the gitignore is in the root folder. However, Unity itself creates a new folder. That is why the paths are not correct.

**Reasons for making this change:**
Paths point to invalid folders because Unity still creates a subfolder.

