### PR TITLE
Add files to ignore in Node projects

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -125,6 +125,7 @@ dist
 # yarn v2
 .yarn/cache
 .yarn/unplugged
+.yarn/releases
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*


### PR DESCRIPTION
Add .yarn/releases to Node.gitignore. When using yarn set version <version> as outlined on <https://yarnpkg.com/cli/set/version> in your git repo you end up with .yarn/releases/yarn-*.cjs (>2MB) that should not be commited to git in my eyes.


