### PR TITLE
Add latexindent

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -147,6 +147,9 @@ acs-*.bib
 # *.tikz
 *-tikzDictionary
 
+# latexindent will create succesive backup files by default
+#*.bak*
+
 # listings
 *.lol
 


### PR DESCRIPTION
**Reasons for making this change:**
* Allow users to ignore successive backup files generated by latexindent on default

**Links to documentation supporting these rule changes:**
* [latexindent.pl](https://ctan.uib.no/support/latexindent/documentation/latexindent.pdf#subsection.5.1)