### PR TITLE
Update Python.gitignore to include .vscode

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -152,9 +152,18 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# IDE Specific - Uncomment as necessary
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the enitre vscode folder
+# .vscode/


### PR DESCRIPTION
As VSCode is a widely used IDE, it is better to include it here similar to PyCharm

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Visual Studio Code is a widely used IDE now similar to PyCharm

**Links to documentation supporting these rule changes:**

NA

If this is a new template:

 - **Link to application or project’s homepage**: NA
