### PR TITLE
Update Go.gitignore -> Added .env

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# env file
+.env


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
I use the default Go gitignore and it should have .env in it by default

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
