### PR TITLE
Update Swift.gitignore - Remove Accio

### DIFF
--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -66,10 +66,6 @@ playground.xcworkspace
 
 Carthage/Build/
 
-# Accio dependency management
-Dependencies/
-.accio/
-
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo.


### PR DESCRIPTION
**Reasons for making this change:**
The dependency management tool Accio is deprecated and no longer supported. The readme suggests _not_ using it and rather opting to use Xcode's SPM integration directly. 

The ignored directory name "Dependencies" is general enough that it should be a usable directory name in a project. A developer may inadvertently use this name w/o realizing it is ignored, potentially resulting in lost work/time.

**Links to documentation supporting these rule changes:**

https://github.com/JamitLabs/Accio/blob/stable/README.md