### PR TITLE
Create ReScript.gitignore

### DIFF
--- a/ReScript.gitignore
+++ b/ReScript.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/node_modules/
+/lib/
+.bsb.lock

--- a/ReScript.gitignore
+++ b/ReScript.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
 /node_modules/
 /lib/
 .bsb.lock


### PR DESCRIPTION
**Reasons for making this change:**
There is a lack of support for the [ReScript programming language](https://rescript-lang.org/).

**Links to documentation supporting these rule changes:**

There was a [discussion](https://forum.rescript-lang.org/t/what-would-belong-in-a-gitignore-template-for-rescript/5263) about what to include in the file. What is being proposed matches what a [new project](https://rescript-lang.org/docs/manual/latest/installation#new-project) sets in its `.gitignore` file.

If this is a new template:

 - **Link to application or project’s homepage**: https://rescript-lang.org/
