### PR TITLE
Add UPM samples folder to Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -70,3 +70,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Samples imported via Package Manager
+/[Aa]ssets/[Ss]amples/
+/[Aa]ssets/[Ss]amples.meta


### PR DESCRIPTION
When importing samples via Unity Package Manager it creates them in Assets/Samples.  This folder likely shouldn't end up in source control.

**Reasons for making this change:**
It's easy to end up committing sample code that is not meant to be in a project if this folder isn't ignored.
