### PR TITLE
Ignore Jetbrains Rider Cache Folder

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -34,6 +34,10 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+
+# Jetbrains Rider cache/options directory
+.idea/
+
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
**Reasons for making this change:**
As a Jetbrains Rider's user, I need to exclude temporary folder made by Rider IDE

**Links to documentation supporting these rule changes:**
https://www.jetbrains.com/help/rider/Directories_Used_by_the_IDE_to_Store_Settings_Caches_Plugins_and_Logs.html

