### PR TITLE
Add `*.bbl-SAVE-ERROR` TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -26,6 +26,7 @@
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl
+*.bbl-SAVE-ERROR
 *.bcf
 *.blg
 *-blx.aux


### PR DESCRIPTION
 This PR is proposing to add `*.bbl-SAVE-ERROR` to `TeX.gitignore` for BibLaTeX.

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Recently I found that `*.bbl-SAVE-ERROR` files are generated in my LaTeX working directory, and I would like to exclude them from my git repository.

**Links to documentation supporting these rule changes:**

I do not recall when such files first appeared, but they appear in my working directory.

If this is a new template:

 - **Link to application or project’s homepage**: Not a new template.
