### PR TITLE
Updated ignore rule for "umbraco" folder with trailing *

### DIFF
--- a/community/DotNet/Umbraco.gitignore
+++ b/community/DotNet/Umbraco.gitignore
@@ -43,7 +43,7 @@
 *.sqlite.db*
 
 #ignore umbraco data/views/settings
-**/umbraco/
+**/umbraco/*
 
 #include default location for modelsbuilder output
 !**/umbraco/models


### PR DESCRIPTION
Updated ignore rule for "umbraco" folder with trailing * to ensure include folders below are actually included

**Reasons for making this change:**

The current version ignores the folder `umbraco`, but there are include rules below it that don't work.

<!-- Include your relationship to the project and what you expect to get from this change. -->

I use the Umbraco CMS and every time we set up a new project we have to remember to make this change to the gitignore file.

Without this change, the include `!**/umbraco/models` isn't working and the models folder is missing from the repo causing compilation issues.
