### PR TITLE
Use allowlist instead of whitelist

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -52,7 +52,7 @@ Plugins/*/Binaries/*
 # Builds
 Build/*
 
-# Whitelist PakBlacklist-<BuildConfiguration>.txt files
+# Allowlist PakBlacklist-<BuildConfiguration>.txt files
 !Build/*/
 Build/*/**
 !Build/*/PakBlacklist*.txt

--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -37,12 +37,12 @@ wp-config.php
 
 # All plugins
 #
-# Note: If you wish to whitelist plugins,
+# Note: If you wish to allowlist plugins,
 # uncomment the next line
 #/wp-content/plugins
 
 # All themes
 #
-# Note: If you wish to whitelist themes,
+# Note: If you wish to allowlist themes,
 # uncomment the next line
 #/wp-content/themes


### PR DESCRIPTION
**Reasons for making this change:**
Update of .gitignore file for the UnrealEngine and the WordPress (Use allowlist instead of whitelist).
