### PR TITLE
Added `dist/` in go ignore

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+dist/


### PR DESCRIPTION
**Reasons for making this change:**
By default, the goreleaser tool will create its artifacts in the `dist/` directory. and this should not be part of the repo, generally


**Links to documentation supporting these rule changes:**

More info: https://goreleaser.com/customization/dist/


