### PR TITLE
Add Zig.gitignore

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,0 +1,7 @@
+zig-cache/
+zig-out/
+/release/
+/debug/
+/build/
+/build-*/
+/docgen_tmp/


### PR DESCRIPTION
This `.gitignore` template is taken from https://github.com/ziglang/zig/blob/master/.gitignore.

 - **Link to application or project’s homepage**: https://ziglang.org/
