### PR TITLE
filter Windows thumbs and Mac Finder parameters

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -26,6 +26,18 @@
 #*.obj
 #
 
+# Default Delphi compiler directories
+# Content of this directories are generated with each Compile/Construct of a project.
+# Most of the time, files here have not there place in a code repository.
+#Win32/
+#Win64/
+#OSX64/
+#OSXARM64/
+#Android/
+#Android64/
+#iOSDevice64/
+#Linux64/
+
 # Delphi compiler-generated binaries (safe to delete)
 *.exe
 *.dll

--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -67,3 +67,7 @@ __recovery/
 
 # Boss dependency manager vendor folder https://github.com/HashLoad/boss
 modules/
+
+# Mac Finder and Windows explorer files
+.DS_Store
+Thumbs.db

--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -31,12 +31,17 @@
 # Most of the time, files here have not there place in a code repository.
 #Win32/
 #Win64/
+#OSX32/
 #OSX64/
 #OSXARM64/
 #Android/
 #Android64/
+#iOSDevice32/
 #iOSDevice64/
 #Linux64/
+#iOSSimulator/
+#iOSSimARM64/
+#TMSWeb/
 
 # Delphi compiler-generated binaries (safe to delete)
 *.exe


### PR DESCRIPTION
Hi
I have added the default Delphi compilation folders (but disabled for compatibility with previous .gitignore filters) even if their content has nothing to do in a code repository because it's regenerated each time a project is compiled.
I also added the Finder (macOS) and Windows folder settings files which has nothing to do with source code and should not be store anywhere.
Best regards
Patrick Prémartin