### PR TITLE
Add ignores for Angular projects

### DIFF
--- a/Global/Angular.gitignore
+++ b/Global/Angular.gitignore
@@ -1,0 +1,30 @@
+dist/
+tmp/
+/out-tsc
+
+# dependencies
+node_modules/
+bower_components/
+
+# IDEs and editors
+.idea/
+jsconfig.json
+.vscode/
+
+# misc
+/.angular
+/.angular/cache
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+
+#System Files
+**/.DS_Store
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Reasons for making this change:

Make Angular and Angular Schematics development and deploy easier  

Links to documentation supporting these rule changes:

https://angular.io/cli/cache
https://angular.io/guide/schematics

If this is a new template:

Link to application or project’s homepage: http://angular.io/