### PR TITLE
Update Maven.gitignore

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -15,3 +15,6 @@ buildNumber.properties
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+#This file records project specific settings vs. workspace preferences.
+.settings/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

It's good to take it out on legacy projects that can't be compiled with the latest and greatest java compiler or a source code generated by a 3rd party produces a lot of warnings that are benign but pollute your view. Otherwise keep it in .gitignore

**Links to documentation supporting these rule changes:**

[https://www.ibm.com/docs/en/spm/7.0.4?topic=files-settings-directory](url)
[https://wiki.lyrasis.org/pages/viewpage.action?pageId=30221028&focusedCommentId=30221030](url)

