### PR TITLE
Ignore *.tmp files, which are temporary files Godot creates

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -5,6 +5,7 @@
 .import/
 export.cfg
 export_presets.cfg
+*.tmp
 
 # Imported translations (automatically generated from CSV files)
 *.translation


### PR DESCRIPTION
**Reasons for making this change:**

These are temporary files Godot engine creates, which are supposed to be automatically removed, but there can be issues which prevent them from being removed.

Although these not being removed is an issue with the engine which may be fixed in the future, I think it would still be a good idea to add them here, in case a different issue occurs that causes them to not be removed.

**Links to documentation supporting these rule changes:**

Here is a current issue for this, but in searching I found that there have been other related issues in the past which caused .tmp files to show up. In addition, based on the conversations in this issue, there seem to be multiple sets of actions which cause the .tmp files to persist. Thus, I think it's a good idea to just add them in here:

https://github.com/godotengine/godot/issues/82270