### PR TITLE
Created MuleSoft.gitignore file

### DIFF
--- a/community/MuleSoft.gitignore
+++ b/community/MuleSoft.gitignore
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------------ #
+# Java defaults (https://github.com/github/gitignore/blob/master/Java.gitignore) #
+# ------------------------------------------------------------------------------ #
+*.class
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# ------------------------------------------------------------------------------------------- #
+# Eclipse-specific (https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore) #
+# ------------------------------------------------------------------------------------------- #
+*.pydevproject
+.metadata
+bin/**
+tmp/**
+tmp/**/*
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.project
+.classpath
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# PDT-specific
+.buildpath
+
+# --------------- #
+# Anypoint Studio-specific #
+# --------------- #
+target/
+.mule/**
+.mule/**/*
+.DS_Store
+velocity.log


### PR DESCRIPTION
This MuleSoft specific gitignore file is for projects created in the Anypoint Studio which is an eclipse based IDE developed by MuleSoft.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
I am a MuleSoft employee and just noticed that template for gitignore is missing for MuleSoft projects in GitHub, so made sense to create one.

**Links to documentation supporting these rule changes:**
https://docs.mulesoft.com/studio/6.x/preparing-a-gitignore-file

