### PR TITLE
Add files via upload

### DIFF
--- a/community/embedded/STM32CubeIDE.gitignore
+++ b/community/embedded/STM32CubeIDE.gitignore
@@ -1,0 +1,87 @@
+# https://github.com/github/gitignore/blob/master/C.gitignore
+
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+*.list
+
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# cscope with Vim
+cscope.*
+ctrlp.root
+
+# Sourcetrail
+Sourcetrail
+
+# CubeIDE
+*.launch
+STM32CubeIDE/
+STM32CubeIDE/Debug
+STM32CubeIDE/.settings
+.settings/
+
+# VSCODE
+.vscode/
+
+# Log files
+*.log
+
+# Compiled Binaries
+*.hex
+
+# Trash files
+*.bak
+
+
+*.cyclo
+*.mk
+makefile


### PR DESCRIPTION
Add STM32CubeIDE .gitignore

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
I am developing st mcu on STM32CubeIDE and I can't find any .gitignore online. I have tested this .gitignore on STM32CubeIDE environment to trace only necessary files.
_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
