### PR TITLE
ignore files without extensions

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -1,3 +1,8 @@
+# Compiled Object files without extensions
+*
+!*/
+!*.*
+
 # History files
 .Rhistory
 .Rapp.history


### PR DESCRIPTION
**Reasons for making this change:**

Some R packages (e.g., `rstan`) create compiled object files without extensions, which should be ignored.
