### PR TITLE
Update Godot.gitignore for Godot 4+

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,3 +1,6 @@
+# Godot 4+ specific ignores
+.godot/
+
 # Godot-specific ignores
 .import/
 export.cfg


### PR DESCRIPTION
**Reasons for making this change:**
Godot 4 Beta was recently released. It adds a .godot folder that should be ignored in git

I am an end user that used this template but it was missing the .godot folder

**Links to documentation supporting these rule changes:**
.gitignore file from a official godot 4 demo project:
https://github.com/godotengine/godot-demo-projects/blob/master/.gitignore
