### PR TITLE
Create Dbt.gitignore

### DIFF
--- a/Dbt.gitignore
+++ b/Dbt.gitignore
@@ -1,0 +1,5 @@
+# dbt generated files
+target/
+dbt_modules/
+dbt_packages/
+logs/


### PR DESCRIPTION
**Reasons for making this change:**

[dbt](https://www.getdbt.com/) generates tons of files on running, so wanna add this template for ignoring the generated files.

**Links to documentation supporting these rule changes:**

This template is modified from the official repo [dbt-labs/dbt-utils](https://github.com/dbt-labs/dbt-utils/blob/main/.gitignore).

I remove the `venv` folder from that gitignore file because it is already covered by python.gitignore.

**If this is a new template:**

- [homepage](https://www.getdbt.com/)
- [github repo](https://github.com/dbt-labs/dbt-core)
