### PR TITLE
Ruby: Ignore .irb_history file

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -13,8 +13,9 @@
 # Used by dotenv library to load environment variables.
 # .env
 
-# Ignore Byebug command history file.
+# Ignore Byebug/IRB command history files.
 .byebug_history
+.irb_history
 
 ## Specific to RubyMotion:
 .dat*


### PR DESCRIPTION
**Reasons for making this change:**

In a Ruby IRB ("interactive Ruby") console session, my commands
are persisted in a file named `.irb_history`; by default the file
stores the last 1,000 commands.

It doesn't make sense to check my IRB history into a repository.

**Links to documentation supporting these rule changes:**

https://ruby-doc.org/stdlib-2.4.0/libdoc/irb/rdoc/IRB.html#module-IRB-label-History