### PR TITLE
Nova Code Editor

### DIFF
--- a/Global/Nova.gitignore
+++ b/Global/Nova.gitignore
@@ -1,0 +1,2 @@
+# Nova Configuration File
+.nova


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

**Relationship to Project:** 

I am not officially associated with [Nova](https://nova.app/) or its developers, [Panic](https://panic.com/).

**Expectation from Change:**

Hoping to add the `.nova` directory to Global .gitignores so other developers can easily reference and exclude this directory. The `.nova` directory contains configuration and workspace-specific settings used by the Nova editor. Ignoring it is essential for those using Nova to ensure that Git does not track personal or workspace-specific settings.

**Links to documentation supporting these rule changes:**


- [Official docs about the `.nova` directory configuration and format](https://docs.nova.app/extensions/preferences/#:~:text=Configuration%20stored%20for%20a%20workspace,using%20a%20simple%20JSON%20format.)
- [Nova's guidance on how the `.nova` directory stores project settings and data](https://help.panic.com/nova/moving-data/#local-projects)


If this is a new template:

 - **Link to application or project’s homepage**: [Nova Homepage](https://nova.app/)
