### PR TITLE
Added gitignore for macOS-developers of DS_Store

### DIFF
--- a/DS_Store.gitignore
+++ b/DS_Store.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Added gitignore for macOS-developers of DS_Store

**Reasons for making this change:**
This change will resolve this common problem for macOS-developers that are using GitHub on their devices.

**Links to documentation supporting these rule changes:**
- https://stackoverflow.com/questions/107701/how-can-i-remove-ds-store-files-from-a-git-repository
- https://osxdaily.com/2023/05/30/how-to-remove-ds_store-files-from-git-repository/
- https://www.linkedin.com/pulse/how-remove-dsstore-files-from-git-repositories-chandan-thakur
- https://dev.to/mattiaorfano/gitignore-mac-dsstore-files-even-if-already-committed-14dm
- https://pineco.de/snippets/globally-gitignore-the-ds_store-file/

If this is a new template:
- https://stackoverflow.com/questions/107701/how-can-i-remove-ds-store-files-from-a-git-repository
- https://osxdaily.com/2023/05/30/how-to-remove-ds_store-files-from-git-repository/
- https://www.linkedin.com/pulse/how-remove-dsstore-files-from-git-repositories-chandan-thakur
- https://dev.to/mattiaorfano/gitignore-mac-dsstore-files-even-if-already-committed-14dm
- https://pineco.de/snippets/globally-gitignore-the-ds_store-file/