### PR TITLE
Add .localized to macOS.gitignore

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -3,8 +3,11 @@
 .AppleDouble
 .LSOverride
 
+# Decorators files
+.localized
+
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*


### PR DESCRIPTION
**Reasons for making this change:**
Remove `.localized` macOS file from git repositories

**Links to documentation supporting these rule changes:**

>`.localized` files just indicate (by their presence) that apps should display the "localized" name for a given folder if one has been defined. So for example, instead of the folder names that '
 ls' would show as "Library" or "Users", someone with their language set to "French" in the "International" pref pane would see "Bibliothèque" or "Utilisateurs" in "Finder" or through "Open" and "Save" dialogues.

https://discussions.apple.com/thread/252040