### PR TITLE
Update Node.gitignore, dist folder

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -89,7 +89,7 @@ out
 
 # Nuxt.js build / generate output
 .nuxt
-dist
+/dist
 
 # Gatsby files
 .cache/


### PR DESCRIPTION
"dist"  folder shouldn't be a global ignore.
subfolders such as www root, will probably need some js folder named "dist" 