### PR TITLE
Added appsettings.json to VisualStudio.gitignore as this file commonly holds connection strings and should be excluded

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -58,6 +58,8 @@ dlldata.c
 BenchmarkDotNet.Artifacts/
 
 # .NET Core
+appsettings.json
+appsettings.Development.json
 project.lock.json
 project.fragment.lock.json
 artifacts/


### PR DESCRIPTION
I have seen projects where `appsettings.json` has been inadvertently included in commits and have also done it myself in the past. The `.gitignore` file has a section for .NET Core but it misses out this file which I think should be included.

**Reasons for making this change:**
Being able to use the .gitignore templates to keep temporary and sensitive files out of the shared repository is important but I feel it misses one of the most important files which could lead people to inadvertently upload database connection details contained within `.appsettings.json`.
If the pull request is accepted then it saves me having to add the additional lines myself and should protect developers from accidentally disclosing credentials which could cause a serious issue, especially if a database server is publicly accessible.

Having a `.gitignore` specifically file for VisualStudio, developers may think this covers everything and be less likely to check what they are uploading until their server is compromised. 

This change should have no negative impact and should help keep the developer community secure.
