### PR TITLE
Remove extra .cache pattern

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -102,7 +102,6 @@ dist
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Docusaurus cache and generated files
 .docusaurus

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -100,7 +100,7 @@ dist
 # vuepress build output
 .vuepress/dist
 
-# vuepress v2.x temp and cache directory
+# vuepress v2.x temp directory
 .temp
 
 # Docusaurus cache and generated files


### PR DESCRIPTION
pattern ".cache" is duplicate and already defined in parcel-bundler section

**Reasons for making this change:**
".cache" patter is extra and already defined in parcel-bundler section at line number 87

**Links to documentation supporting these rule changes:**

https://github.com/github/gitignore/blob/main/Node.gitignore#L83

If this is a new template:

 - **Link to application or project’s homepage**: NA
