### PR TITLE
Ignore .vscode folder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Visual Studio Code (VS Code)
+# If you do not want to share settings, tasks and debug configurations, you can uncomment the following to ignore the entire (.vscode) folder.
+#.vscode/


### PR DESCRIPTION
**Reasons for making this change:**
- The folder (.vscode) sometimes gets committed for no reason. Some people might need it but, most people don't.

<!-- Include your relationship to the project and what you expect to get from this change. -->
- I use Visual Studio Code & this file for almost every python project to ignore certain files and folders.

_TODO_
- If someone needs to ignore the (.vscode) folder, they can just uncomment it and they're good to go.

**Links to documentation supporting these rule changes:**
There are no official documentations. If there are, I just couldn't find them. It's more of a convention, some people want to ignore this folder and some don't  :)

_TODO_
- If someone finds some documentation on this, help is appreciated.

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
