### PR TITLE
Added undo-tree

### DIFF
--- a/Global/Emacs.gitignore
+++ b/Global/Emacs.gitignore
@@ -47,3 +47,5 @@ flycheck_*.el
 # network security
 /network-security.data
 
+# undo-tree
+*.~undo-tree~


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
Added undo-tree syntax to emacs ignore file, as it is a very popular package, and has a habit of leaving a hidden `*.~undo-tree~` file for every file edited in Emacs. It can really litter up a repository if the user does not manually add the syntax to ignore these files.

_TODO_

**Links to documentation supporting these rule changes:**
The package itself was found in the link below. Tarsius Documents this file well.

https://github.com/tarsiiformes/undo-tree/blob/master/undo-tree.el#L951

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
