### PR TITLE
more compatible node_modules ignore for npm publish

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -39,7 +39,7 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+node_modules
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)


### PR DESCRIPTION
**Reasons for making this change:**

git will ignore `node_modules` directory in any nest directories whether we write `node_modules/` or `node_module`.
However `npm` only ignore `node_modules` in subdirectories when we write `node_modules` in `.gitignore` if `.npmignore` is not exist.

```shell
# when we write `node_modules/` in .gitignore
npm publish

# upload node_modules/xx.js
npm notice aa/node_modules/xx.js
```

```shell
# when we write `node_modules` in .gitignore
npm publish

# will not upload aa/node_modules/xx.js
```