### PR TITLE
Update VisualStudio.gitignore for ENV files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.env
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
Adding .env exclusion

**Reasons for making this change:**
.env file support is starting to happen more and more in .NET ecosystem and VS users.