### PR TITLE
[Xcode, Objective-C, Swift] Remove legacy Xcode compatibility

### DIFF
--- a/Global/Xcode.gitignore
+++ b/Global/Xcode.gitignore
@@ -1,6 +1,2 @@
 ## User settings
 xcuserdata/
-
-## Xcode 8 and earlier
-*.xcscmblueprint
-*.xccheckout

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -9,19 +9,6 @@ xcuserdata/
 *.xcscmblueprint
 *.xccheckout
 
-## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
-build/
-DerivedData/
-*.moved-aside
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-
 ## Obj-C/Swift specific
 *.hmap
 

--- a/Objective-C.gitignore
+++ b/Objective-C.gitignore
@@ -5,10 +5,6 @@
 ## User settings
 xcuserdata/
 
-## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
-*.xcscmblueprint
-*.xccheckout
-
 ## Obj-C/Swift specific
 *.hmap
 

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -9,19 +9,6 @@ xcuserdata/
 *.xcscmblueprint
 *.xccheckout
 
-## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
-build/
-DerivedData/
-*.moved-aside
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-
 ## Obj-C/Swift specific
 *.hmap
 

--- a/Swift.gitignore
+++ b/Swift.gitignore
@@ -5,10 +5,6 @@
 ## User settings
 xcuserdata/
 
-## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
-*.xcscmblueprint
-*.xccheckout
-
 ## Obj-C/Swift specific
 *.hmap
 


### PR DESCRIPTION
This is a rebase of https://github.com/github/gitignore/pull/2860. Check it for earlier discussion and approvals.

- ebee5bfe87a2799d26d346798f7364eb0dccdcaf is a cleanup of Xcode 3 compatibility in `ObjectiveC` and `Swift` templates (already merged in https://github.com/github/gitignore/pull/3935 for `Xcode`)
  - related code is unnecessary since ~2011
- a4043487860cd48d0bdb54aa41e21dbd7fc91afc is a cleanup of Xcode 8 compatibility in `Xcode`, `ObjectiveC` and `Swift` templates
  - related code is unnecessary since ~2017

**Links to documentation supporting these rule changes:**

> Please note that as of April 2024 all iOS and iPadOS apps submitted to the App Store must be built with a minimum of Xcode 15 and the iOS 17 SDK.
(https://developer.apple.com/ios/submit/)

Also see https://stackoverflow.com/a/53039267
