### PR TITLE
Created the git-init script file

### DIFF
--- a/community/bin/README.md
+++ b/community/bin/README.md
@@ -1,0 +1,75 @@
+# Git-Init script
+
+The git-init script is designed to initialize a new git repository using the 
+files from the github/gitignore file list.
+
+This script can be run inside an initialized git repository if no .gitignore file
+already exist. The script will not overwrite any existing .gitignore or reinitialize
+a git repository.
+
+## Installation
+
+Clone the github/gitignore repository to your ~/.local/share folder
+
+```
+    git clone https://github.com/github/gitignore
+```
+
+Create a link in your ~/.local/bin folder (or in any other bin folder in your PATH variable)
+called git-init to the git-init.sh file.
+
+```
+    ln -s ~/.local/share/gitignore/community/bin/git-init.sh ~/.local/bin/git-init
+```
+
+You can clone the repository to another folder and then set the
+GIT_INIT_PATH environment variable.
+
+```
+    GIT_INIT_PATH=/path/to/gitignore
+```
+
+## Usage
+
+Run the git-init script with the name of a prefix in the github/gitignore file list.
+
+```
+    git-init [project-type]
+
+    project-type    The prefix used for a .gitignore file.
+```
+
+Examples:
+
+```
+    # Initialize a C project using the C.gitignore file
+    git-init c
+
+    # Initialize a Node project using the Node.gitignore file
+    git-init node
+```
+
+Running the git-init command without a project-type will generate a default empty .gitignore file
+
+## Environment configuration
+
+The GIT_INIT_PATH sets the path that the github/gitignore repository is stored in. 
+The default path is ~/.local/share/gitignore
+
+```
+    export GIT_INIT_PATH=/path/to/gitignore
+
+```
+
+Setting the environment variable GIT_INIT_EXTRAS_FOLDER will create a .extras folder to store files
+that may be useful to keep locally but the git repository should ignore.
+
+```
+    export GIT_INIT_EXTRAS_FOLDER=true
+```
+
+## Requirements
+
+The script requires the following tools:
+
+`git`, `bash` and `find`

--- a/community/bin/git-init.sh
+++ b/community/bin/git-init.sh
@@ -1,0 +1,80 @@
+#! /bin/bash
+
+GIT_INIT_PATH=$(echo -e "${GIT_INIT_PATH:=~/.local/share/gitignore}")
+
+help() {
+
+    echo -e "\ngit-init: A git init script to initialize a new git repository with a .gitignore file"
+    echo -e "          copied from the github/gitignore repository\n"
+
+    echo -e "usage: git-init [project-type]\n"
+
+    echo -e "    project-type\tThe prefix used for a .gitignore file."
+    echo -e "\n"
+
+    echo -e "Running the git-init command without a project-type will generate a defauly empty .gitignore file"
+
+    echo -e "The GIT_INIT_PATH sets the path that the github/gitignore repository is stored in."
+    echo -e "The default path is ~/.local/share/gitignore\n"
+
+    echo -e "Setting the environment variable GIT_INIT_EXTRAS_FOLDER will create a .extras folder to store files"
+    echo -e "that may be useful to keep locally but the git repository should ignore.\n"
+
+    exit
+}
+
+gitignore () {  
+
+    if [ -f .gitignore ]; then
+
+        return
+    fi
+
+    if [ $# -eq 0 ]; then  
+
+        echo -e "# Default .gitignore" > .gitignore
+        return
+
+    else
+        GITIGNORE_FILE=$(find $GIT_INIT_PATH -iname "$1.gitignore")
+    fi
+
+    if [ -z $GITIGNORE_FILE ]; then
+
+        echo -e "Unknown gitignore file type: $1"
+        echo -e "see available types in \n\t${GIT_INIT_PATH}"
+        exit 1
+    fi
+
+    if [ ! -f $GITIGNORE_FILE ]; then
+
+        echo -e "Missing $GITIGNORE_FILE"
+        return
+    fi
+
+    cp $GITIGNORE_FILE .gitignore
+    echo -e "Create .gitignore file for $1\n"
+    head -n 3 .gitignore
+    echo
+}
+
+gitextras () {
+
+    if [ -n "$GIT_INIT_EXTRAS_FOLDER" ]; then 
+
+        mkdir -p $(pwd)/.extras    
+        echo -e "\n\n# Extra files kept locally but ignored in the repository\n.extras/\n" >> .gitignore
+    fi    
+}
+
+if [ "$1" == "-h" ]|| [[ "$1" == "--help" ]]; then
+    help
+fi
+
+gitignore $1
+gitextras
+
+if [ ! -d .git ]; then
+
+    git init
+fi


### PR DESCRIPTION
Reasons for making this change:

git-init is a script created to initialize new git repositories using the github/gitignore files to initialize a new repository and create a .gitignore file from a template.

The basic usage is instead of typing `git init` you would type `git-init node` to initialize a new node project with the Node.gitignore template.

It is in a new section under community/bin