### PR TITLE
UC: Added ignore template for BFH workflows

### DIFF
--- a/community/bfh.gitignore
+++ b/community/bfh.gitignore
@@ -1,0 +1,19 @@
+# gitignore template for Bern University of Applied Sciences (BFH) workflows
+# website: https://www.ti.bfh.ch
+
+# Additions to LaTeX build flow
+_output/
+
+# Additions used in embedded build flows
+_build/
+build/
+
+# Additions used in STM32 based workflows
+STM32Make.make
+STM32-for-VSCode.config.yaml
+
+# Additions in general purpose flows
+[Au][Uu][Tt]??[_/]*
+[Ss][Pp][Rr]??[_/]*
+_sandbox/
+[aefimswx]?[abcdefghimop]_*


### PR DESCRIPTION
This set of ignore patterns is used at BFH in combination with other gitignore templates.

**Reasons for making this change:**
I work at BFH. We have several projects either in education or research activities. We use git a lot and therefore gitignore pattern templates from this repositories. To build a specific gitignore file we use APIs like gitignore.io/api. In terms of maintainability and ease of use, a bfh template covering some specific properties would be very handy.

**Links to documentation supporting these rule changes:**
Unfortunately, not possible.

If this is a new template:

 - **Link to application or project’s homepage**:  https://www.bfh.ch/ti/en/
