### PR TITLE
Ignore Xamarin.Android Resource.Designer.cs files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,9 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# ignore Xamarin.Android Resource.Designer.cs files
+**/*.Droid/**/[Rr]esource.[Dd]esigner.cs
+**/*.Android/**/[Rr]esource.[Dd]esigner.cs
+**/Android/**/[Rr]esource.[Dd]esigner.cs
+**/Droid/**/[Rr]esource.[Dd]esigner.cs


### PR DESCRIPTION
**Reasons for making this change:**
The file is generated at compile time with Visual Studio Version Infos. Depending which version is used the file appears as edited.

_TODO_

XF Team has the same rule: https://github.com/xamarin/xamarin-forms-samples/blob/main/.gitignore

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
