### PR TITLE
feat(dm): ignore map backups and savefiles

### DIFF
--- a/DM.gitignore
+++ b/DM.gitignore
@@ -1,5 +1,7 @@
+backup/*.dmm
 *.dmb
 *.rsc
 *.int
 *.lk
+*.sav
 *.zip


### PR DESCRIPTION
**Reasons for making this change:**
- Map backups should be excluded from versioning because maps are already versioned.
- Most games have savefiles in the `.sav` format and should be excluded from versioning.