### PR TITLE
- Added Cypress gitignore file

### DIFF
--- a/Cypress.gitignore
+++ b/Cypress.gitignore
@@ -1,0 +1,18 @@
+node_modules
+
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+package-lock.json
+cypress/fixtures/
+cypress/videos/
+cypress/screenshot/
+mochawesome-report/
+cypress/reports/
+cypress/screenshots
+cypress/helpers/cms/savedData


### PR DESCRIPTION
- Added Cypress gitignore file

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

There was no ignore file for cypress end to end testing framework. 

**Links to documentation supporting these rule changes:**

https://github.com/cypress-io/cypress/blob/develop/.gitignore
The link above support the cypress gitignore changes.

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
