### PR TITLE
Update TeX.gitignore to capture .pygtex and .pygstyle

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -169,7 +169,7 @@ acs-*.bib
 
 # minted
 _minted*
-*.pyg
+*.pyg*
 
 # morewrites
 *.mw


### PR DESCRIPTION
**Reasons for making this change:**

When ``minted`` is ran with caching enabled, two file types are created used in the caching process, ``.pgytex`` and ``.pygstyle``. These were not being captured before pull request.

**Links to documentation supporting these rule changes:**

https://tug.ctan.org/macros/latex/contrib/minted/minted.pdf 
``.pygtex`` files are discussed in the section 8.3 of the implementation portion of the  documentation and ``.pygstyle`` is mentioned in section 8.5.