### PR TITLE
Update Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# PyPI configuration file
+.pypirc


### PR DESCRIPTION
Add .pypirc to protect sensitive information

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->
Adding .pypirc to the .gitignore file to ensure that sensitive information such as PyPI credentials are not included in the repository.

**Links to documentation supporting these rule changes:**
- https://packaging.python.org/guides/using-testpypi/#pypirc

