### PR TITLE
Add hypdoc temporary files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -138,6 +138,9 @@ acs-*.bib
 *.trc
 *.xref
 
+# hypdoc
+*.hd
+
 # hyperref
 *.brf
 


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The `hypdoc` package is used in the documentation of most LaTeX packages. It creates a `.hd` auxiliary file upon compilation that should be ignored by Git.

**Links to documentation supporting these rule changes:**

- [Package page on CTAN](https://ctan.org/pkg/hypdoc)
- [Package documentation (pdf)](http://mirrors.ctan.org/macros/latex/contrib/hypdoc/hypdoc.pdf)
