### PR TITLE
Update VisualStudio.gitignore editorconfig

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -98,6 +98,9 @@ StyleCopReport.xml
 *.svclog
 *.scc
 
+#VisualStudio 2022 custom editor settings
+.editorconfig
+
 # Chutzpah Test files
 _Chutzpah*
 


### PR DESCRIPTION
VS2022 saves editor settings in an .editorconfig file.

Ref: https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2022

**Reasons for making this change:**
EditorConfig settings are supported by many code editors and IDEs, including Visual Studio. It's a portable component that travels with your code, and can enforce coding styles even outside of Visual Studio. I believe this is not wanted behavior unless 
you are enforcing coding standards within a closed team 

_TODO_

[**Links to documentation supporting these rule changes:**]
(https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2022)

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
