### PR TITLE
Ignore .DS_Store

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# OSX
+.DS_Store
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**

Unity project in osx sometime add `DS_Store` unnecessary