### PR TITLE
Create Nix.gitignore

### DIFF
--- a/Nix.gitignore
+++ b/Nix.gitignore
@@ -1,0 +1,2 @@
+/result
+/result-*


### PR DESCRIPTION
**Reasons for making this change:**
Support for common Nix output paths. I use Nix Flakes in all of my projects and this would be awesome for automatically ignoring the related Nix output directories

**Links to documentation supporting these rule changes:**

- for `result/`: https://nixos.org/manual/nix/stable/command-ref/nix-build#description
- for `result-<N>-<outname>/`: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-build#description

If this is a new template:

 - **Link to application or project’s homepage**: https://nixos.org/
