### PR TITLE
Ignore terragrunt cache

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -32,7 +32,3 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
-
-# Ignore the default terragrunt cache directory
-# https://terragrunt.gruntwork.io/docs/features/caching/
-.terragrunt-cache

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -32,3 +32,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore the default terragrunt cache directory
+# https://terragrunt.gruntwork.io/docs/features/caching/
+.terragrunt-cache

--- a/community/Terragrunt.gitignore
+++ b/community/Terragrunt.gitignore
@@ -1,0 +1,3 @@
+# Ignore the default terragrunt cache directory
+# https://terragrunt.gruntwork.io/docs/features/caching/
+.terragrunt-cache


### PR DESCRIPTION
This excludes the common/default cache location from source control

**Reasons for making this change:**

Terragrunt is a convenient tool used when using terraform. The cache directory is not needed in source control; as per the docs, it can be safely deleted as it will be re-created automatically when needed.

**Links to documentation supporting these rule changes:**

Here is a sample .gitignore from the terragrunt project itself:
https://github.com/gruntwork-io/terragrunt/blob/master/.gitignore

Reference docs about the cache directory:
https://terragrunt.gruntwork.io/docs/features/caching/