### PR TITLE
Add `.pdm-python` to python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -108,6 +108,7 @@ ipython_config.py
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
+.pdm-python
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -109,6 +109,7 @@ ipython_config.py
 #   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
 .pdm.toml
 .pdm-python
+.pdm-build/
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -106,7 +106,7 @@ ipython_config.py
 #pdm.lock
 #   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
 #   in version control.
-#   https://pdm.fming.dev/#use-with-ide
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
 .pdm.toml
 .pdm-python
 


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Starting with [v2.5.0b0](https://github.com/pdm-project/pdm/releases/tag/2.5.0b0) `pdm` requires a `.pdm-python` file to track the path of the local python installation.

**Links to documentation supporting these rule changes:**

[v2.5.0b0](https://github.com/pdm-project/pdm/releases/tag/2.5.0b0)

If this is a new template:

 - **Link to application or project’s homepage**: https://pdm.fming.dev
