### PR TITLE
ignore mono crash files

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -9,3 +9,4 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+mono_crash*


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I'm working on Godot projects, and mono crash files appear when building a Godot C# project fails. They are crash logs that should not be checked into version control.
