### PR TITLE
Python: ignore virtual_documents from jupyter-lsp

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -77,6 +77,9 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+# created and used by https://github.com/jupyter-lsp/jupyterlab-lsp/
+.virtual_documents/
+*/.virtual_documents/
 
 # IPython
 profile_default/


### PR DESCRIPTION
As the gitignore rules of the community recipe for jupyter-notebooks are copied into here, this is a follow-up of #4267 .

> I'm using JupyterLab as IDE for data/plotting heavy projects - and with it the https://github.com/jupyter-lsp/jupyterlab-lsp/ extension.
> 
> I noticed the `.virtual_documents` folder and its contents frequently popping up in my git status.
> 
> The `.virtual_documents` folder is used by the language server extension as a shadow version of the code to run the linting, so it is transitional and does not contain files which should be versioned.
> 
> Documentation: https://github.com/jupyter-lsp/jupyterlab-lsp/blob/master/docs/Configuring.ipynb
> 
> 