### PR TITLE
Added CMakeUserProfiles.json to CMake template

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -8,4 +8,5 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
+CMakeUserPresets.json
 _deps


### PR DESCRIPTION
**Reasons for making this change:**
CMake 3.19 introduced a feature which allows project maintainers to distribute CMake settings with their code. In addition, there is a facility for users to maintain a local set of CMake settings for convenience.


**Links to documentation supporting these rule changes:**

[CMake Profiles Documentation](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)

>CMakePresets.json may be checked into a version control system, and CMakeUserPresets.json should NOT be checked in. For example, if a project is using Git, CMakePresets.json may be tracked, and CMakeUserPresets.json should be added to the .gitignore.
