### PR TITLE
Update UnrealEngine.gitignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -47,7 +47,7 @@ SourceArt/**/*.tga
 
 # Binary Files
 Binaries/*
-Plugins/*/Binaries/*
+Plugins/**/Binaries/*
 
 # Builds
 Build/*

--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -68,7 +68,7 @@ Saved/*
 
 # Compiled source files for the engine to use
 Intermediate/*
-Plugins/*/Intermediate/*
+Plugins/**/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*


### PR DESCRIPTION
Edited Unreal Engine gitignore to also ignore `Intermediate` data in the `Plugins` directory, so it ignores deeper nested intermediate data, like with Epic's **Game Features** plugin e.g. `Plugins/GameFeatures/MyGameFeature/Intermediate`.

**Links to documentation supporting these rule changes:**

The applied glob pattern:
https://github.com/git/git/blob/3ee1e0fe11e2eb617170d0487fccfffc67f2b82b/Documentation/glossary-content.txt#L358-L383

Unreal Engine's Game Feature plugin docs. with the required directory structure which is currently not ignored accordingly in the template:
https://dev.epicgames.com/documentation/fr-fr/unreal-engine/game-features-and-modular-gameplay-in-unreal-engine?application_version=5.3 