### PR TITLE
elisp: Ignore more build tools

### DIFF
--- a/Elisp.gitignore
+++ b/Elisp.gitignore
@@ -2,7 +2,13 @@
 *.elc
 
 # Packaging
-.cask
+.cask/
+.eask/
+.eldev/
+.keg/
+
+# Built distribution
+dist/
 
 # Backup files
 *~


### PR DESCRIPTION
.eask, .eldev, .keg are other build tools like .cask. dist is the default folder to build package distribution files.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The reason is pretty much the same as #1096.

**Links to documentation supporting these rule changes:**

- `.eask/`, https://emacs-eask.github.io/
- `.eldev`, https://doublep.github.io/eldev/
- `.keg/`, https://github.com/conao3/keg.el
- `dist/`, see https://cask.readthedocs.io/en/latest/guide/usage.html#cask-package (Eask uses the same directory too)

