### PR TITLE
Add more to C++.gitignore

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -56,13 +56,6 @@ CMakeCache.txt
 CMakeScripts/
 Testing/
 
-# VSCode directories and files
-.vscode/
-settings.json
-tasks.json
-launch.json
-c_cpp_properties.json
-
 # Qt project files
 *.pro.user
 *.pro.user.*

--- a/C++.gitignore
+++ b/C++.gitignore
@@ -30,3 +30,50 @@
 *.exe
 *.out
 *.app
+
+# CMake build directory
+build/
+
+# Visual Studio Code directory
+.vscode/
+
+# Sublime Text workspace files
+*.sublime-workspace
+
+# Eclipse directory
+.settings/
+
+# Code::Blocks directory
+bin/
+
+# Xcode directory
+*.xcodeproj/
+*.xcworkspace/
+
+# CMake build files
+CMakeFiles/
+CMakeCache.txt
+CMakeScripts/
+Testing/
+
+# VSCode directories and files
+.vscode/
+settings.json
+tasks.json
+launch.json
+c_cpp_properties.json
+
+# Qt project files
+*.pro.user
+*.pro.user.*
+
+# Qt Creator directory
+*.user
+*.user.*
+
+# Boost build directory
+bin.v2/
+
+# CLion directory
+.idea/
+*.iml


### PR DESCRIPTION
### Reasons for making this change:

I am a contributor to this repo. The changes to the C++.gitignore file were necessary to ensure that unnecessary build artifacts and IDE-specific files are not tracked by version control. This helps maintain a clean repository focused on source code.