### PR TITLE
Unity: Ignore SceneDependencyCache

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -17,6 +17,9 @@
 # Recordings can get excessive in size
 /[Rr]ecordings/
 
+# Subscene dependency cache used by Entities (DOTS)
+[Aa]ssets/SceneDependencyCache*
+
 # Uncomment this line if you wish to ignore the asset store tools plugin
 # /[Aa]ssets/AssetStoreTools*
 


### PR DESCRIPTION
In a DOTS project (that is one referencing Unity Entities package) when you add a subscene Unity will add `Assets/SceneDependencyCache`

Note that working with subscenes is a requirement of DOTS https://docs.unity3d.com/Packages/com.unity.entities@1.0/manual/conversion-scene-overview.html

While SceneDependencyCache is unfortunately visible in the Project explorer it is not a user managed file. And if you delete it, it will be recreated.

Observe that Unity ignore this in their ECS samples  
https://github.com/Unity-Technologies/EntityComponentSystemSamples/blob/master/.gitignore#L63C1-L63C29

It does seem the use of this folder is temporary, but I observe it in 2022.3 LTS version, so it may be with us for some time https://docs.unity3d.com/Packages/com.unity.entities@1.0/changelog/CHANGELOG.html

Finally, this comment from a Unity rep

> These files should be in .gitignore in your project
> They will be moved into the Library folder when the asset pipeline supports that.

https://forum.unity.com/threads/scenedependencycache-shouldnt-be-an-asset.863140/#post-5685628