### PR TITLE
UnrealEngine exclude binaries from Plugins recursively

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -47,7 +47,7 @@ SourceArt/**/*.tga
 
 # Binary Files
 Binaries/*
-Plugins/*/Binaries/*
+Plugins/**/Binaries/*
 
 # Builds
 Build/*


### PR DESCRIPTION
Example not excluded otherwise: `Plugins/Nvidia/DLSS/Binaries/`