### PR TITLE
Update for Flutter Support

### DIFF
--- a/Flutter.gitignore
+++ b/Flutter.gitignore
@@ -1,0 +1,46 @@
+# See https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/templates/app_shared/.gitignore.tmpl
+
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release


### PR DESCRIPTION
**Reasons for making this change:**


The 'flutter project' is generated by the command 'flutter create'.

I wrote it by referring to the gitignore template maintained by Flutter Team.

Please refer to the link below And it is well maintained and shows the template of the Stable version.

https://github.com/flutter/flutter/blob/stable/packages/flutter_tools/templates/app_shared/.gitignore.tmpl


https://flutter.dev/