### PR TITLE
Update R.gitignore to include .env files

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -38,6 +38,7 @@ vignettes/*.pdf
 
 # R Environment Variables
 .Renviron
+.env
 
 # pkgdown site
 docs/


### PR DESCRIPTION
Small change to include `.env` files which are also used in R projects.