### PR TITLE
added .vsconfig file to ignore in Unity's .gitignore file

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -25,6 +25,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vsconfig
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

`.vsconfig` is a part of Visual Studio 2022 Installer that able to exists in Unity's project folder.

**Links to documentation supporting these rule changes:**

https://learn.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022
