### PR TITLE
Add RustRover entry for Rust.gitignore

### DIFF
--- a/Rust.gitignore
+++ b/Rust.gitignore
@@ -12,3 +12,10 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# RustRover
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/


### PR DESCRIPTION


**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Add an optional entry for JetBrains's RustRover IDE in Rust.gitignore.

**Links to documentation supporting these rule changes:**

None

If this is a new template:

 - **Link to application or project’s homepage**: None
