### PR TITLE
Add *.trx to ignored files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -43,6 +43,7 @@ Generated\ Files/
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
+*.trx
 
 # NUnit
 *.VisualState.xml
@@ -396,6 +397,3 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
-
-# Microsoft Test Results XML file
-*.trx

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Microsoft Test Results file
+*.trx

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -397,5 +397,5 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 
-# Microsoft Test Results file
+# Microsoft Test Results XML file
 *.trx


### PR DESCRIPTION
**Reasons for making this change:**
As a user of .gitignore files, I wanted to include the ephemeral .trx (Test Result XML) files, as they are frequently built under project root, but (IMHO) not of value to commit to SCM.

**Links to documentation supporting these rule changes:**
No links available. This is my own opinion, from a project that I'm working on.
