### PR TITLE
Removed redundant VS 6 technical files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -301,10 +301,6 @@ node_modules/
 *.dsw
 *.dsp
 
-# Visual Studio 6 technical files
-*.ncb
-*.aps
-
 # Visual Studio LightSwitch build output
 **/*.HTMLClient/GeneratedArtifacts
 **/*.DesktopClient/GeneratedArtifacts


### PR DESCRIPTION
**Reasons for making this change:**
# Visual C++ cache files
*.aps
*.ncb

Already contains the vs 6 technical files
See: 
https://github.com/github/gitignore/blob/main/VisualStudio.gitignore#L106
https://github.com/github/gitignore/blob/main/VisualStudio.gitignore#L107
