### PR TITLE
Add DLL and PDB to Java gitignore

### DIFF
--- a/Java.gitignore
+++ b/Java.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Microsoft/VSCode files
+*.dll
+*.pdb


### PR DESCRIPTION
These files are commonly found when using Windows and/or VSCode and should not generally be checked in by default.  They are typically large and cause upload problems.

**Reasons for making this change:**

I use github extensively when teaching robotics coding to high school students.  This problem catches them out continually whenever they try to add a new repo.  Fixing it is fiddly.

**Links to documentation supporting these rule changes:**

https://stackoverflow.com/questions/47152662/how-to-ignore-dll-and-pdb-files-in-git-with-vs2015
