### PR TITLE
Use yarn v3 instead of v2

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -122,9 +122,11 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
-# yarn v2
-.yarn/cache
-.yarn/unplugged
-.yarn/build-state.yml
-.yarn/install-state.gz
+# yarn v3
 .pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
Updates the `gitignore` for Node to use yarn v3 instead of yarn v2. Ignores the files recommended by yarn on the docs.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Yarn v3 has a different ruleset than yarn v2, ignoring everything except the patches, plugins, releases, sdks, and versions in the `.yarn/` folder. My changes update the `gitignore` to support these changes.

**Links to documentation supporting these rule changes:**

- ["Which files should be gitignored?"](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)
