### PR TITLE
KiCad: Add some Fabrication Output files

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -27,3 +27,38 @@ fp-info-cache
 # Exported BOM files
 *.xml
 *.csv
+
+# Gerbers
+*.gbr
+*.gbrjob
+
+# Gerbers Protel filename extensions
+*.gtp
+*.gts
+*.gtp
+*.gtl
+*.g1
+*.g2
+*.gp1
+*.gp2
+*.gbl
+*.gpb
+*.gbs
+*.gbo
+*.gd1
+*.gg1
+*.gko
+*.gm1
+*.gm3
+
+# Drill files
+*.drl
+
+# Component Placement
+*.pos
+
+# Footprint Report
+*.rpt
+
+# IPC-D-365 Netlist File
+*.d365


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Because after modifying the `.kicad_pro` file, these files will not be updated accordingly.

**Links to documentation supporting these rule changes:**

https://docs.kicad.org/7.0/en/pcbnew/pcbnew.html#fabrication_outputs_and_plotting
