### PR TITLE
gitignore for Visual Studio Code

### DIFF
--- a/vscode.gitignore
+++ b/vscode.gitignore
@@ -1,0 +1,4 @@
+### VSCODE ###
+#Template for Microsoft Visual Studio Code projects
+#vscode settings folder
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**
I use this a lot and am tired of having to write it every time, I'd preferr to just use it with GitHub Desktop

If this is a new template:

 - **Link to application or project’s homepage**: https://code.visualstudio.com/
