### PR TITLE
New extension to ignore in Delphi IDE.

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -56,6 +56,7 @@
 *.projdata
 *.tvsconfig
 *.dsk
+*.dsv
 
 # Delphi history and backups
 __history/


### PR DESCRIPTION
The Delphi IDE released an updated version, called Athens with create a new local file that doesn't need versioning control.
