### PR TITLE
Add Ballerina gitignore file

### DIFF
--- a/Ballerina.gitignore
+++ b/Ballerina.gitignore
@@ -1,0 +1,11 @@
+# Ballerina generates this directory during the compilation of a package. 
+# It contains compiler-generated artifacts and the final executable if this is an application package.
+target/
+
+# Ballerina maintains the compiler-generated source code here.
+# Remove this if you want to commit generated sources.
+generated/
+
+# Contains configuration values used during development time.
+# See https://ballerina.io/learn/provide-values-to-configurable-variables/ for more details.
+Config.toml


### PR DESCRIPTION
**Reasons for making this change:**

Ballerina is a growing open-source programming language focused on integration, and I would like to ask you to add a .gitignore template tailored for Ballerina projects to your collection. Currently, there are numerous repositories on GitHub utilizing Ballerina, and having a dedicated .gitignore template would greatly benefit our community.

**Links to documentation supporting these rule changes:**
https://ballerina.io/learn/#reference-documentation

If this is a new template:

 - **Link to application or project’s homepage**: https://ballerina.io/
