### PR TITLE
Add .DS_Store to Xcode global and children

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,3 +1,6 @@
+## General
+.DS_Store
+
 ## User settings
 xcuserdata/
 

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## General
+.DS_Store
+
 ## User settings
 xcuserdata/
 

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## General
+.DS_Store
+
 ## User settings
 xcuserdata/
 


### PR DESCRIPTION
# Summary

This change introduces the addition of `.DS_Store` files to the **Xcode** global template and by inheritance, to the `Swift` & `Objective-C` children.

The ignore is already present in a few other files, for instance the `macOS.gitignore` but was missing from the most impactful one, the files used by developers based on **macOS** systems.
