### PR TITLE
Create KickAssembler.gitignore

### DIFF
--- a/KickAssembler.gitignore
+++ b/KickAssembler.gitignore
@@ -1,0 +1,21 @@
+# gitignore template for KickAssembler project inside Visual Studio Code
+# website: http://theweb.dk/KickAssembler/Main.html
+#
+# Generated from build
+build
+*.prg
+*.sym
+*.dbg
+
+# typical lib folder
+.ra
+
+# gradle
+.gradle
+
+# other unused files
+.asminfo.txt
+.source.txt
+*.vs
+.idea
+.vscode


### PR DESCRIPTION
**Reasons for making this change:**
Adding gitignore for KickAssembler project (Commodore 64 compiler)

**Links to documentation supporting these rule changes:**

If this is a new template:

 - **Link to application or project’s homepage**:  http://theweb.dk/KickAssembler/Main.html
