### PR TITLE
Add .exe to Haskell.gitignore

### DIFF
--- a/Haskell.gitignore
+++ b/Haskell.gitignore
@@ -1,6 +1,7 @@
 dist
 dist-*
 cabal-dev
+*.exe
 *.o
 *.hi
 *.hie


### PR DESCRIPTION
on windows ghc procudes .exe files which should be ignored in source control

**Reasons for making this change:**
New haskell git repo with ghc on windows will now ignore output .exe files.

https://downloads.haskell.org/~ghc/6.0/docs/html/users_guide/options-output.html#:~:text=Note%3A-,on%20Windows,-%2C%20if%20the%20result