### PR TITLE
Add `pyrightconfig.json` to python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Pyright settings
+pyrightconfig.json


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The configuration file `pyrightconfig.json` is for the LSP Pyright, is only for those who use Pyright, and is often personal. Like IDE configurations it should not be committed.

**Links to documentation supporting these rule changes:**

https://github.com/microsoft/pyright/blob/main/docs/configuration.md

If this is a new template:

No.