### PR TITLE
Add Ballerina.gitignore

### DIFF
--- a/Ballerina.gitignore
+++ b/Ballerina.gitignore
@@ -1,0 +1,11 @@
+# generated files
+target/
+generated/
+
+# dependencies
+Dependencies.toml
+
+# config files
+Config.toml
+# the config files used for testing, Uncomment the following line if you want to commit the test config files
+#!**/tests/Config.toml


### PR DESCRIPTION
**Reasons for making this change:**
Currently, there are no gitignore files for Ballerina language.

**Links to documentation supporting these rule changes:** 
[Learn Ballerina](https://ballerina.io/learn/)

Ballerina project directory structure contains directories named `target` and `generated`.

- `target` is used to store jars, cached files (such as jsons), docs, etc when a specific `bal` command is executed.
- `generated` directory is used to store generated `.bal` files. (Ex: store data model's client API which is generated during by `bal persist generate`)

Config.toml is used to store secrets/configurable variable values.

If this is a new template:

 - **Link to application or project’s homepage**: [Ballerina Homepage](https://ballerina.io/)
