### PR TITLE
KiCAD - Ignore local project settings and backups

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -16,6 +16,7 @@ _autosave-*
 *-save.pro
 *-save.kicad_pcb
 fp-info-cache
+*-backups
 
 # Netlist files (exported from Eeschema)
 *.net
@@ -27,3 +28,6 @@ fp-info-cache
 # Exported BOM files
 *.xml
 *.csv
+
+# Local project settings
+*.kicad_prl


### PR DESCRIPTION
**Reasons for making this change:**
As an embedded engineer I use git for my source control system. It works great for Firmware/Software and thus I use it for my Kicad based PCB designs. The current .gitignore template however is dated and not up to date with the latest file extensions of Kicad v6.

The file extensions and standards have changed for KiCAD backup. Thus the addition of ```*-backups``` and local project settings are now saved in a ```*.kicad_prl``` file. These are intended to be used for the local developer and are not settings you push to other developers when using git as a source control method.

**Links to documentation supporting these rule changes:**
https://forum.kicad.info/t/new-project-file-format/23705
