### PR TITLE
Add `.DS_Store` to `Python.gitignore`

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# System files
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

As a Python developer, I always manually add `.DS_Store` to `.gitignore` in my projects. These files are created by macOS to store folder attributes: https://en.wikipedia.org/wiki/.DS_Store

These files are not relevant to the project's codebase and can clutter the repo if committed. I think it makes sense for `.DS_Store` exclusion to be the default.

**Links to documentation supporting these rule changes:**

- The `.gitignore` documentation from Git supports the idea of excluding system-specific files which are not relevant to the project: https://git-scm.com/docs/gitignore
- Stack Overflow discussions on the topic, such as [this thread](https://stackoverflow.com/questions/107701/how-can-i-remove-ds-store-files-from-a-git-repository) which highlights the common practice of ignoring `.DS_Store` in git repos.
