### PR TITLE
Add Visual Studio Code cache directory

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
Unity has recently released their new, updated extension to Visual Studio Code which allows for debugging, etc. However, the default .gitignore for Unity has not been updated to ignore the Visual Studio Cache directory `.vscode`, and puts the responsibility on the user. Added the directory to the file so this responsibility is removed.

[Link to the Visual Studio Code extension on the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=visualstudiotoolsforunity.vstuc)

