### PR TITLE
Complete `OCaml.gitignore`

### DIFF
--- a/OCaml.gitignore
+++ b/OCaml.gitignore
@@ -8,7 +8,7 @@
 *.cmxs
 *.cmxa
 
-# ocamlbuild working directory
+# ocamlbuild and Dune default working directory
 _build/
 
 # ocamlbuild targets

--- a/OCaml.gitignore
+++ b/OCaml.gitignore
@@ -8,6 +8,13 @@
 *.cmxs
 *.cmxa
 
+# Files containing detailed information about the compilation (generated
+# by `ocamlc`/`ocamlopt` when invoked using the option `-bin-annot`).
+# These files are typically useful for code inspection tools
+# (e.g. Merlin).
+*.cmt
+*.cmti
+
 # ocamlbuild and Dune default working directory
 _build/
 


### PR DESCRIPTION
**Reasons for making this change:**

- Binary files `*.cmt` and `*.cmti` are generated by `ocamlc`/`ocamlopt` when invoked using the option `-bin-annot`.
- These files are used by code inspection tools such as Merlin.

**Links to documentation supporting these rule changes:**

- https://ocaml.org/manual/comp.html#s:comp-overview
