### PR TITLE
Add wildcard so that all .env files are ignored - Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -120,7 +120,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
So that all files starting with `.env` are ignored.

**Example why this is useful:**

With python 3.11 there is now native TOML support, so it is a valid use case to have `.env.toml` files.
Additionally, it would be useful if more than one ".env" file is present, like ".env_topic1" for example.

**Current status**
The problem with the current "gitignore" is, that these files are not ignored.

**Solution**
With the wildcard `.env*` they are ignored.

**Links to documentation supporting these rule changes:**
[python 3.11 tomlib native support](https://docs.python.org/3/library/tomllib.html)

[The Dart gitignore](https://github.com/github/gitignore/blob/main/Dart.gitignore) also has the wildcard to ignore all .env* files and from my perspective it would be useful for python too

_BTW: If something is missing or not correct, please let me know, this is my first pull request to this repo_