### PR TITLE
ignore split-dwarf debugging-related auxilary .dwo files for C and C+…

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# debug information files
+*.dwo

--- a/C.gitignore
+++ b/C.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# debug information files
+*.dwo


### PR DESCRIPTION
Adds `.dwo` file to the ignore templates of C and C++. `.dwo` is the file extension for auxiliary debug information written to disk when using the `-gsplit-dwarf` compile flag.

- https://undo.io/resources/gdb-watchpoint/reduce-binary-size-compile-time-split-dwarf/
- https://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/
