### PR TITLE
Create .gitignore with main rules for Flutter projects

### DIFF
--- a/Flutter.gitignore
+++ b/Flutter.gitignore
@@ -1,0 +1,132 @@
+*.g.dart
+*.freezed.dart
+*.mocks.dart
+*.config.dart
+.fvm/flutter_sdk
+.env
+.env.dev
+/doc/
+
+# Miscellaneous
+*.class
+*.lock
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.ipr
+*.iws
+.idea/*
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+# Visual Studio Code related
+.classpath
+.project
+.settings/
+.vscode/*
+
+# Flutter repo-specific
+/bin/cache/
+/bin/mingit/
+/dev/benchmarks/mega_gallery/
+/dev/bots/.recipe_deps
+/dev/bots/android_tools/
+/dev/docs/doc/
+/dev/docs/flutter.docs.zip
+/dev/docs/lib/
+/dev/docs/pubspec.yaml
+/dev/integration_tests//xcuserdata/Pods
+/packages/flutter/coverage/
+version
+
+# packages file containing multi-root paths
+.packages.generated
+
+# Flutter/Dart/Pub related
+/doc/api/ # - need dartdoc docs at Github repository for this project
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+flutter_*.png
+linked_*.ds
+unlinked.ds
+unlinked_spec.ds
+.fvm/
+
+# Android related
+/android//gradle-wrapper.jar
+/android/.gradle
+/android/captures/
+/android/gradlew
+/android/gradlew.bat
+/android/local.properties/GeneratedPluginRegistrant.java
+/android/key.properties
+/android/.idea/
+/android/settings_aar.gradle
+/android/app/features/main/gen/
+/android/key.properfties
+
+# iOS/XCode related
+/ios//*.mode1v3/*.mode2v3/*.moved-aside/*.pbxuser/*.perspectivev3/*sync//.sconsign.dblite/.tags*/.vagrant//DerivedData//Icon?/Pods//.symlinks//profile/xcuserdata
+/ios/.generated/
+/ios/Flutter/App.framework
+/ios/Flutter/Flutter.framework
+/ios/Flutter/Flutter.podspec
+/ios/Flutter/Generated.xcconfig
+/ios/Flutter/app.flx
+/ios/Flutter/app.zip
+/ios/Flutter/.last_build_id
+/ios/Flutter/flutter_assets/
+/ios/Flutter/flutter_export_environment.sh
+/ios/ServiceDefinitions.json
+/ios/Runner/GeneratedPluginRegistrant.*
+/ios/Podfile.lock
+
+# Coverage
+coverage/
+
+# Submodules
+pubspec.lock
+packages//pubspec.lock
+
+# Web related
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Generated files
+bin/
+gen/
+out/
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release
+
+# Exceptions to the above rules.
+!/ios//default.mode1v3/default.mode2v3/default.pbxuser/default.perspectivev3
+!/ios/Podfile.lock
+!/packages/flutter_tools/test/data/dart_dependencies_test//.packages
+!/dev/ci/**/Gemfile.lock
+!.vscode/launch.json
+!.idea/codeStyles/
+!.idea/dictionaries/
+!.idea/runConfigurations/
+


### PR DESCRIPTION
**Reasons for making this change:**
Add template for Flutter projects. This template is created based on experience of multiple production Flutter projects. Happy to share my experience with community. 
