### PR TITLE
Add ignore lines for Unity Visual Scripting generated files

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -70,3 +70,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Visual scripting generated files
+/[Aa]ssets/Unity.VisualScripting.Generated/VisualScripting.Flow/UnitOptions.db*
+/[Aa]ssets/Unity.VisualScripting.Generated/VisualScripting.Core/Property Providers*


### PR DESCRIPTION
**Reasons for making this change:**

The *Visual Scripting* package will generate some files in `/Assets` directory.
These are irrelevant to game developing and could be safely ignored within version management.

**Links to documentation supporting these rule changes:**

- [Official documentation of Visual Scripting for manually git ignoring](https://docs.unity3d.com/Packages/com.unity.visualscripting@1.7/manual/vs-version-control.html)
- [An unofficial tutorial for creating a `.gitignore` of projects with Visual Scripting](https://note.com/maruton/n/na48680cc8fe9)
