### PR TITLE
Add CompetitiveProgramming.gitignore

### DIFF
--- a/community/CompetitiveProgramming.gitignore
+++ b/community/CompetitiveProgramming.gitignore
@@ -1,0 +1,9 @@
+# gitignore template for competitive programming (ICPC, IOI, Codeforces Round, etc.)
+
+# input/output files
+*.in
+*.out
+*.ans
+
+# executable files
+*.exe


### PR DESCRIPTION
As far as I know, some sport programmers (those who submit codes on online judge websites) like to use git and GitHub to manage their codes. This gitignore contains IO files and executable files which aren't necessary to keep track on.

The file name might be too long? Maybe I should change that.