### PR TITLE
KiCad : Ignore lock files for KiCad v7

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -11,6 +11,7 @@
 *.kicad_prl
 *.sch-bak
 *~
+~*.kicad*.lck
 _autosave-*
 *.tmp
 *-save.pro


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

KiCad v7 now creates lock files when opening a PCB schematic or layout.
These lock files should be ignored in version control, as their presence in a repository can lead to [errors](https://forum.kicad.info/t/opening-schematic-error/43525/11) when opening a project.

**Links to documentation supporting these rule changes:**

There are a few discussions on the KiCad forum that supports ignoring `*.lck` lock files. [Here is an example](https://forum.kicad.info/t/kicad-7-reliability-constant-crashes-damaged-source-files/44043/67)
