### PR TITLE
Add support for Opendylan

### DIFF
--- a/Dylan.gitignore
+++ b/Dylan.gitignore
@@ -1,0 +1,16 @@
+# backup files
+*~
+*.bak
+.DS_Store
+
+# project file
+*.hdp
+
+# documentation build directory
+build/
+
+# compiler build directory
+_build/
+
+# dylan tool package cache
+_packages/


### PR DESCRIPTION
[Opendylan](https://opendylan.org) is an object-functional language originally created by Apple for the Newton. Dylan is a direct descendant of Scheme and CLOS (without the Lisp syntax).

**Reasons for making this change:**

Add gitignore initial support for Opendylan. I'm part of [Dylan language](https://github.com/dylan-lang) and [Dylan hackers](https://github.com/orgs/dylan-lang/teams/dylan-hackers) team.
