### PR TITLE
Support option abbreviations of glossaries-extra

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -110,7 +110,7 @@ acs-*.bib
 *.glo
 *.glo-abr
 *.gls
-*.glo-abr
+*.gls-abr
 *.glsdefs
 *.lzo
 *.lzs

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -106,8 +106,11 @@ acs-*.bib
 *.acn
 *.acr
 *.glg
+*.glg-abr
 *.glo
+*.glo-abr
 *.gls
+*.glo-abr
 *.glsdefs
 *.lzo
 *.lzs


### PR DESCRIPTION
**Reasons for making this change:**

When you are using glossaries with the package `glossaries-extra` and the package option `abbreviations`, the extra files `glg-abr`, `glo-abr`, and `gls-abr` are created that can be ignored.

**Links to documentation supporting these rule changes:**

This is supported by the official [user manual](http://mirrors.ctan.org/macros/latex/contrib/glossaries-extra/glossaries-extra-manual.pdf) (Section 2.1. Glossary Lists, page 9) of the [glossaries-extra package](https://ctan.org/pkg/glossaries-extra):
> This option has no value and can’t be cancelled. If used, it will automatically create a new glossary with the label abbreviations and redefines \glsxtrabbrvtype to this label. (The file extensions are glg-abr, gls-abr and glo-abr.)


