### PR TITLE
Add missing Nuxt 3's generated dirs

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -90,6 +90,9 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+.nuxt-*
+.output
+.gen
 
 # Gatsby files
 .cache/


### PR DESCRIPTION
## Description
I updated the Nuxt section to include the new Nuxt 3 generated folders.

## References
- Official [.gitignore](https://github.com/nuxt/nuxt/blob/main/.gitignore#L22-L24) file.
- Nuxt Team's recommended .gitignore [entries](https://nuxt.com/docs/guide/directory-structure/gitignore#git-ignore-file).
