### PR TITLE
Integrating Integrations in the Unity gitignore (vscode, Rider, FMOD, Blender)

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -94,3 +94,6 @@ crashlytics-build.properties
 
 # Log files can be ignored.
 fmod_editor.log
+
+# Ignore temporary Blender files.
+*.blend[0-9]*

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -76,3 +76,21 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Never ignore DLLs in the FMOD subfolder.
+!/[Aa]ssets/Plugins/FMOD/**/lib/*
+
+# Don't ignore images and gizmos used by FMOD in the Unity Editor.
+!/[Aa]ssets/Gizmos/FMOD/*
+!/[Aa]ssets/Editor Default Resources/FMOD/*
+
+# Ignore the Cache folder since it is updated locally.
+/[Aa]ssets/Plugins/FMOD/Cache/*
+
+# Ignore bank files in the StreamingAssets folder.
+/[Aa]ssets/[Ss]treamingAssets/**/*.bank
+/[Aa]ssets/[Ss]treamingAssets/**/*.bank.meta
+# If the source bank files are kept outside of the StreamingAssets folder then these can be ignored.
+
+# Log files can be ignored.
+fmod_editor.log

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -29,6 +29,9 @@
 # Visual Studio Code cache directory
 .vscode/
 
+# Idea cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**
I'm Casey, a fourth year bachelor student at the HKU (Hogeschool Kunstacademie Utrecht) studying in Unity Development. Every now and again I help teams out with their github, and I see a lot of conflicts arise that could have been avoided, so I've been questing to improve the unity github experience for my peers and students to come. This PR is part of that initiative.

**Important note on flexibility:**
The commits for this gitignore have been designed with flexibility, or rather rebase, in mind. If some part of this ignore is rejected, let me know which commit specifically is the culprit so I can rebase it, remove it, and we can all forget it ever existed.

**Links to documentation supporting these rule changes:**
d8cafd215f20f3852cfae34a276507f264ff770f, 37bc45039c3cc53c84a3c22dd242f7246afd13f3 have no source but are literally cache directories.
d4c81e8602ecac6cc205f86357ba5c5d31f5f940 taken from [FMOD Unity Integration Using Source Control](https://www.fmod.com/docs/2.02/unity/user-guide.html#using-source-control)
682c73e0f7cd21b2dfcf83e41dcdef96cbdc3cdf [What is a blend1 file and why do you (not) need them?](https://cgcookie.com/posts/what-is-a-blend1-file-and-do-you-really-need-them) blend1, blend2, blend3, etc. files are autosave backup files. If you have a habit of using blender in Unity, then you probably don't want to push all these files with your final result.