### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -70,3 +70,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# TextMesh Pro
+/[Aa]ssets/[Tt]extMesh Pro*


### PR DESCRIPTION
TextMesh Pro is importable from the Unity Package Registry and when you have a package reference to TMP and the package is missing, the Unity Editor detects that and prompts for import (see the image), so there's no need to version Assets/TextMesh Pro files.

<img width="481" alt="image" src="https://github.com/github/gitignore/assets/33404489/6ecc3071-f9b0-40ec-aa6c-437e40f425c9">

TMP docs: https://docs.unity3d.com/Packages/com.unity.textmeshpro@3.0/manual/index.html
