### PR TITLE
Fix link into maven wrapper documentation

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,7 +7,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+# https://maven.apache.org/wrapper/#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
 # Eclipse m2e generated files


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Maven wrapper project was merged into main maven project and link is not working now.

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
