### PR TITLE
Change old /takari/ to maven.apache.org/wrapper in Maven.gitignore

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,7 +7,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+# https://maven.apache.org/wrapper/#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
 # Eclipse m2e generated files


### PR DESCRIPTION
**Reasons for making this change:**

The link was outdated.

**Links to documentation supporting these rule changes:**

https://github.com/takari/maven-wrapper is now https://maven.apache.org/wrapper.
