### PR TITLE
Update Scala template to include `.tasty` files introduced in Scala 3

### DIFF
--- a/Scala.gitignore
+++ b/Scala.gitignore
@@ -1,4 +1,5 @@
 *.class
+*.tasty
 *.log
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Scala 3 introduced a new type of IR file that is produced when compiling Scala sources with the new compiler - `.tasty` files. When version control is concerned, those files should be treated the same way `.class` files are.

My relationship to the project: I'm one of the maintainers [see here](https://github.com/lampepfl/dotty/blob/main/MAINTENANCE.md).

**Links to documentation supporting these rule changes:**

[https://docs.scala-lang.org/scala3/guides/tasty-overview.html](https://docs.scala-lang.org/scala3/guides/tasty-overview.html)
