### PR TITLE
Add ruff_cache

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -143,6 +143,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff Python linter
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 


### PR DESCRIPTION
[Ruff](https://github.com/charliermarsh/ruff) is a Python linter which generate ruff_cache directory.

