### PR TITLE
Update Terraform.gitignore to ignore .hcl file to be committed

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore hcl file
+*.hcl


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Making this change to ignore .terraform.lock.hcl which is an internal file generated by terraform and not needed in our remote repos as they are automatically generated on each terraform init runs
![image](https://github.com/github/gitignore/assets/108367225/051afa3a-5d61-4e46-899d-039262ec34a0)

_TODO_

**Links to documentation supporting these rule changes:**
NA
_TODO_

If this is a new template:
existing template, just modified.

 - **Link to application or project’s homepage**: _TODO_
 NA
