### PR TITLE
Ignore Addressables link.xml build file

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -67,6 +67,9 @@ crashlytics-build.properties
 # Packed Addressables
 /[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/*/*.bin*
 
+# Addressables link build file
+/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Ll]ink.xml
+
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*

--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -69,6 +69,7 @@ crashlytics-build.properties
 
 # Addressables link build file
 /[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Ll]ink.xml
+/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/[Ll]ink.xml.meta
 
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta


### PR DESCRIPTION
Unity's Addressables creates a link.xml file on build. This is a temporary file and can be ignored, per https://forum.unity.com/threads/link-xml-part-of-version-control.1227360/#post-8190567