### PR TITLE
add more flexibility to Virtual environments

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -127,6 +127,10 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.env*/
+.venv*/
+env*/
+venv*/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
As a good practice, you should define your virtualenv alongside the python version like
`venv(3.10.4)` or `.env3.8.2`
