### PR TITLE
Update Leiningen.gitignore to ignore lsp and clj-kondo cache in Clojure projects

### DIFF
--- a/Leiningen.gitignore
+++ b/Leiningen.gitignore
@@ -12,3 +12,5 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
+.lsp/.cache
+.clj-kondo/.cache


### PR DESCRIPTION
Ignore `.lsp/.cache` and `.clj-kondo/.cache`directories.

**clojure-lsp** is the [Language Server](https://microsoft.github.io/language-server-protocol/) for Clojure(script).

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

When a new clojure project is created it is necessary to ignore the cache files of clojure-lsp and clj-kondo.

Project examples:
- https://github.com/babashka/sci/blob/master/.gitignore#L14
- https://github.com/polyfy/polylith/blob/master/.gitignore#L38-L39
- https://github.com/seancorfield/clj-new/blob/develop/.gitignore#L3 and https://github.com/seancorfield/clj-new/blob/develop/.gitignore#L12

**Links to documentation supporting these rule changes:**

**clojure-lsp**

clojure-lsp cache should be ignored in clojure projects.

https://clojure-lsp.io/settings/#all-settings

<img width="962" alt="image" src="https://user-images.githubusercontent.com/25042103/216835605-4fdddfcc-d49e-4cfd-b17c-cdd7250b1f55.png">

**clj-kondo**

Since clojure-lsp uses clj-kondo under the hood (see documentation [here](https://clojure-lsp.io/settings/#clj-kondo)), the clj-kondo cache will be stored in .clj-kondo/.cache and have to be ignored too.


If this is a new template:

 - **Link to application or project’s homepage**: N/A
