### PR TITLE
No need to share debug breakpoint configuration

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,5 +1,6 @@
 ## User settings
 xcuserdata/
+*.xcbkptlist
 
 ## Xcode 8 and earlier
 *.xcscmblueprint


### PR DESCRIPTION
**Reasons for making this change:**

There is no reason to share personal debug configuration in a shared Xcode project. This change removes all such files from tracking to ensure one person's debug session doesn't blow out other people's sessions when they pull the latest changes. 

**Links to documentation supporting these rule changes:**

I can't find any documentation on Apple's website about what files to include in version control for Xcode. This is on brand 🤷🏽 If you want _a_ link, [here's a recommended file](https://www.delasign.com/blog/recommended-gitignore-for-swift-projects-in-xcode/), but this change isn't trying to go that far. 


