### PR TITLE
Ignore lock info files in terraform `.gitignore`

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -23,6 +23,9 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
 # Include override files you do wish to add to version control using negated pattern
 # !example_override.tf
 


### PR DESCRIPTION
This is recommended by the official Style Guide here: https://developer.hashicorp.com/terraform/language/style#gitignore.
