### PR TITLE
Remove pnpm debug log

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -5,7 +5,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
-.pnpm-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json


### PR DESCRIPTION
**Reasons for making this change:**

- it is contained within `node_modules/`, which is already ignored
- the previous versions, which were not in `node_modules/`, did not have a period at the beginning of the filename

**Links to documentation supporting these rule changes:**

Changelog with proof here:

https://github.com/pnpm/pnpm/blob/ba4b2db1f201640dad5d7ee9fe68a2d0defd6047/pnpm/CHANGELOG.md?plain=1#L3330

**History**

First introduced in https://github.com/github/gitignore/pull/3732 by @sakurayang (merged by @martinwoodward)