### PR TITLE
Add Zig.gitignore

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,0 +1,6 @@
+# Object files
+*.o
+
+# Build artifacts and cache
+zig-cache/
+zig-out/

--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,6 +1,3 @@
-# Object files
-*.o
-
 # Build artifacts and cache
 zig-cache/
 zig-out/


### PR DESCRIPTION
**Reasons for making this change:**

I'm not affiliated with the project. I'm adding this Zig.gitignore as I missed it when opening up a repository in which I planned to use Zig.

**Links to documentation supporting these rule changes:**

[_ziglang.org/Zig-Build-System_](https://ziglang.org/documentation/master/#Zig-Build-System)

 **Link to application or project’s homepage**: 

[_ziglang.org_](https://ziglang.org)
