### PR TITLE
Update Godot.gitignore

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,5 +1,11 @@
 # Godot 4+ specific ignores
-.godot/
+.godot/*
+
+# allow those folders and files as they are required for remote-building e.g. using github actions 
+# They do not get recreated properly when you use PCK files inside of your project in Version 4.1.13
+!.godot/exported/
+!.godot/imported/
+!.godot/global_script_class_cache.cfg
 
 # Godot-specific ignores
 .import/


### PR DESCRIPTION
I need to keep certain folders and files within the .godot directory in my project's repository, specifically due to issues related to PCK files during the GitHub workflow process. PCK files, which are essential for the Godot Engine projects, contain packaged project assets and resources. When the GitHub workflow runs without these specific directories ('exported', 'imported') and the file global_script_class_cache.cfg present, it tries to recreate them. However, it often fails to properly reestablish the necessary links and configurations.

Moreover, there's an observed issue where, if these directories are missing, the project builds successfully, but the resulting executable exhibits errors upon launching. Particularly, some scripts fail to execute correctly. This problem might not directly stem from the PCK files themselves, but the absence of these directories seems to disrupt the proper functioning of the build. Retaining these directories and files is thus crucial to ensure a smooth and error-free build and execution process

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
