### PR TITLE
Update Terraform.gitignore to ignore .hcl files based on pr #4447

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -35,3 +35,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore hcl file
+.terraform.lock.hcl


### PR DESCRIPTION
Reasons for making this change:

Making this change to ignore .terraform.lock.hcl which is an internal file generated by terraform and not needed in our remote repos as they are automatically generated on each terraform init runs

![image](https://github.com/github/gitignore/assets/108367225/59c813af-0d9c-493a-a8f7-b40b4df03f0b)

**The new chnages are added to this PR which was discussed on https://github.com/github/gitignore/pull/4447**

TODO

Links to documentation supporting these rule changes:
NA
TODO

If this is a new template:
existing template, just modified.

Link to application or project’s homepage: TODO
NA
