### PR TITLE
Create Deno.gitignore

### DIFF
--- a/Deno.gitignore
+++ b/Deno.gitignore
@@ -1,0 +1,36 @@
+*.orig
+*.pyc
+*.swp
+.env
+
+/.cargo_home/
+/.idea/
+/.vscode/
+gclient_config.py_entries
+/gh-pages/
+/target/
+/std/hash/_wasm/target
+/tools/wpt/manifest.json
+
+# Files that help ensure VSCode can work but we don't want checked into the
+# repo
+/node_modules
+/tsconfig.json
+
+# compiled wasm files
+std/wasi/testdata/snapshot_preview1/
+
+# generated v8 coverage files
+cli/tests/.test_coverage/
+
+# MacOS generated files
+.DS_Store
+.DS_Store?
+
+# Flamegraphs
+/flamebench*.svg
+/flamegraph*.svg
+
+# WPT generated cert files
+/tools/wpt/certs/index.txt*
+/tools/wpt/certs/serial*

--- a/Deno.gitignore
+++ b/Deno.gitignore
@@ -3,29 +3,13 @@
 *.swp
 .env
 
-/.cargo_home/
-/.idea/
-/.vscode/
 gclient_config.py_entries
-/gh-pages/
 /target/
 /std/hash/_wasm/target
 /tools/wpt/manifest.json
-
-# Files that help ensure VSCode can work but we don't want checked into the
-# repo
-/node_modules
-/tsconfig.json
-
-# compiled wasm files
-std/wasi/testdata/snapshot_preview1/
-
-# generated v8 coverage files
-cli/tests/.test_coverage/
-
-# MacOS generated files
-.DS_Store
-.DS_Store?
+/test_napi/node_modules
+/test_napi/build
+/test_napi/third_party_tests/node_modules
 
 # Flamegraphs
 /flamebench*.svg


### PR DESCRIPTION
This is a good file to include for those that are choosing to use the Deno framework for new projects. I believe that the Deno project is used enough to warrant an addition to Github's library of preconfigured .gitignore files.

The contents of the provided file is a direct copy of the .gitignore file provided by the project's own repository. The file I copied is located here: https://github.com/denoland/deno/blob/main/.gitignore.

I am not affiliated with the Deno project.

To learn more about the Deno project, please visit https://deno.land.

An explanation for the ignored files not mentioned in the comments directly in the file:
```
*.orig # Generally used as a backup when making changes to a file to compare with the original. These can clutter up a repository when they are left as a future reference.
*.pyc # A compiled python script
*.swp # A swap file created by the Vi editor and it's derivatives
.env # A file containing environment variables. Committing this file to a repository can pose a major security risk.

/.cargo_home/ # A directory used by Cargo: https://github.com/rust-lang/cargo#compiling-from-source
/.idea/ # A configuration directory used by JetBrains programs.
/.vscode/ # A configuration directory used by Visual Studio Code
gclient_config.py_entries # I'm not entirely sure what this is beyond that it is related to gclient, see: https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/HEAD/README.gclient.md. If you know more, please feel free to submit a PR with an explanation replacing this comment.
/gh-pages/ # A directory used by Github Pages
/target/ # Often used as an output folder when compiling, building, transpiling, etc. code.
/std/hash/_wasm/target # I assume this is a target folder when compiling web assembly. If you know, please feel free to submit a PR with an explanation replacing this comment.
/tools/wpt/manifest.json # Manifest file for web-platform-tests.
```

Please see the file in the PR for explanations of the rest of the included rules.
