### PR TITLE
Ignore unity import auto-generated meta

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -61,6 +61,9 @@ sysinfo.txt
 *.unitypackage
 *.app
 
+# Import auto-generated files
+*.unitypackage.meta
+
 # Crashlytics generated file
 crashlytics-build.properties
 


### PR DESCRIPTION
**Reasons for making this change:**
When you import a local `*.unitypackage` file into Unity, the editor might save a copy of the imported package file next to the extracted content.

Unity creates a `<filename>.meta` file for every file.
As `*.unitypackage` is already ignored in the template, only the `*.unitypackage.meta` file gets checked into version control.

If user A imports the package, his unity instance creates the meta file, and it gets committed.
The unity instance of user B sees only the `*.meta` file and automatically deletes it.
User A gets a commit with the `*.meta` deleted, so his Unity recreates the file.

This causes an infinite cycle of creation and deletion.