### PR TITLE
Add Mac OS .DS_Store files ignoring

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -299,3 +299,7 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+
+## Operating Systems:
+# Mac OS
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

I use to use LaTeX for several projects, mainly publishing projects.
When working on Mac OS, adding files or folders to a TeX repository may yield .DS_Store files. Those files are useless regarding versioning, hence they add unnecessary noise to the repository, and would better be ignored automatically.

**Links to documentation supporting these rule changes:**

[.DS-Store files Wikipedia page](https://en.wikipedia.org/wiki/.DS_Store)