### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -146,6 +146,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Ruff
+.ruff_cache/
+
 # pytype static type analyzer
 .pytype/
 


### PR DESCRIPTION
Added .ruff_cache directory (a cache directory used by [ruff linter](https://github.com/astral-sh/ruff)).