### PR TITLE
Remove duplicates.  *.aps and *.ncb included elsewhere

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -103,8 +103,6 @@ _Chutzpah*
 
 # Visual C++ cache files
 ipch/
-*.aps
-*.ncb
 *.opendb
 *.opensdf
 *.sdf


### PR DESCRIPTION
Someone added a new section, # Visual Studio 6 technical files, for *.aps and *.ncb, but these are duplicates in the file.  So duplicates removed.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
