### PR TITLE
Add zstd files to Archives.gitignore

### DIFF
--- a/Global/Archives.gitignore
+++ b/Global/Archives.gitignore
@@ -14,6 +14,8 @@
 *.lzma
 *.cab
 *.xar
+*.zst
+*.tzst
 
 # Packing-only formats
 *.iso


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Zstandard usage is becoming more widespread, necessitating its inclusion in `Archives.gitignore`.

**Links to documentation supporting these rule changes:**

<https://en.wikipedia.org/wiki/Tar_(computing)#Suffixes_for_compressed_files>

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
