### PR TITLE
Fix Icon ignore being clobbered by line-ending normalization.

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -3,8 +3,8 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two \r
-Icon
+# Icon
+Icon[\r]
 
 # Thumbnails
 ._*


### PR DESCRIPTION
**Reasons for making this change:**
Collaborators on platforms other than macOS who edit a repository's gitignore break this ignore rule on macOS.