### PR TITLE
Added .idea/ to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/


### PR DESCRIPTION
**Reasons for making this change:**

Added folder `.idea` which is created by the JetBrains Rider IDE for .NET projects.

See https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder-

