### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -86,6 +86,10 @@ web_modules/
 # Next.js build output
 .next
 out
+build
+
+# turbo (https://turbo.build/rep)
+.turbo
 
 # Nuxt.js build / generate output
 .nuxt


### PR DESCRIPTION
**Reasons for making this change:**

No relation to the project other than a user of next.js and turborepo. Per docs, the addition of .turbo is recommended.

**Links to documentation supporting these rule changes:**

<https://turbo.build/repo/docs/getting-started/add-to-project>
