### PR TITLE
[VisualStudio] Add SARIF file extensions

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -97,6 +97,8 @@ StyleCopReport.xml
 *.pidb
 *.svclog
 *.scc
+*.sarif
+*.sarif.json
 
 # Chutzpah Test files
 _Chutzpah*


### PR DESCRIPTION
**Reasons for making this change:**

MSBuild lets you optionally create logs from static analysis results for postprocessing by external tools; these logs are exported in the SARIF format. Given these are generated files, they should by ignored by default.

**Links to documentation supporting these rule changes:**

* https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errors-warnings#errorlog
* https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317421

If this is a new template:

N/A
