### PR TITLE
Update Maven Wrapper url in Maven.gitignore

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,7 +7,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+# https://maven.apache.org/wrapper/#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
 # Eclipse m2e generated files


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Maven Wrapper has been migrated to Apache Maven. Also the currently linked README.md section doesn't exist anymore.

**Links to documentation supporting these rule changes:**

https://github.com/takari/maven-wrapper
https://github.com/apache/maven-wrapper
The currently linked section doesn't exist anymore: https://github.com/takari/maven-wrapper/commit/dce6f0ddb95c49d18ed659ccc729649bdd20210c#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119
GitHub link to the same section in the new Apache project: https://github.com/apache/maven-wrapper/blob/master/src/site/markdown/index.md#usage-without-binary-jar
Link to the same section in the new Apache project: https://maven.apache.org/wrapper/#usage-without-binary-jar
