### PR TITLE
Update UnrealEngine.gitignore - Jetbrains Rider

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,9 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# Jetbrains Rider project files
+.idea/
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
Ignore Jetbrains Rider (default or Unreal Engine version) generated project and settings files.

Jetbrains Rider IDE page: https://www.jetbrains.com/lp/rider-unreal/

Many Unreal Engine developers use Rider IDE instead of Visual Studio, as it has better code completion and UE specific hints, such as Blueprint class usage counters, UPROPERTY and UFUNCTION macros parameters e.t.c.