### PR TITLE
Update link to poetry.lock documentation

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#   https://python-poetry.org/docs/basic-usage/#committing-your-poetrylock-file-to-version-control
 #poetry.lock
 
 # pdm


### PR DESCRIPTION
**Reasons for making this change:**

When I attempted to follow a link to the Poetry project's documentation regarding committing a `poetry.lock` file to version control, the anchor reference was no longer valid.

This PR updates the link to use the correct anchor.
