### PR TITLE
Add environment file to Golang gitignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -19,3 +19,7 @@
 
 # Go workspace file
 go.work
+
+# Environment file
+.env
+.ENV


### PR DESCRIPTION
**Reasons for making this change:**
 Prevent sensible information such as environment variables from being uploaded to a public repo

Links to documentation supporting these rule changes:
There isn't too much documentation but I found this page that explains why we should add the environment file into .gitignore https://salferrarello.com/add-env-to-gitignore/