### PR TITLE
Added Delphi default compile/construct directories

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -26,6 +26,18 @@
 #*.obj
 #
 
+# Default Delphi compiler directories
+# Content of this directories are generated with each Compile/Construct of a project.
+# Most of the time, files here have not there place in a code repository.
+#Win32/
+#Win64/
+#OSX64/
+#OSXARM64/
+#Android/
+#Android64/
+#iOSDevice64/
+#Linux64/
+
 # Delphi compiler-generated binaries (safe to delete)
 *.exe
 *.dll


### PR DESCRIPTION
Files in the default compile/construct directories are generated each time Delphi need them. Most of them are binaries. There is no reason to put them in the code repository.

Filter added as comment, but it would be better to uncomment them.