### PR TITLE
Added inclusion phrase for `meta` files

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -47,7 +47,8 @@ ExportedObj/
 *.opendb
 *.VC.db
 
-# Unity3D generated meta files
+# Unity3D generated meta files (include & exclude)
+!*.meta
 *.pidb.meta
 *.pdb.meta
 *.mdb.meta


### PR DESCRIPTION
gitignore template of visualstudio is excluding meta file

a proposal like in this issue could make use of the inclusion phrases to make generated gitignore files more usable: https://github.com/toptal/gitignore.io/issues/626

**Reasons for making this change:**
meta files are excluded by other gitignore templates (e.g. Visualstudio), so it's important to actively include it, so unity is working with versioning correctly.
Using this notation might help gitignore generators to improve their output. Right now the order decides which rule is more important, see the linked issue for more explanation

**Links to documentation supporting these rule changes:**
- https://itecnote.com/tecnote/git-opposite-of-gitignore-file/
- https://github.com/toptal/gitignore.io/issues/626
