### PR TITLE
Remove JetBrains IDE Files from VS Ignore List

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -393,6 +393,3 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
-
-# JetBrains Rider
-*.sln.iml

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -392,4 +392,4 @@ FodyWeavers.xsd
 *.msi
 *.msix
 *.msm
-*.msp
+*.msp 

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -392,4 +392,4 @@ FodyWeavers.xsd
 *.msi
 *.msix
 *.msm
-*.msp 
+*.msp


### PR DESCRIPTION
https://github.com/dotnet/sdk/issues/29224

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
Hi, I work on the .NET SDK at MSFT. We noticed from a customer, due to the below issue, that JetBrains files are in the VS .gitignore template, which doesn't really make sense. The last person who removed the other files didn't understand what the `sln.iml` file was for so they didn't remove it, but it should be removed. https://github.com/github/gitignore/pull/3895 

**Links to documentation supporting these rule changes:**
https://github.com/dotnet/sdk/issues/29224

