### PR TITLE
ignore temporary Microsoft Word template files (.dot/.dotx)

### DIFF
--- a/Global/MicrosoftOffice.gitignore
+++ b/Global/MicrosoftOffice.gitignore
@@ -2,6 +2,7 @@
 
 # Word temporary
 ~$*.doc*
+~$*.dot*
 
 # Word Auto Backup File
 Backup of *.doc*


### PR DESCRIPTION
**Reasons for making this change:**

I had a Word template that I created in my local directory to reuse for multiple documents (Research.dotx). While editing another document based on that template, the temporary file ~$Research.dotx was created in that folder, along with the temporary .docx file for the document I had open. When an automatic backup process committed my work overnight with Word still open, the .docx was ignored, but the .dotx was added to my repository.

**Links to documentation supporting these rule changes:**

https://support.microsoft.com/en-us/office/save-a-word-document-as-a-template-cb17846d-ecec-49d4-82ea-a6f5e3e8b9ae
https://support.microsoft.com/en-us/topic/description-of-how-word-creates-temporary-files-66b112fb-d2c0-8f40-a0be-70a367cc4c85