### PR TITLE
Add build/  to  CMake.gitignore

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -9,3 +9,4 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+build/


### PR DESCRIPTION
I added `build/` to `CMake.gitignore` because some people will put the excutable files(and also the makefile created by CMake)
in the `build/` directory.
