### PR TITLE
Add Ruff to Python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Ruff linter
+.ruff_cache/


### PR DESCRIPTION
Since [ruff ](https://github.com/charliermarsh/ruff) is becoming more and more popular in the Python ecosystem, I figured it would be nice to include it here. 
