### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea


### PR DESCRIPTION
Included an entry to ignore the ".idea" IntelliJ IDEA directory that gets created with Rider.

**Reasons for making this change:**
Required
