### PR TITLE
Add delve debug binary

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -11,6 +11,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Default Delve debug binary
+__debug_bin
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 


### PR DESCRIPTION
**Reasons for making this change:**

Delve is the major Go debugger, and it produces a `__debug_bin` binary by default, which isn't in the Go gitignore template.

I use delve to debug Go binaries, and I'd like to have delve's `__debug_bin` ignored by default.

**Links to documentation supporting these rule changes:**

`--output string   Output path for the binary. (default "./__debug_bin")`

https://github.com/go-delve/delve/blob/4c1f8b4b2536beb8b06c6a6ef0b0383a7928e188/Documentation/usage/dlv_debug.md
