### PR TITLE
JetBrains.gitignore: add ignore for the HTTP Client's private environment

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -70,8 +70,9 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
-# Editor-based Rest Client
+# Editor-based HTTP Client
 .idea/httpRequests
+http-client.private.env.json
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
prevent accidental push of private variables

**Links to documentation supporting these rule changes:**

documentation regarding env config files: https://www.jetbrains.com/help/idea/exploring-http-syntax.html#example-working-with-environment-files


also renamed in the comment `Rest Client` to `HTTP Client` as it is current JetBrains name for this feature
