### PR TITLE
Add .idea for VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea


### PR DESCRIPTION
port https://github.com/dotnet/sdk/pull/34044

**Reasons for making this change:**

`.idea` is the config folder for JetBrains Rider, think it likes `.vs` can be ignored, see https://github.com/github/gitignore/blob/main/community/DotNet/core.gitignore for details

**Links to documentation supporting these rule changes:**

https://github.com/github/gitignore/blob/main/community/DotNet/core.gitignore
https://github.com/dotnet/sdk/pull/34044

