### PR TITLE
Add a Latex.gitignore

### DIFF
--- a/Latex.gitignore
+++ b/Latex.gitignore
@@ -1,0 +1,17 @@
+# LaTex auxilary files
+*.aux
+
+# LaTex Log files
+*.log
+
+# LaTex tables
+*.lot
+*.lof
+*.toc
+
+# Synctex archives
+*.synctex.gz
+
+
+# Pdf Documents
+*.pdf


### PR DESCRIPTION
**Reasons for making this change:**

Latex is widely used to write research papers. When papers are written by several authors, sources there are commonly 
hosted on GitHub to collaborate more efficiently. However, Latex compilers are producing a lot of auxiliary files that one typically doesn't want to include in commits. This .gitignore lists Latex-generated files that could/should be ignored by git.

**Links to documentation supporting these rule changes:**

[https://www.dickimaw-books.com/latex/novices/html/auxiliary.html](https://www.dickimaw-books.com/latex/novices/html/auxiliary.html)

**Link to application or project’s homepage**:

[https://www.latex-project.org/](https://www.latex-project.org/)
