### PR TITLE
Update reference to Maven Wrapper exclusion

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,7 +7,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+# https://maven.apache.org/wrapper/#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
 # Eclipse m2e generated files


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Improve documentation: Since this line was introduced in #3154, Takari has given this code to Apache Maven, the URL referencing the Takari repo is no longer valid, and is replaced with the official Apache Maven Wrapper documentation URL.

**Links to documentation supporting these rule changes:**

https://maven.apache.org/wrapper/#usage-without-binary-jar

