### PR TITLE
Added Carton's local directory

### DIFF
--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -33,3 +33,6 @@ inc/
 /MANIFEST.bak
 /pm_to_blib
 /*.zip
+
+# Carton
+local/


### PR DESCRIPTION
I am a user of Carton. Carton is a dependency manager for Perl, much like Bundler for Ruby.

Carton creates a local directory with the dependency file tree named `local/` just as for example: `node_modules`.

Carton installation documentation recommends adding this particular directory to: `.gitignore`, see: https://metacpan.org/pod/Carton#Initializing-the-environment

> echo local/ >> .gitignore

Carton is widely used for Perl development and on the same level as the other tools listed in the Perl gitignore file.