### PR TITLE
Add Nextflow template

### DIFF
--- a/community/Nextflow.gitignore
+++ b/community/Nextflow.gitignore
@@ -1,0 +1,10 @@
+# Ignore logs and .nextflow directory
+.nextflow*
+# Ignore default work directory
+work/
+# Ignore default nf-test directory
+.nf-test*
+
+# nf-core
+# Ignore results directory
+results/


### PR DESCRIPTION
**Reasons for making this change:**
Nextflow community member, I'd love to start a new repo and be able to select Nextflow. I couldn't tell from the docs if that would happen here.

https://www.nextflow.io/docs/edge/tracing.html
https://github.com/nextflow-io/hello/blob/master/.gitignore
https://github.com/nf-core/rnaseq/blob/3.11.2/.gitignore

If this is a new template:

 - **Link to application or project’s homepage**: https://www.nextflow.io/
