### PR TITLE
Adding the dependency lock file the template.

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore Dependancy lock files
+# example: *lock.hcl


### PR DESCRIPTION
The lock file ties to an external provider dependency, it's something you'd want the option to not have under git control. https://developer.hashicorp.com/terraform/language/files/dependency-lock

**Reasons for making this change:**
It's a file that many would probably want to ignore.

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
