### PR TITLE
Propose to ignore __pycache__ anywhere in sub-directories

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -1,5 +1,5 @@
 # Byte-compiled / optimized / DLL files
-__pycache__/
+**/__pycache__/
 *.py[cod]
 *$py.class
 


### PR DESCRIPTION
Hello!

__pycache__ can be anywhere in sub-directories of python project, it is better ignore it everywhere

