### PR TITLE
Add #auto_saved_files# to the Kicad.gitignore

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -32,3 +32,5 @@ fp-info-cache
 
 # Archived Backups (KiCad 6.0)
 **/*-backups/*.zip
+
+\#auto_saved_files\#


### PR DESCRIPTION
**Reasons for making this change:**
This file is generated by the Kicad and it contains absolute paths of the sch/pcb files so it does not makes sense to track it in git. 

**Links to documentation supporting these rule changes:**
[Other examlpe gitignore](https://techoverflow.net/2020/06/13/what-gitignore-to-use-for-kicad-projects/)
