### PR TITLE
ROS_gitignore - ignore catkin_tools directory

### DIFF
--- a/ROS.gitignore
+++ b/ROS.gitignore
@@ -49,3 +49,4 @@ qtcreator-*
 
 # Catkin custom files
 CATKIN_IGNORE
+.catkin_tools


### PR DESCRIPTION
Reasons for change:
You can initialize a ROS build system using catkin init or catkin build, both of which create a hidden folder called .catkin_tools. The folder is then regenerated every time that you build the packages in the workspace. Since the build command is done locally on the user's own machine, the folder should be ignored when pushing to a repo. 
Explanation and references:
[catkin](http://wiki.ros.org/catkin) is the official build system of ROS. 
[.catkin_tools](https://catkin-tools.readthedocs.io/en/latest/quick_start.html) folder marks a directory path, which might differ from the local path to which the library was cloned. This could cause errors. Otherwise, without errors, the catkin build command, creates the path to match the existing local workspace structure. See implementation [here](https://github.com/catkin/catkin_tools/blob/main/catkin_tools/verbs/catkin_build/build.py). 