### PR TITLE
Python.gitignore's comments tidy

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -87,11 +87,11 @@ ipython_config.py
 #   code is intended to run in multiple environments; otherwise, check them in.
 # .python-version
 
-# pipenv
+# Pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in
 #   version control. However, in case of collaboration, if having
 #   platform-specific dependencies or dependencies having no cross-platform
-#   support, pipenv may install dependencies that don't work, or not install all
+#   support, Pipenv may install dependencies that don't work, or not install all
 #   needed dependencies.
 # Pipfile.lock
 

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -27,8 +27,8 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
 
@@ -153,8 +153,8 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
 # .idea/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -84,7 +84,7 @@ ipython_config.py
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
+#   intended to run in multiple environments; otherwise, check them in.
 # .python-version
 
 # pipenv

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -27,7 +27,7 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#   Usually these files are written by a python script from a template before
+#   Usually these files are written by a Python script from a template before
 #   PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -55,17 +55,17 @@ cover/
 *.mo
 *.pot
 
-# Django stuff:
+# Django stuff
 *.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
-# Flask stuff:
+# Flask stuff
 instance/
 .webassets-cache
 
-# Scrapy stuff:
+# Scrapy stuff
 .scrapy
 
 # Sphinx documentation

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -27,8 +27,8 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#   Usually these files are written by a python script from a template
-#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+#   Usually these files are written by a python script from a template before
+#   PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
 
@@ -83,29 +83,31 @@ profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in.
+#   For a library or package, you might want to ignore these files since the
+#   code is intended to run in multiple environments; otherwise, check them in.
 # .python-version
 
 # pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in
+#   version control. However, in case of collaboration, if having
+#   platform-specific dependencies or dependencies having no cross-platform
+#   support, pipenv may install dependencies that don't work, or not install all
+#   needed dependencies.
 # Pipfile.lock
 
 # poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock
+#   in version control. This is especially recommended for binary packages to
+#   ensure reproducibility, and is more commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 # poetry.lock
 
 # pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in
+#   version control.
 # pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended
+#   to not include it in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
@@ -153,8 +155,10 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#   and can be added to the global gitignore or merged into this file.  For a more nuclear
-#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore
+#   that can be found at
+#   https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore and
+#   can be added to the global gitignore or merged into this file. For a more
+#   nuclear option (not recommended) you can uncomment the following to ignore
+#   the entire idea folder.
 # .idea/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -55,17 +55,17 @@ cover/
 *.mo
 *.pot
 
-# Django stuff
+# Django
 *.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
-# Flask stuff
+# Flask
 instance/
 .webassets-cache
 
-# Scrapy stuff
+# Scrapy
 .scrapy
 
 # Sphinx documentation
@@ -112,7 +112,7 @@ ipython_config.py
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
-# Celery stuff
+# Celery
 celerybeat-schedule
 celerybeat.pid
 

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -102,11 +102,11 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 # poetry.lock
 
-# pdm
+# PDM
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in
 #   version control.
 # pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended
+#   PDM stores project-wide configurations in .pdm.toml, but it is recommended
 #   to not include it in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -95,7 +95,7 @@ ipython_config.py
 #   needed dependencies.
 # Pipfile.lock
 
-# poetry
+# Poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock
 #   in version control. This is especially recommended for binary packages to
 #   ensure reproducibility, and is more commonly ignored for libraries.

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -111,7 +111,9 @@ ipython_config.py
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+# PEP 582
+#   __pypackages__ is used by e.g. github.com/David-OConnor/pyflow and
+#   github.com/pdm-project/pdm.
 __pypackages__/
 
 # Celery

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -92,18 +92,18 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+# Pipfile.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+# poetry.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
+# pdm.lock
 #   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+# .idea/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -139,7 +139,7 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
+# MkDocs documentation
 /site
 
 # mypy


### PR DESCRIPTION
**Reasons for making this change:**

This change affects only `Python.gitignore`'s comments. It makes the punctuation, indentation and line length consistent and corrects the capitalization of the names of packages.

**Links to documentation supporting these rule changes:**

The names of [Pipenv](https://pypi.org/project/pipenv/), [Poetry](https://pypi.org/project/poetry/), [PDM](https://pypi.org/project/pdm/) and [MkDocs](https://pypi.org/project/mkdocs/) have been capitalized as in the linked documentation.