### PR TITLE
Update VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea


### PR DESCRIPTION
Added the ".idea" entry. This template is used with the .NET CLI and anyone using the JetBrains platform currently has to add this entry manually.