### PR TITLE
Ruby: ignore more command history files

### DIFF
--- a/Ruby.gitignore
+++ b/Ruby.gitignore
@@ -13,8 +13,11 @@
 # Used by dotenv library to load environment variables.
 # .env
 
-# Ignore Byebug command history file.
-.byebug_history
+# Ignore command history files.
+.byebug_history  # Byebug
+.rdbg_history    # debug.rb
+.irb_history     # IRB
+.pry_history     # Pry
 
 ## Specific to RubyMotion:
 .dat*


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Nowadays, with the advent of [debug.rb](https://github.com/ruby/debug) and the active development of [IRB](https://github.com/ruby/irb), etc, the realistic options of debuggers and REPLs in the Ruby world have been expanding. So now, it would be very useful to add the command history files of these leading tools here 🙌 

**Links to documentation supporting these rule changes:**

- debug.rb: https://github.com/ruby/debug/tree/v1.5.0#configuration-list
- IRB: https://ruby-doc.org/stdlib-3.1.2/libdoc/irb/rdoc/IRB.html#module-IRB-label-History
- Pry: https://github.com/pry/pry/wiki/Customization-and-configuration#Config_history