### PR TITLE
Exclude project related _Repository folder

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -23,3 +23,4 @@ _Boot/
 _CompileInfo/
 _Libraries/
 _ModuleInstall/
+_Repository/


### PR DESCRIPTION
The folder appears when a (Versioned) TwinCAT C++ project is present in the TwinCAT project.

The folder contains the binaries for the TcCOM modules and should not be part of the underlying repository.

If a TcCOM module (binary) should be shared without the related source files between different engineering environments (TwinCAT XAE), binaries and the TMC description of TcCOM modules have to be present in global Repository folder (see chapter[ 7.1 Versioned C++ Projects](https://download.beckhoff.com/download/document/automation/twincat3/TE1000_TC3_C_EN.pdf#page=49) and chapter [12.1.3 Tc Publish](https://download.beckhoff.com/download/document/automation/twincat3/TE1000_TC3_C_EN.pdf#page=150)).
