### PR TITLE
Add rubber cache files to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -39,6 +39,8 @@
 *.synctex.gz
 *.synctex.gz(busy)
 *.pdfsync
+*.rubbercache
+rubber.cache
 
 ## Build tool directories for auxiliary files
 # latexrun


### PR DESCRIPTION
Generated by [rubber](https://tex-talk.net/2011/12/building-documents-with-rubber/).  [The docs](https://github.com/petrhosek/rubber/blob/8ec18fd096b186901f197d26c8e1060b42f0b34f/doc/rubber.texi#L158) claim to use `rubber.cache`, but I've seen $filename.rubbercache in the wild, so I'm including both.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

_TODO_

**Links to documentation supporting these rule changes:**

_TODO_

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
