### PR TITLE
Ignore Plugins/**/ folders and vsconfig

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,5 +1,6 @@
-# Visual Studio 2015 user specific files
+# Visual Studio user specific files
 .vs/
+.vsconfig
 
 # Compiled Object files
 *.slo
@@ -47,7 +48,7 @@ SourceArt/**/*.tga
 
 # Binary Files
 Binaries/*
-Plugins/*/Binaries/*
+Plugins/**/Binaries/*
 
 # Builds
 Build/*
@@ -68,7 +69,7 @@ Saved/*
 
 # Compiled source files for the engine to use
 Intermediate/*
-Plugins/*/Intermediate/*
+Plugins/**/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*


### PR DESCRIPTION
The current ignore would not cater for `Intermediate` and `Binaries` folder within second level plugins such as `Plugins/GameFeatures/MyLyraFeaturePlugin` . Hence the ignore pattern should be `Plugins/**/`

Also .vsconfig should be ignored and the `Visual Studio 2015` comment is out of date.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
