### PR TITLE
Sync TYPO3.gitignore with project standard

### DIFF
--- a/Typo3.gitignore
+++ b/Typo3.gitignore
@@ -1,23 +1,12 @@
-## TYPO3 v6.2
-# Ignore several upload and file directories.
-/fileadmin/user_upload/
-/fileadmin/_temp_/
-/fileadmin/_processed_/
-/uploads/
-# Ignore cache
-/typo3conf/temp_CACHED*
-/typo3conf/temp_fieldInfo.php
-/typo3conf/deprecation_*.log
-/typo3conf/ENABLE_INSTALL_TOOL
-/typo3conf/realurl_autoconf.php
-/FIRST_INSTALL
-# Ignore system folders, you should have them symlinked.
-# If not comment out the following entries.
-/typo3
-/typo3_src
-/typo3_src-*
-/Packages
-/.htaccess
-/index.php
-# Ignore temp directory.
-/typo3temp/
+.DS_Store
+.idea
+nbproject
+/var/*
+!/var/labels
+/vendor
+/public/*
+!/public/.htaccess
+!/public/typo3conf
+/public/typo3conf/*
+!/public/typo3conf/LocalConfiguration.php
+!/public/typo3conf/AdditionalConfiguration.php


### PR DESCRIPTION
**Reasons for making this change:**

The TYPO3 has evolved drastically in the recent years. The current `.gitignore` has been last updated 5 years ago and seems radically outdated. This PRs seeks to update the `.gitignore` to the TYPO3 standard allowing users to start clean.

**Links to documentation supporting these rule changes:**

- [Base Distribution's .gitignore](https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/blob/main/.gitignore)