### PR TITLE
Need to ignore .DS_Store from macOS filesystem

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

In macOS, there is a hidden system-generated file `.DS_Store` which is not important for git, but always gets added to commits making them dirtier.

**Links to documentation supporting these rule changes:**

[WikiPedia](https://en.wikipedia.org/wiki/.DS_Store):
>.DS_Store files may impose additional burdens on a [revision control](https://en.wikipedia.org/wiki/Revision_control) process, since they are frequently changed and can therefore appear in commits, unless specifically excluded.

[Microsoft](https://support.microsoft.com/en-us/office/remove-ds-store-files-on-macos-d2f8dca0-740a-4f7e-89b9-5b2cbbc50386):
> Corrupted .DS_Store files can prevent OneDrive from syncing correctly. Deleting the corrupted files can help restore normal sync operation.
No data is lost by deleting the corrupted files as Mac Finder only creates .DS_Store files to store viewing options, such as the positions of icons, size of the Finder window, and window backgrounds.

[Adobe](https://helpx.adobe.com/dreamweaver/kb/remove-ds-store-files-mac.html): 
> These files contain information about system configuration. If you upload them along with other files, the files can be misused to obtain information about your computer.

[Apple](https://support.apple.com/en-in/102497): 
> By enticing a user to open a directory containing a maliciously crafted .DS_Store file, an attacker may cause arbitrary code execution. This update addresses the issue through improved bounds checking.

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_

@shiftkey @bdougie 