### PR TITLE
[Unity] Add more folders and files to ignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -5,10 +5,13 @@
 /[Ll]ibrary/
 /[Tt]emp/
 /[Oo]bj/
+/[Bb]in/
 /[Bb]uild/
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+/[Aa]rtifacts/
+/[Ll]ocal[Cc]ache/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data
@@ -46,6 +49,11 @@ ExportedObj/
 *.mdb
 *.opendb
 *.VC.db
+*.opensdf
+*.sdf
+*.ipch
+*.log
+*.idb
 
 # Unity3D generated meta files
 *.pidb.meta
@@ -70,3 +78,37 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Ignore UnityVS so that users can use different versions
+/[Aa]ssets/UnityVS/*
+/[Aa]ssets/UnityVS.meta
+
+# Platform-specific build directories
+/WebBuild/
+/WindowsBuild/
+
+# Windows Store App folders
+/WindowsStoreApp/
+/WSA/
+
+# Automatically generated Unity-related folders
+/UnityGenerated/
+/UnityPackageManager/
+
+# Generated Unity UWP files and folders
+/UWP/
+/project.json
+/project.lock.json
+
+# Folder for generated UWP App to export to HoloLens
+/[Aa]pp/
+
+# Debug output
+/DebugOutput/
+/DebugOutput.meta
+
+# Certificates
+*.cert
+*.privkey
+*.pfx
+*.pfx.meta


### PR DESCRIPTION
This commit adds the following categories of folders and files to ignore:
- Automatically generated Unity-related folders
- Platform-specific build directories
- Windows Store App
- UWP
- UnityVS
- Debug output
- Certificates

**Reasons for making this change:**

I am an occasional Unity user and have slowly built up a custom list of folders and files to ignore over time. I thought it would be good to contribute this list to this upstream repository. This list is a clean version of my personal one and it should be suitable for inclusion as a template `.gitignore` file.

**Links to documentation supporting these rule changes:**

Some of these changes were accumulated over time and others were acquired from various sources, both official and unofficial. Most were sourced from the official [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/main/.gitignore) and [MRTK v3](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/blob/main/.gitignore) repositories.