### PR TITLE
Added DS_Store

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -21,6 +21,7 @@ DerivedData/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

When programming on mac computers the .DS_Store file is very common. This should be added to the .gitignore so that it does not accidentally get pushed. When i have worked with my many friends it is a common issue that they push this file for no reason. I therefore think it would be good to have this included so that this mistake is not carried though. Especially since the .DS_Store is a hidden file and many people do not think about its existence and therefore it can be hard to miss. Oh wait i meant it can be easy to miss.

_TODO_

**Links to documentation supporting these rule changes:**

[_TODO_](https://en.wikipedia.org/wiki/.DS_Store)

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
