### PR TITLE
Ignore gradle bin directory

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,6 +1,7 @@
 .gradle
 **/build/
 !src/**/build/
+**/bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
When compiled, class files created in bin directory.
These should be ignored.
