### PR TITLE
KiCad: add pcb and schematic lock file patterns

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -16,6 +16,8 @@ _autosave-*
 *-save.pro
 *-save.kicad_pcb
 fp-info-cache
+~*.kicad_pcb.lck
+~*.kicad_sch.lck
 
 # Netlist files (exported from Eeschema)
 *.net


### PR DESCRIPTION
KiCad creates lock files when schematic and/or pcb is open, that should not be included in repos:

~*.kicad_pcb.lck
~*.kicad_sch.lck

These files are unfortunately not mentioned in the documentation, but are used on at least macos with KiCad v8.0.
I am not affiliated with the KiCad project, lest, only a lowly user.

https://www.kicad.org/

