### PR TITLE
Remove superfluous globs from Terraform.gitignore

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -1,5 +1,5 @@
 # Local .terraform directories
-**/.terraform/*
+.terraform/
 
 # .tfstate files
 *.tfstate


### PR DESCRIPTION
Hey team, long time listener, first time caller..

**Reasons for making this change:**

Here is the original pattern:

```
**/.terraform/*
```

First, let's look at that glob at the end - the `/*` part. You cannot commit an empty folder to git, so ignoring `<path>/*` is analogous to ignoring `<path>`. In both cases, you will ignore the folder and its contents. I cannot think of an example where ignoring `**/.terraform/` would produce a different result than ignoring `**/.terraform/*`.

Next, what about that glob at the front (that's the `**` part)? The gitignore documentation says:

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. **Otherwise the pattern may also match at any level below the .gitignore level**.

Emphasis mine. In other words, the glob at the beginning is necessary to ignore `.terraform` folders below the root of the repo if and only if we leave the glob at the end, which serves no purpose. By removing the glob at the end, the rule is applied "at any level below the .gitignore level", and thus has no need for the recursive `**` glob at the beginning.

**Links to documentation supporting these rule changes:**

- <https://git-scm.com/docs/gitignore>

