### PR TITLE
ignore meta files of unity packages

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -59,6 +59,7 @@ sysinfo.txt
 *.apk
 *.aab
 *.unitypackage
+*.unitypackage.meta
 *.app
 
 # Crashlytics generated file


### PR DESCRIPTION
Unity will automatically generate [meta files](https://docs.unity3d.com/Manual/AssetMetadata.html) for just about any file added to its directory structure. This is in order to maintain references between things that may be moving around or getting renamed in the project.

It's very common that an asset from the Unity Asset Store comes with `.unitypackage` files for optional features or compatibility add-ons. In such a case, the importer's machine will contain a `.unitypackage` and `.unitypackage.meta` file. 

The `.unitypackage` file is ignored by this template, but the `.unitypackage.meta` file is not. If the meta file isn't also ignored, the person who imports an asset containing a `.unitypackage` file could accidentally commit the meta files. The next person will pull in those meta files, which Unity will consider orphaned without the accompanying `.unitypackage` file. Unity will automatically delete the orphaned meta files, and those deletes also tend to get committed. The importer auto-adds and commits them again, and the cycle goes on and on until someone like me gets fed up.

This change fixes that inconsistency by adding the `*.unitypackage.meta` to the ignore list.