### PR TITLE
clean: remove outdated `microbundle` cache directories

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -57,12 +57,6 @@ web_modules/
 # Optional stylelint cache
 .stylelintcache
 
-# Microbundle cache
-.rpt2_cache/
-.rts2_cache_cjs/
-.rts2_cache_es/
-.rts2_cache_umd/
-
 # Optional REPL history
 .node_repl_history
 


### PR DESCRIPTION
## Summary

Remove outdated directories for `microbundle` from the Node `gitignore`

## Details

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

- `microbundle` hasn't used these directories in 3+ years
- and `rollup-plugin-typescript2`, which `microbundle` depends on and which actually created the dirs, hasn't used them in ~3 years either
- I help maintain rpt2 and formerly solo-maintained TSDX for ~1.5 years, which, as a fork of `microbundle`, has similarly used those directories in the past until I changed them

Noticed these when I used the built-in `gitignore` template in https://github.com/agilgur5/tsconfig/commit/8be4fdd46b578c20b6e173169bf8f51d25cd44a2

**Links to documentation supporting these rule changes:**

- https://github.com/developit/microbundle/pull/361
- https://github.com/ezolenko/rollup-plugin-typescript2/pull/167
- https://github.com/jaredpalmer/tsdx/pull/329

