### PR TITLE
Refine .xcworkspace ignores for CocoaPods

### DIFF
--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -40,6 +40,7 @@ DerivedData/
 #
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
+# !*.xcodeproj/project.xcworkspace
 
 # Carthage
 #

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -58,6 +58,7 @@ playground.xcworkspace
 #
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
+# !*.xcodeproj/project.xcworkspace
 
 # Carthage
 #


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I recently migrated a CocoaPods based project into a Swift Package Manager project and found issues when building the project with CI due to `Project.xcodeproj/project.xcworkspace/` accidentally ignored by CocoaPods related rules. This PR fixes the issue.

**Links to documentation supporting these rule changes:**

[Resolving Versions (Package.resolved File)
](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#resolving-versions-packageresolved-file)
