### PR TITLE
Emacs: ignore .dir-locals-2.el

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -42,7 +42,7 @@ flycheck_*.el
 .projectile
 
 # directory configuration
-.dir-locals.el
+.dir-locals-2.el
 
 # network security
 /network-security.data


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The file .dir-locals.el, which changes the behavior of Emacs within a directory, has been the subject of some debate in the past as to whether or not it should be committed.

Recently, Emacs has put an end to this debate by defining a .dir-locals-2.el file that allows each user to change the behavior of Emacs, so that the default Emacs behavior can be set within a project.

**Links to documentation supporting these rule changes:**
https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html
> You can also use .dir-locals-2.el; if found, Emacs loads it in addition to .dir-locals.el. This is useful when .dir-locals.el is under version control in a shared repository and can’t be used for personal customizations. 

