### PR TITLE
Jupyter-Notebooks: ignore virtual_documents from jupyter-lsp

### DIFF
--- a/community/Python/JupyterNotebooks.gitignore
+++ b/community/Python/JupyterNotebooks.gitignore
@@ -4,6 +4,10 @@
 .ipynb_checkpoints
 */.ipynb_checkpoints/*
 
+# created and used by https://github.com/jupyter-lsp/jupyterlab-lsp/
+.virtual_documents/
+*/.virtual_documents/
+
 # IPython
 profile_default/
 ipython_config.py


### PR DESCRIPTION
I'm using JupyterLab as IDE for data/plotting heavy projects - and with it the https://github.com/jupyter-lsp/jupyterlab-lsp/ extension.

I noticed the `.virtual_documents` folder and its contents frequently popping up in my git status.

The `.virtual_documents` folder is used by the language server extension as a shadow version of the code to run the linting, so it is transitional and does not contain files which should be versioned.

Documentation: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs/Configuring.ipynb