### PR TITLE
Update Go.ignore to add Delve debugger binary output

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Delve debugger binary
+__debug_bin*


### PR DESCRIPTION
the other 2 PRs on this are outdated and inactive:
- https://github.com/github/gitignore/pull/4239
- https://github.com/github/gitignore/pull/3530
