### PR TITLE
Create Debian.gitignore

### DIFF
--- a/community/Linux/Debian.gitignore
+++ b/community/Linux/Debian.gitignore
@@ -1,6 +1,11 @@
 # gitignore template for creating Debian packages
 # website: https://wiki.debian.org/HowToPackageForDebian
 
+# It's also strongly recommended to include project specific names in this
+# gitignore file, as the Debian packaging scripts will create directories for
+# the packages' content. Just uncomment and modify the line below:
+#debian/<package_name>/
+
 debian/autoreconf.*
 debian/debhelper-build-stamp
 debian/files

--- a/community/Linux/Debian.gitignore
+++ b/community/Linux/Debian.gitignore
@@ -1,6 +1,10 @@
 # gitginore template for creating Debian packages
 # website: https://wiki.debian.org/HowToPackageForDebian
 
-debian/.debhelper
+debian/autoreconf.*
 debian/debhelper-build-stamp
+debian/files
+debian/tmp/
+debian/*.debhelper
+debian/*.log
 debian/*.substvars

--- a/community/Linux/Debian.gitignore
+++ b/community/Linux/Debian.gitignore
@@ -1,4 +1,4 @@
-# gitginore template for creating Debian packages
+# gitignore template for creating Debian packages
 # website: https://wiki.debian.org/HowToPackageForDebian
 
 debian/autoreconf.*

--- a/community/Linux/Debian.gitignore
+++ b/community/Linux/Debian.gitignore
@@ -1,0 +1,6 @@
+# gitginore template for creating Debian packages
+# website: https://wiki.debian.org/HowToPackageForDebian
+
+debian/.debhelper
+debian/debhelper-build-stamp
+debian/*.substvars


### PR DESCRIPTION
**Reasons for making this change:**

Just started to learn Debian Packaging and noticed, that there is no .gitignore template for the temporary build files of debhelper packaging toolchain yet.
So I started building one.

It might be incomplete, I hope for more experienced developers to improve and support this change.

 - **Link to application or project’s homepage**: [How To Package For Debian](https://wiki.debian.org/HowToPackageForDebian)
