### PR TITLE
adding Intellisense precompiled headers

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -10,6 +10,7 @@
 # Precompiled Headers
 *.gch
 *.pch
+*.ipch
 
 # Compiled Dynamic libraries
 *.so


### PR DESCRIPTION


**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

ipch files can appear in Unreal projects folder with VS 2022.
I personally use Unreal Engine and git/perforce, and I would like to have Intellisense precompiled headers ignored on version control in the first place. I think other devs would like it as well. 

**Links to documentation supporting these rule changes:**

For more details on ipch files :
https://stackoverflow.com/questions/19398287/ipch-files-on-a-visual-studio-project
