### PR TITLE
Updated Unreal GitIgnore to ignore nested  Binaries/Intermediate folders

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -47,7 +47,7 @@ SourceArt/**/*.tga
 
 # Binary Files
 Binaries/*
-Plugins/*/Binaries/*
+Plugins/**/Binaries/*
 
 # Builds
 Build/*
@@ -68,7 +68,7 @@ Saved/*
 
 # Compiled source files for the engine to use
 Intermediate/*
-Plugins/*/Intermediate/*
+Plugins/**/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*


### PR DESCRIPTION

I.E Plugins/MyCompaniesPlugins/Plugin1/Intermediate/ would not have been ignored previously.

Usually, plugins in unreal are not nested, but there is no reason they can't be!

I have no relationship to this project. 