### PR TITLE
Add Vim swap file

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Swap file created by Vi text editor or its variants (such as Vim)
+*.swp


### PR DESCRIPTION
**Reasons for making this change:**
As a common template [.gitignore](https://github.com/dotnet/sdk/blob/main/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore) maintained by https://github.com/dotnet/templating, the customer requested to add Vim swap files to it. To keep both sides aligned, request to add Vim swap files to this template.

**Links to documentation supporting these rule changes:**

https://github.com/dotnet/templating/issues/5048
