### PR TITLE
Update Stata.gitignore to ignore new auto backup files

### DIFF
--- a/Global/Stata.gitignore
+++ b/Global/Stata.gitignore
@@ -8,6 +8,7 @@
 *.smcl
 *.stpr
 *.stsem
+~*.stswp
 
 # Graphic export files from Stata
 # Stata command graph export: http://www.stata.com/manuals14/g-2graphexport.pdf


### PR DESCRIPTION
**Reasons for making this change:**
Stata 18 introduced an auto-backup feature which creates a temporary file while a code file is open it its IDE.

These auto-backup files are analogous to the [Microsoft Office backup files that are gitignored](https://github.com/github/gitignore/blob/main/Global/MicrosoftOffice.gitignore).

**Links to documentation supporting these rule changes:**

[As described in the Stata Manual](https://www.stata.com/manuals/gsm13.pdf):
> The Do-file Editor now creates a backup file whenever it opens a document or creates a new one.
> When an existing document is opened, Stata creates a backup file of a document that is saved to disk
> in the same directory using the existing document’s filename prefixed with ~ and with the extension
> .stswp. When you edit a new and unsaved document, it saves the backup file to the temp directory.
> When a document is closed, the backup file is deleted. However, if Stata does not exit cleanly because
> of a power outage or a computer crash, the backup file is left behind.
