### PR TITLE
Update Terraform.gitignore to include Terragrunt

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -35,3 +35,4 @@ terraform.rc
 
 # Ignore local Terragrunt cache files and directories
 .terragrunt-cache/
+terragrunt-debug.tfvars.json

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore local Terragrunt cache files and directories
+.terragrunt-cache/


### PR DESCRIPTION
Reasons for making this change:

Terragrunt is a thin wrapper tool for Terraform: https://terragrunt.gruntwork.io/

It makes sense to add this to the Terraform template, because if one is using Terragrunt, then by default Terraform is also being used. Terragrunt is popular and increasingly becoming a necessary wrapper for complex Terraform operations.

Links to documentation supporting these rule changes:

Documentation which highlights the caching folder:
https://terragrunt.gruntwork.io/docs/features/caching/#clearing-the-terragrunt-cache

The generate command which creates arbitrary generated* files in the current working directory:
https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#generate

*Reopening #3508 