### PR TITLE
Create LTspice.gitignore

### DIFF
--- a/community/LTspice.gitignore
+++ b/community/LTspice.gitignore
@@ -1,0 +1,12 @@
+# gitignore template for LTspice
+# website: https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html
+
+# Logfile
+*.log
+
+# Simulation Outputs
+*.raw
+*.fft
+
+# Netlist
+*.net


### PR DESCRIPTION
**Reasons for making this change:**
LTspice is a high-performance SPICE simulation software, schematic capture and waveform viewer with enhancements and models for easing the simulation of analogue circuits.

It is the most popular Freeware SPICE simulator used extensively in both hobby and professional environments. As a hardware engineer using Github, a built in template would be quite valuable.

This is a rework of #3080, putting the `.gitignore` file in the correct directory.

**Links to documentation supporting these rule changes:**

[LTSpice Filetypes List](https://ltwiki.org/index.php?title=Most_frequently_asked_questions_for_beginners#What_are_the_different_LTspice_file_types.3F)

If this is a new template:

 - **Link to application or project’s homepage**: [LTspice website](https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html)
