### PR TITLE
Update VisualStudio.gitignore for vcpkg

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -285,6 +285,9 @@ FakesAssemblies/
 .ntvs_analysis.dat
 node_modules/
 
+# vcpkg package files
+vcpkg_installed/
+
 # Visual Studio 6 build log
 *.plg
 


### PR DESCRIPTION


**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

vcpkg running in manifest mode will create a folder vcpkg_installed/ containing installed package files that should not be committed to any project.

**Links to documentation supporting these rule changes:**

The manifest mode of vcpkg is documented at https://learn.microsoft.com/en-us/vcpkg/users/manifests
