### PR TITLE
Redundant VSCode exceptions

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -1,9 +1,9 @@
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+.vscode/settings.json
+.vscode/tasks.json
+.vscode/launch.json
+.vscode/extensions.json
+.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/


### PR DESCRIPTION
The VSCode template as it is contains so many exceptions that it defacto doesn't cause git to ignore the majoriy of VSCode relevant files. As it is one has to opt-in into ignoring any relevant files by configuring the .gitignore instead of opt-out. This makes the template redundant as it makes more sense to just not include it and have the same functionality. 