### PR TITLE
Add MSBuild_Logs/ to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -351,6 +351,7 @@ ASALocalRun/
 
 # MSBuild Binary and Structured Log
 *.binlog
+MSBuild_Logs/
 
 # NVidia Nsight GPU debugger configuration file
 *.nvuser


### PR DESCRIPTION


**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The MsBuild team added a switch to the Visual Studio engine that generates a debugging information under the directory MsBuild_Logs/ that shouldn't be in source control systems.

**Links to documentation supporting these rule changes:**

- Here's the [original PR](https://github.com/dotnet/msbuild/commit/cdb5077c451180ab38161e0b5e70f5448e70355b) from the msbuild team. 
- Here is the documentation from the msbuild team explaining the feature that [generates the path](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs)
- Heres' a similar PR for the dotnet [runtime](https://github.com/dotnet/runtime/pull/59323)

If this is a new template:

 - **Link to application or project’s homepage**:  N/A
