### PR TITLE
Update Global/Syncthing.gitignore

### DIFF
--- a/Global/Syncthing.gitignore
+++ b/Global/Syncthing.gitignore
@@ -1,2 +1,3 @@
 # Syncthing caches
 .stversions
+.stfolder


### PR DESCRIPTION
added missing ignore for .stfolder directories created by Syncthing

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Syncthing creates `.stfolder` directories alongside `.stversion` directories by default (they call it a "folder marker").

Relationship to the project: (which project?) I use Syncthing sometimes, I use these templates and this is my first PR here.
Expectations from this change: I'd like both to be ignored in the template, I don't expect to get anything beyond that.

**Links to documentation supporting these rule changes:**

[Syncthing FAQ](https://docs.syncthing.net/users/faq.html?highlight=stfolder#how-do-i-serve-a-folder-from-a-read-only-filesystem)
[Syncthing Configuration docs](https://docs.syncthing.net/users/config.html?highlight=stfolder#config-option-folder.markername)
