### PR TITLE
Contrib folder is generated by Composer

### DIFF
--- a/Drupal.gitignore
+++ b/Drupal.gitignore
@@ -25,6 +25,7 @@
 /web/vendor
 /web/core
 /web/modules/README.txt
+/web/modules/contrib
 /web/profiles/README.txt
 /web/sites/development.services.yml
 /web/sites/example.settings.local.php


### PR DESCRIPTION
It should be excluded. If devs need to change in contrib modules, they can write patches also they can share them with the community.

https://www.drupal.org/docs/develop/git/using-git-to-contribute-to-drupal
