### PR TITLE
feat: add KiCad lock/autosave files

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -16,6 +16,8 @@ _autosave-*
 *-save.pro
 *-save.kicad_pcb
 fp-info-cache
+~*.lck
+\#auto_saved_files#
 
 # Netlist files (exported from Eeschema)
 *.net


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Add `~*.lck` and `#auto_saved_files#` files for [KiCad](https://www.kicad.org)

**Links to documentation supporting these rule changes:**

These are _working files_ so they are not well-documented but we are able to see their usage from the [`KiCad/kicad-source-mirror`](https://github.com/KiCad/kicad-source-mirror).

**`~*.lck`**

https://github.com/KiCad/kicad-source-mirror/blob/69c95acc579e09195410f713ca42c79610cc4e05/common/wildcards_and_files_ext.cpp#L126-L127

https://github.com/KiCad/kicad-source-mirror/blob/69c95acc579e09195410f713ca42c79610cc4e05/include/lockfile.h#L54-L55

**`#auto_saved_files#`**

https://github.com/KiCad/kicad-source-mirror/blob/69c95acc579e09195410f713ca42c79610cc4e05/eeschema/files-io.cpp#L1688
