### PR TITLE
C++: precompiled C++2b module files

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -11,6 +11,10 @@
 *.gch
 *.pch
 
+# Precompiled module files
+ModuleCache
+*.pcm
+
 # Compiled Dynamic libraries
 *.so
 *.dylib


### PR DESCRIPTION
**Links to documentation supporting these rule changes:**

[Clang Documentation](https://clang.llvm.org/docs/StandardCPlusPlusModules.html)

