### PR TITLE
Ignore go.work.sum

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -19,3 +19,4 @@
 
 # Go workspace file
 go.work
+go.work.sum


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

As the `go.work` file is excluded, the `go.work.sum` file, which is generated based on the `go.work` file, should be excluded, too.
Also mentioned in https://github.com/github/gitignore/commit/fbc053fe49d7f3b4a882ddf9651fc60f8954db21#commitcomment-73352144

**Links to documentation supporting these rule changes:**
Currently there isn't much documentation regarding `go.work.sum` (see https://github.com/golang/go/issues/51941), the only thing I can refer to is the [proposal](https://go.googlesource.com/proposal/+/master/design/45713-workspace.md#preventing-files-from-being-checked-in-to-repositories), which suggests to not check in the `go.work` file.
