### PR TITLE
Update xcuserdata entries

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,5 +1,5 @@
 ## User settings
-xcuserdata/
+**/xcuserdata/
 
 ## Xcode 8 and earlier
 *.xcscmblueprint

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -3,7 +3,7 @@
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
 ## User settings
-xcuserdata/
+**/xcuserdata/
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -3,7 +3,7 @@
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
 ## User settings
-xcuserdata/
+**/xcuserdata/
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The expectation is to update entries that allow ignoring the _xcuserdata_ sub-folders using the syntax introduced by the 1.8.2 version of Git. _xcuserdata_ contains individual user settings and state data that can be safely removed since the Xcode IDE will recreate it if it is not available for the current user. 

Currently, this sub-folder is not being ignored by the latest versions of Git. This results in an additional step of prepending `**/` to `xcuserdata/` after I copy the corresponding _.gitignore_ file (usually _Swift.gitignore_) as part of my everyday workflow since I am an iOS developer and depend on this repository for work purposes. These changes would solve this issue.

**Links to documentation supporting these rule changes:**

[Git v1.8.2 Release Notes](https://github.com/git/git/blob/master/Documentation/RelNotes/1.8.2.txt)
Some evidence on solutions for related issues:
[https://stackoverflow.com/a/32899573/5691990](https://stackoverflow.com/a/32899573/5691990)
[https://stackoverflow.com/a/66831936/5691990](https://stackoverflow.com/a/66831936/5691990)
An example of its use in the wild:
[https://chromium.googlesource.com/external/github.com/google/flatbuffers/+/6f7a57eaa0ef872af87ee3333a4a0fa1bfb607ce/.gitignore](https://chromium.googlesource.com/external/github.com/google/flatbuffers/+/6f7a57eaa0ef872af87ee3333a4a0fa1bfb607ce/.gitignore)
