### PR TITLE
add deb to arch gitignore

### DIFF
--- a/ArchLinuxPackages.gitignore
+++ b/ArchLinuxPackages.gitignore
@@ -3,6 +3,7 @@
 *.jar
 *.exe
 *.msi
+*.deb
 *.zip
 *.tgz
 *.log


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

on aur, it's common to repack the deb.

**Links to documentation supporting these rule changes:**

https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=wemeet-bin#n16

```sh
source_x86_64=("${_pkgname}-${pkgver}-x86_64.deb::https://updatecdn.meeting.qq.com/cos/${_x86_md5}/TencentMeeting_0300000000_${pkgver}_x86_64_default.publish.deb"
)
```



