### PR TITLE
Added target directory to Git exclusion list

### DIFF
--- a/Global/NetBeans.gitignore
+++ b/Global/NetBeans.gitignore
@@ -6,3 +6,4 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+target/


### PR DESCRIPTION
**Reasons for making this change:**

`target` directory is not included in the NetBeans.gitignore template file.

**Links to documentation supporting these rule changes:**

Made a new Java Maven project under NetBeans 16. Build files were saved in `target` directory.