### PR TITLE
Added lck files and autosave files to KiCad gitignore

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -12,6 +12,8 @@
 *.sch-bak
 *~
 _autosave-*
+\#auto_saved_files\#
+~*.lck
 *.tmp
 *-save.pro
 *-save.kicad_pcb


### PR DESCRIPTION
No apparent canonical documentation for lck files in KiCad, but here's an issue that mentions them:

https://gitlab.com/kicad/code/kicad/-/issues/15148

Also ignoring `auto_saved_files` file.

https://techoverflow.net/2020/06/13/what-gitignore-to-use-for-kicad-projects/