### PR TITLE
add visual studio backup files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Backup files created when files are modified outside of Visual Studio
+# It is named "<filename> - Backup.csproj"
+* - Backup.csproj


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Backup files should not be committed

**Links to documentation supporting these rule changes:**

Undocumented AFAIK, but see for example https://github.com/github/VisualStudio/issues/2597
