### PR TITLE
MuleSoft Anypoint Studio .gitgnore file

### DIFF
--- a/MuleSoft.gitignore
+++ b/MuleSoft.gitignore
@@ -1,0 +1,49 @@
+# ------------------------------------------------------------------------------ #
+# Java defaults (https://github.com/github/gitignore/blob/master/Java.gitignore) #
+# ------------------------------------------------------------------------------ #
+*.class
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# ------------------------------------------------------------------------------------------- #
+# Eclipse-specific (https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore) #
+# ------------------------------------------------------------------------------------------- #
+*.pydevproject
+.metadata
+bin/**
+tmp/**
+tmp/**/*
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.project
+.classpath
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# PDT-specific
+.buildpath
+
+# --------------- #
+# MuleSoft Studio-specific (https://docs.mulesoft.com/studio/7.14/)#
+# --------------- #
+target/
+.mule/**
+.mule/**/*
+.DS_Store
+velocity.log
+bin/


### PR DESCRIPTION
MuleSoft IDE is built on Eclipse. Anypoint Studio is an IDE that we build MuleSoft project. 

**Reasons for making this change:**
- When committing the code to github, it includes the builds files and bin folder which can cause a huge file size. Adding the .gitignore specific for MuleSoft will prevent the unnecessary files to be added to git. It would be nice to have this added to GitIgnore list so that new MuleSoft developer will be able to use this as there template.

**Links to documentation supporting these rule changes:**
- For more information, please refer to https://docs.mulesoft.com/studio/7.14
- Preparing .gitgnore file in Studio 6.x https://docs.mulesoft.com/studio/6.x/preparing-a-gitignore-file

If this is a new template:
 - **Link to application or project’s homepage**: [MuleSoft Anypoint Studio](https://docs.mulesoft.com/studio/7.14/)
