### PR TITLE
Revert #4451

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -35,6 +35,3 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
-
-# Ignore hcl file
-.terraform.lock.hcl


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

As discussed in https://github.com/github/gitignore/pull/4451, the Terraform lock file should be committed to version control.

**Links to documentation supporting these rule changes:**

https://developer.hashicorp.com/terraform/language/files/dependency-lock
https://developer.hashicorp.com/terraform/language/style#gitignore