### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -30,7 +30,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt


### PR DESCRIPTION
**Reasons for making this change:**
spec file created by PyInstaller is useful to share, since contains information like hidden-imports, datas and exe-related meta that are fundamentals and necessary for other developers to recreate the exe locally, without struggling to search by themselves what imports and other things are needed.
The vast majority of the time, this isn't a simple file automatically generated by PyInstaller, but a file that needs to be manually changed and adjusted by the dev in order to get all the things working properly.

**Links to documentation supporting these rule changes:**

https://pyinstaller.org/en/stable/spec-files.html#spec-file-operation
