### PR TITLE
Added a .gitignore file for Madcap Flare projects. Madcap Flare is used for technical documentation purposes.

### DIFF
--- a/community/MadcapFlare/MadcapFlare.gitignore
+++ b/community/MadcapFlare/MadcapFlare.gitignore
@@ -1,0 +1,21 @@
+# gitignore template for Madcap Flare projects
+# website: https://www.madcapsoftware.com/products/flare/
+#
+# Recommended: madcapflare.gitignore
+######################################################################################
+# Placing a # in front of any of the items listed below (e.g., # /Project/Users) will 
+# allow these items to be pushed to your Git repository. Keep in mind the more files 
+# you push to your repository, the more your performance may be affected. 
+######################################################################################
+
+# Ignore auto-generated MadCap folders for output and analysis
+/Output
+/Analyzer
+/FileSync
+
+# Ignore auto-generated MadCap files for users
+/Project/Users
+
+# Ignore any residual svn folder
+/.svn
+**/Thumbs.db


### PR DESCRIPTION
Added a .gitignore file for Madcap Flare projects. 

**Reasons for making this change:**
[Madcap Flare](https://www.madcapsoftware.com/products/flare/) is used for technical documentation purposes. Writers need to create an .gitignore file for every Madcap Flare project to ignore the auto-generated folders and files. Instead of creating a new file from scratch everytime, a template file would save a lot of time. 

**Links to documentation supporting these rule changes:**
 - **Link to application or project’s homepage**: [Madcap Flare Help page](https://help.madcapsoftware.com/flare2023r2/Content/Flare/Source-Control/Git/Other-Activities/Adding-Editing-Ignore-File.htm)
