### PR TITLE
Add Qt Creator clang cache folder in Qt.gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -52,3 +52,6 @@ compile_commands.json
 *creator.user*
 
 *_qmlcache.qrc
+
+# QtCreator clang cache
+.qtc_clangd/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
Since Qt Creator version 6, a cache folder for the clangd code model is created. This folder should be ignored on Git

**Links to documentation supporting these rule changes:**

