### PR TITLE
Add emacs directory variable file pattern

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -43,6 +43,7 @@ flycheck_*.el
 
 # directory configuration
 .dir-locals.el
+.dir-locals-2.el
 
 # network security
 /network-security.data


### PR DESCRIPTION
I use GNU Emacs and dir-locals.el files to manage my config for individual projects.  I noticed that the recommendation in Global/Emacs.gitignore doesn't cover all cases.

See [Emacs docs](https://gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html):
> You can also use .dir-locals-2.el; if found, Emacs loads it in addition to .dir-locals.el. This is useful when .dir-locals.el is under version control in a shared repository and can’t be used for personal customizations.

I have tested locally that GNU Emacs 28.2 doesn't support other numbers (e.g. dir-locals-3.el etc).