### PR TITLE
[VisualStudio.gitignore] Update VS Code ignores to match file in global

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -382,10 +382,13 @@ FodyWeavers.xsd
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-*.code-workspace
+!.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/
+
+# Built Visual Studio Code Extensions
+*.vsix
 
 # Windows Installer files from build outputs
 *.cab


### PR DESCRIPTION
**Reasons for making this change:**
VS Code ignores should match `Global/VisualStudioCode.gitignore` for consistency.

**Links to documentation supporting these rule changes:**
Code Snippets (PR #3916):
https://code.visualstudio.com/docs/editor/userdefinedsnippets#_project-snippet-scope
Workspace File (PR #3832):
https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-file
VSIX File (PR #3788):
https://code.visualstudio.com/api/working-with-extensions/publishing-extension#packaging-extensions