### PR TITLE
Update Python.gitignore to keep .idea in gitignore by default

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/


### PR DESCRIPTION
uncommenting .idea in line 160 python gitignore file to make it by default

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
The .idea folder (hidden on OS X) in the solution root contains IntelliJ’s project specific settings files. These include per-project details such as VCS mapping and run and debug configurations, as well as per-user details, such as currently open files, navigation history and currently selected configuration.

_TODO_

**Links to documentation supporting these rule changes:**
https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

we can see entirely dedicated gitignore for it. but for python folks selecting python as language .idea is commented by default
_TODO_

If this is a new template:
Not a new template. just updated existing
 - **Link to application or project’s homepage**: _TODO_
