### PR TITLE
Added package-lock.json for Node.js Tools for Visual Studio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -283,6 +283,7 @@ FakesAssemblies/
 
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
+package-lock.json
 node_modules/
 
 # Visual Studio 6 build log


### PR DESCRIPTION
**Application of the change:**
The change is made in VisualStudio.gitignore for Node.js Tools for Visual Studio

**Reasons for making this change:**
package-lock.json is automatically generated for any operations where npm modifies either the node_modules tree or package.json. That is why node_modules and package.json must be managed together so that package.json is consistent with what node_modules contains, or else, npm may not work correctly. As it is essential to ignore node_modules, it is also vital to ignore package-lock.json.

**Links to documentation supporting these rule changes:**
Documentation about package-lock.json: https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json