### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -32,6 +32,13 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+#Xamarin build results
+*/[Bb]in/
+*/[Oo]bj/
+*/[Oo]ut/
+*/[Ll]og/
+*/[Ll]ogs/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot


### PR DESCRIPTION
Included Xamarin build files

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
Just contributing, The standard template leaves out these files and its a headache. Just a little sunshine for the next developer's rainy day :)

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
