### PR TITLE
Update `maven-wrapper` URL

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,7 +7,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+# https://maven.apache.org/wrapper/#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
 # Eclipse m2e generated files


### PR DESCRIPTION
**Reasons for making this change:**

The Maven Wrapper is now part of the Apache Software Foundation therefore the current URL about its usage without the binary JAR is outdated.

**Links to documentation supporting these rule changes:**

https://maven.apache.org/wrapper/#usage-without-binary-jar