### PR TITLE
Create nextjs.gitignore

### DIFF
--- a/community/JavaScript/nextjs.gitignore
+++ b/community/JavaScript/nextjs.gitignore
@@ -1,0 +1,37 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# turborepo builds files
+.turbo


### PR DESCRIPTION
**Reasons for making this change:**

Create gitignore template for Next.js Framework

### Links to documentation supporting these rule changes

https://nextjs.org/docs/getting-started/project-structure

### Link to application or project’s homepage

https://github.com/vercel/next.js/tree/canary/examples/with-typescript)
