### PR TITLE
Ensuring that all obj and bin folders are ignored

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -27,8 +27,8 @@ x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
-[Bb]in/
-[Oo]bj/
+**/[Bb]in/
+**/[Oo]bj/
 [Ll]og/
 [Ll]ogs/
 


### PR DESCRIPTION
**Reasons for making this change:**

I use GitHub personally using a Pro account and through work using an Enterprise account. Using gitignore files
are a basic part of my job and process. I rely upon the gitignore file to keep out of my local Git repositories and my and our 
remote Git repositories on GitHub, files and/or folders which should not be in Git repos.

I am involved in migrating several Team Foundation Server (TFS) repos from on old on-prem TFS server, to repos in a new
organization associated with my work. We are using the utilitiy `git-tfs` to migrate our TFS projects and repos to GitHub. Many of the TFS Projects have multiple Team Foundation Version Control (TFVC) repos within them. I have found that the VisualStudio.gitignore file does not take multiple Visual Studio (VS) solutions into consideration. Working with any VS solution in a migrated repo will result in adding .obj and .dll/.exe files to sub-VS solutions when performing a Git commit. I am certain that others who must migrate TFS Projects containing multiple TFVC repos, into one repo in a GitHub repo using `git-tfs`, will encounter the same issue that we have. Therefore, I propose the change to the VisualStudio.gitignore file, to handle when an obj or bin folder is not in the place that the current VisualStudio.gitignore file considers those folders to be in.

_TODO_

I consulted the official Git web site on the [Gitignore file](https://git-scm.com/docs/gitignore).

_TODO_

If this is a new template:

This is not a new template but is a proposed modification of the **VisualStudio.gitignore** template.
