### PR TITLE
Ignore *.aab

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -12,6 +12,7 @@ local.properties
 captures/
 .externalNativeBuild/
 .cxx/
+*.aab
 *.apk
 output.json
 


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_"After August 2021, all new apps and games will be required to publish with the Android App Bundle format."_
Generated Android App Bundles (\*.aab), just like Android Packages (\*.apk), should not be checked into VCS.

**Links to documentation supporting these rule changes:**

[Android Developers Blog: New Android App Bundle and target API level requirements in 2021](https://android-developers.googleblog.com/2020/11/new-android-app-bundle-and-target-api.html)