### PR TITLE
Ignore all `.env` files in `Node.gitignore` and unignore `.env.example`

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -74,10 +74,6 @@ web_modules/
 
 # dotenv environment variable files
 .env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -75,6 +75,7 @@ web_modules/
 # dotenv environment variable files
 .env
 .env.*
+!.env.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -74,6 +74,7 @@ web_modules/
 
 # dotenv environment variable files
 .env
+.env.*
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache


### PR DESCRIPTION
## Reasons for making this change:
<!-- Include your relationship to the project and what you expect to get from this change. -->

1. Removed ignores that uses the conventions from https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
Even if it used by some modern JS frameworks it shouldn't be used here since this is a general node.js template and these conventions are specific to some frameworks.

2. Added `.env.*` as in #3651 it's safer to ignore all `.env` files since people names it differently (e.g. `.env.production`, `.env.prod`)
see this comment https://github.com/github/gitignore/pull/3316#issuecomment-991413112

3. Unignored `.env.example` as what @kachick tried to do in b236e1717b90f1755af76900f5387bfa20636de3 

## Links to documentation supporting these rule changes:

`dotenv` node.js package: https://github.com/motdotla/dotenv#should-i-commit-my-env-file