### PR TITLE
Add _CompileInfo_Upload/ to twincat3 gitignore

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -21,5 +21,6 @@ LineIDs.dbg
 LineIDs.dbg.bak
 _Boot/
 _CompileInfo/
+_CompileInfo_Upload/
 _Libraries/
 _ModuleInstall/


### PR DESCRIPTION
New additional compileinfo will be used with 3..1.4026.x
