### PR TITLE
Update TwinCAT3.gitignore

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -3,23 +3,32 @@
 #
 # Recommended: VisualStudio.gitignore
 
-# TwinCAT files
+# TwinCAT3 PLC
+*.plcproj.bak
+*.plcproj.orig
 *.tpy
 *.tclrs
 *.compiled-library
-*.compileinfo
-# Don't include the tmc-file rule if either of the following is true:
-#   1. You've got TwinCAT C++ projects, as the information in the TMC-file is created manually for the C++ projects (in that case, only (manually) ignore the tmc-files for the PLC projects)
-#   2. You've created a standalone PLC-project and added events to it, as these are stored in the TMC-file.
-*.tmc
-*.tmcRefac
 *.library
-*.project.~u
-*.tsproj.bak
-*.xti.bak
+*.compileinfo
 LineIDs.dbg
 LineIDs.dbg.bak
-_Boot/
-_CompileInfo/
-_Libraries/
-_ModuleInstall/
+
+*.tmcRefac
+
+# TwinCAT3 project files
+*.tsproj.bak
+*.tsproj.b?k
+*.tsproj.orig
+*.xti.bak
+*.xti.b?k
+*.xti.orig
+*.project.~u
+
+# folders that should be excluded
+**/_Boot/
+**/_CompileInfo/
+**/_Libraries/
+**/_ModuleInstall/
+**/_Deployment/
+**/_Repository/


### PR DESCRIPTION
adapted to the current version and to the fact that the expcluded folders can also exist in subfolders

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
