### PR TITLE
Add .artifacts folder to Visual Studio .gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -61,6 +61,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+.artifacts/
 
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt


### PR DESCRIPTION
We are planning to add a [new output path format](https://github.com/dotnet/designs/pull/281) to .NET projects which will by default put output in an `.artifacts` folder.  So this PR adds that folder to the Visual Studio .gitignore file.

The first support for this will be in .NET 8 Preview 3.  We will be looking for feedback through the preview process, so it's possible that the folder name or other aspects of the design could change as a result.