### PR TITLE
Update VS Code (remove a path and add a missing one)

### DIFF
--- a/Global/VisualStudioCode.gitignore
+++ b/Global/VisualStudioCode.gitignore
@@ -4,9 +4,7 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
-
-# Local History for Visual Studio Code
-.history/
+!*.code-workspace
 
 # Built Visual Studio Code Extensions
 *.vsix


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

- Removes a 3rd party extension directory (`.history/`) because of reasons described below.
- Adds the `*.code-workspace` path that exists in https://github.com/github/gitignore/blob/main/VisualStudio.gitignore#L385 and https://github.com/github/gitignore/blob/main/Global/AL.gitignore#L6. (They should also be updated with the missing `!.vscode/*.code-snippets` that exists here. I can open PRs when this is merged)

**Links to documentation supporting these rule changes:**

The `.history/` directory is only used by [this third party extension](https://marketplace.visualstudio.com/items?itemName=xyz.local-history) which has already been stated in https://github.com/github/gitignore/pull/3008#issue-423274609.
Moreso, VS Code has since officially released their own 'local history' feature which doesn't use such a directory: [release notes](https://code.visualstudio.com/updates/v1_66#_local-history)
