### PR TITLE
Added .DS_Store to gitignore

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+# macOS System Files
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

.DS_Store files are generated automatically by macOS, and it should be omitted from source control.