### PR TITLE
[AL] Ignore bclicense files

### DIFF
--- a/AL.gitignore
+++ b/AL.gitignore
@@ -16,7 +16,7 @@
 rad.json
 #Translation Base-file
 *.g.xlf
-#License-file
+#License-files
 *.bclicense
 *.flf
 #Test results file

--- a/AL.gitignore
+++ b/AL.gitignore
@@ -17,6 +17,7 @@ rad.json
 #Translation Base-file
 *.g.xlf
 #License-file
+*.bclicense
 *.flf
 #Test results file
 TestResults.xml


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

As suggested in this tweet https://twitter.com/schnieringer/status/1518652737369649153 by *Christian Schnieringer* we should ignore the `.bclicense` files aswell so that they don't get committed by accident.

**Links to documentation supporting these rule changes:**

https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/cside/cside-upload-license-file: `So we recommend that you use the .bclicense file if you've gotten one.`
