### PR TITLE
Ignore mono_crash files

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -55,6 +55,9 @@ ExportedObj/
 # Unity3D generated file on crash reports
 sysinfo.txt
 
+# Mono auto generated files
+mono_crash.*
+
 # Builds
 *.apk
 *.aab


### PR DESCRIPTION
These can be generated by Unity on crash

**Reasons for making this change:**

- Unity can generate mono_crash.* files in some crash conditions.
- This happened to us recently and we ended up with these files in version control.

**Links to documentation supporting these rule changes:**

Honestly I can't find it documented in Unity docs. I asked in official Unity discord and was told it was created by Unity.
A mention of it here: https://forum.unity.com/threads/debugging-editor-crashes.1457002/

I assume they're created by Mono itself, which is embedded in Unity.