### PR TITLE
add community template for NextJs

### DIFF
--- a/community/JavaScript/Nextjs.gitignore
+++ b/community/JavaScript/Nextjs.gitignore
@@ -1,0 +1,34 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# next.js build files
+/.next/
+/out/
+
+# production build files
+/build
+
+# project linking
+.vercel
+
+# misc
+.DS_Store
+*.pem
+
+# debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+
+# sw stuff
+public/sw.js
+public/workbox-*.js


### PR DESCRIPTION
**Reasons for making this change:**
For dev who want to migrate from CRA to Nextjs

_TODO_

**Links to documentation supporting these rule changes:** [migrate](https://nextjs.org/docs/migrating/from-create-react-app)


If this is a new template:

 - **Link to application or project’s homepage**:  [nextjs](https://nextjs.org/)
