### PR TITLE
Create gitignore file for ECU-TEST workspaces

### DIFF
--- a/ECU-TEST.gitignore
+++ b/ECU-TEST.gitignore
@@ -1,4 +1,4 @@
-# gitignore template for ECU-TEST workspaces
+# gitignore template for ECU-TEST workspaces - by TraceTronic https://tracetronic.com
 # website: https://www.ecu-test.com
 #   * all directories are related to the default directories, please adapt the .gitignore if you use customized
 #     directories

--- a/ECU-TEST.gitignore
+++ b/ECU-TEST.gitignore
@@ -1,0 +1,62 @@
+# gitignore template for ECU-TEST workspaces
+# website: https://www.ecu-test.com
+#   * all directories are related to the default directories, please adapt the .gitignore if you use customized
+#     directories
+
+# Dynamic workspace settings
+#   * We don't recommend to ignore the .workspace directory, because of important project specific settings
+# local user settings
+.workspace/ETdrive.xml
+.workspace/favorites.xml
+.workspace/filters.xml
+.workspace/generators.xml
+.workspace/history.xml
+.workspace/parallelExecution.xml
+.workspace/signalviewer.xml
+.workspace/signalViewerHistory.json
+.workspace/signalviewer2layout.xml
+.workspace/testeditor.xml
+.workspace/tooladapter.xml
+.workspace/view.xml
+# optional, if your process depends on this file remove exclusion
+.workspace/interactiveexecution.xml
+.workspace/pythonlibrary.xml
+# deprecated, support for older versions
+.workspace/traceexplorer.xml
+
+# Custom file formats and test dependencies
+#  * you can manage your artifacts also with TEST-GUIDE (https://www.test-guide.info) and reference them via Playbooks
+*.arxml
+*.a2l
+*.dbc
+*.hex
+*.s19
+[tT]estdata
+[tT]estdaten
+
+# Test results and test execution related content
+#   * Git is not intended to store and provide test results for all iterations
+#   * We recommend to use TEST-GUIDE (https://www.test-guide.info) for the test report management
+TestReports
+
+# Report generators and templates
+#  * if you want to provide (f.e.) your own report generators exclude the directory here and ignore only the
+#    unnecessary subdirectories
+Templates
+
+# Exclude large binary artifacts
+#  * you can manage your artifacts also with TEST-GUIDE (https://www.test-guide.info) and reference them via Playbooks
+Offline-FIUs
+Offline-Models
+Offline-SGBDs
+*.exe
+*.msi
+*.zip
+*.7z
+
+# Exclude default and custom temporary directories
+Backup_*
+
+# Python bytecode and cache files
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

As the developers and product owners of [ECU-TEST](https://www.ecu-test.com), we want to provide a .gitignore template for all of our customers. 

**Links to documentation supporting these rule changes:**

There is no public documentation for these rules. The rules are documented within the file. Additional information can be requested via [TraceTronic Support](mailto:support@tracetronic.com).

If this is a new template:

 - **Link to application or project’s homepage**: [ECU-TEST](https://www.ecu-test.com)
