### PR TITLE
feat: add turbo cache folder

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -113,6 +113,9 @@ dist
 # FuseBox cache
 .fusebox/
 
+# Turbo repo and pack cache
+.turbo
+
 # DynamoDB Local files
 .dynamodb/
 


### PR DESCRIPTION
**Reasons for making this change:**
Turbo repo generates a folder .turbo, this folder should be ignored

**Links to documentation supporting these rule changes:**

https://turbo.build/repo
