### PR TITLE
Update C++.gitignore

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -30,3 +30,12 @@
 *.exe
 *.out
 *.app
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile


### PR DESCRIPTION
Added extra extensions that must be ignored when a C++ project is created in VS.

**Reasons for making this change:**: This PR is a solution for the error that arises when the a C++ .gitignore file is added to a C++ project created in visual studio. However, the creator does not select Visual Studio gitignore

_TODO_

**Links to documentation supporting these rule changes:**: https://stackoverflow.com/a/34979320

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**:  https://stackoverflow.com/a/34979320
