### PR TITLE
feat(TwinCAT3): ignore .tspproj.bak files

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -16,6 +16,7 @@
 *.library
 *.project.~u
 *.tsproj.bak
+*.tspproj.bak
 *.xti.bak
 LineIDs.dbg
 LineIDs.dbg.bak


### PR DESCRIPTION
These files are used in stand-alone PLC projects: https://infosys.beckhoff.com/english.php?content=../content/1033/variant_management/10480356619.html&id=