### PR TITLE
In Python.gitignore's comments delete some `:`s

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -55,17 +55,17 @@ cover/
 *.mo
 *.pot
 
-# Django stuff:
+# Django stuff
 *.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
-# Flask stuff:
+# Flask stuff
 instance/
 .webassets-cache
 
-# Scrapy stuff:
+# Scrapy stuff
 .scrapy
 
 # Sphinx documentation
@@ -84,7 +84,7 @@ ipython_config.py
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
+#   intended to run in multiple environments; otherwise, check them in.
 # .python-version
 
 # pipenv


### PR DESCRIPTION
-------

**Reasons for making this change:**

This change makes `Python.gitignore`'s comments more consistent.

##### Before
``` gitignore
# Django stuff:

# Celery stuff
```
##### After
``` gitignore
# Django stuff

# Celery stuff
```

##### Before
``` gitignore
# PyInstaller
#  Usually these files are written by a python script from a template
#  before PyInstaller builds the exe, so as to inject date/other infos into it.

# pyenv
#   For a library or package, you might want to ignore these files since the code is
#   intended to run in multiple environments; otherwise, check them in:
```
##### After
``` gitignore
# PyInstaller
#  Usually these files are written by a python script from a template
#  before PyInstaller builds the exe, so as to inject date/other infos into it.

# pyenv
#   For a library or package, you might want to ignore these files since the code is
#   intended to run in multiple environments; otherwise, check them in.
```