### PR TITLE
Support for LaTeX Workshop with TeXlive

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -299,3 +299,6 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+
+# For the VS Code Extension: LaTeX Workshop with TeXlive 
+live.*.tex


### PR DESCRIPTION
**Reasons for making this change:**

For the VS Code Extension: [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) with TeXlive 
It produces live.main.tex