### PR TITLE
Update Swift.gitignore // Add Pods/ line to add Pods Generated

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -12,6 +12,7 @@ xcuserdata/
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
 DerivedData/
+Pods/
 *.moved-aside
 *.pbxuser
 !default.pbxuser


### PR DESCRIPTION
I add Pods cause if you are for example add RealmSwift as a pod you can not push it to the git cause big file error appears so it is need to be there.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
