### PR TITLE
Remove `CodeInjection` block from Swift.gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -81,10 +81,3 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
-
-# Code Injection
-#
-# After new code Injection tools there's a generated folder /iOSInjectionProject
-# https://github.com/johnno1962/injectionforxcode
-
-iOSInjectionProject/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
Remove `CodeInjection` block which used by no longer maintained tool.

**Links to documentation supporting these rule changes:**

https://github.com/johnno1962/injectionforxcode#-injection-plugin-for-xcode