### PR TITLE
Update Python.gitignore for PEP 441

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -1,6 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
+*.py[codz]
 *$py.class
 
 # C extensions


### PR DESCRIPTION
PEP 441 introduces Python ZIP Applications to bundle a Python Application into a ZIP file with file extension `pyz`.

**Reasons for making this change:**
Python ZIP Applications, described in [PIP 441](https://peps.python.org/pep-0441/), are an artifact from the build process and shouldn't be added to the repository. These files have their own file extension `pyz` making it easy to exclude them.

**Links to documentation supporting these rule changes:**

- [PEP 441](https://peps.python.org/pep-0441/) describing Python ZIP Applications
