### PR TITLE
Fix Metals gitignore

### DIFF
--- a/Global/Metals.gitignore
+++ b/Global/Metals.gitignore
@@ -1,5 +1,6 @@
- # Generated Metals (Scala Language Server) files
- # Reference: https://scalameta.org/metals/
+# Metals (Scala Language Server)
+# Reference: https://scalameta.org/metals/docs/editors/vscode#files-and-directories-to-include-in-your-gitignore
 .metals/
 .bloop/
-project/metals.sbt
+.ammonite/
+metals.sbt


### PR DESCRIPTION
**Reasons for making this change:**
* Bring the gitignore inline with current recommendations 
* Comments had leading spaces so they weren't treated as comments
* Change Reference to recommended gitignore configuration documentation

**Links to documentation supporting these rule changes:**
* [metals-vscode/README.md](https://github.com/scalameta/metals-vscode/blob/09380cda3f7529f05c9ec3766075ba450efeda65/README.md?plain=1#L215)
