### PR TITLE
Add .rebel_readline_history to Leiningen.gitignore

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
+.rebel_readline_history


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Remove `.rebel_readline_history` file from git repositories

**Links to documentation supporting these rule changes:**

https://github.com/bhauman/rebel-readline