### PR TITLE
Add Nix.gitignore

### DIFF
--- a/Nix.gitignore
+++ b/Nix.gitignore
@@ -1,0 +1,5 @@
+# Nix derivation output
+**/result/**
+
+# Nix shell file system overlay (like chroot but per repo)
+.devenv/**


### PR DESCRIPTION
**Reasons for making this change:**

So nix builds locally some builds (like bin/obj) into `result` folder.

And also produces links for custom "home" per git repo per user in .devenv.

**Links**

https://devenv.sh/

https://nixos.org/manual/nix/stable/command-ref/nix-build

