### PR TITLE
Extend VisualStudio.gitignore by $tf1

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -123,6 +123,7 @@ ipch/
 
 # TFS 2012 Local Workspace
 $tf/
+$tf[1-9]/
 
 # Guidance Automation Toolkit
 *.gpState


### PR DESCRIPTION
Usually cache folder $tf is created for init a TFS project.
But it creates folder $tf1 when you connect to your team project after renaming the repo folder.
On the next renaming the $tf2 is created, so it makes sense to ignore $tf1 to $tf9.
