### PR TITLE
ignore node-config local files

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -32,6 +32,9 @@ coverage
 # Bower dependency directory (https://bower.io/)
 bower_components
 
+# node-config configuration (https://www.npmjs.com/package/config)
+config/local*
+
 # node-waf configuration
 .lock-wscript
 


### PR DESCRIPTION
[Node config](https://www.npmjs.com/package/config) is an often used module. It allows local configuration files that apply to the current platform and should not be tracked.

[https://github.com/node-config/node-config/wiki/Configuration-Files#local-files](https://github.com/node-config/node-config/wiki/Configuration-Files#local-files)

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
