### PR TITLE
Update Windows.gitignore

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -22,3 +22,7 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# When copying a downloaded file from Windows >= 10 to WSL, a `<FILE-NAME>:Zone.Identifier` file is generated on certain configurations.
+# See this issue for details: https://github.com/microsoft/WSL/issues/7456
+*.Identifier


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

When copying a downloaded file from Windows >= 10 to WSL directory, a `<FILE-NAME>:Zone.Identifier` file is generated on certain configurations. Upon closer inspection, I've found that this is actually a policy that can be changed (see [here](https://github.com/microsoft/WSL/issues/7456#issuecomment-1172877312)). However, on certain corporate setups, one cannot simply change this feature due to being enrolled in AD. Because of this, 100% of the git repos from my company has this file added in gitignore.


**Links to documentation supporting these rule changes:**

- https://github.com/microsoft/WSL/issues/7456 (from 2021)
- https://github.com/microsoft/WSL/issues/4609 (from 2019)

