### PR TITLE
ignore visual studio live config file

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -151,6 +151,9 @@ coverage*.info
 *.coverage
 *.coveragexml
 
+# Visual Studio live testing config
+*.lutconfig
+
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml


### PR DESCRIPTION
**Reasons for making this change:**

Ignore Visual Studio live testing config

**Links to documentation supporting these rule changes:**

https://devblogs.microsoft.com/visualstudio/live-unit-testing-preview-better-and-faster/#configuration-and-setup
