### PR TITLE
Ignore environments created in a `.direnv` folder

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -127,6 +127,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.direnv/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Visual Studio Code looks for environments in a `.direnv` as well (in addition to the usual locations), so it would be good to ignore that folder.

**Links to documentation supporting these rule changes:**

Context: https://code.visualstudio.com/docs/python/environments#_where-the-extension-looks-for-environments
