### PR TITLE
add `.DS_Store` to Android `.gitignore` template

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Mac
+.DS_Store


### PR DESCRIPTION
ignoring .DS_Store for Android projects on mac

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

When working on a mac, DS_Store files are automatically added to folders in Android projects. These files don't need to be in the repository, they are not related to Android source code in any way. Therefore, they should be ignored.

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store#:~:text=In%20the%20Apple%20macOS%20operating,positions%2C%20and%20other%20visual%20information.

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
