### PR TITLE
Update KiCad.gitignore

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -8,10 +8,13 @@
 *.kicad_pcb-bak
 *.kicad_sch-bak
 *-backups
-*.kicad_prl
-*.sch-bak
+*-cache*
+*-bak
+*-bak*
 *~
+~*
 _autosave-*
+\#auto_saved_files\#
 *.tmp
 *-save.pro
 *-save.kicad_pcb
@@ -33,4 +36,5 @@ fp-info-cache
 # Archived Backups (KiCad 6.0)
 **/*-backups/*.zip
 
-\#auto_saved_files\#
+# Local project settings
+*.kicad_prl


### PR DESCRIPTION
**Reasons for making this change:**
When using KiCad with git/GitHub, I always use a modified version of the official `KiCad.gitignore` file with these changes applied. New KiCad versions have changed the way backups and autosaves are performed, and this PR hopes to reflect those changes in this repository.

Enumerated list of changes:
1. Add `*-cache*`
2. Generalize `*.sch-bak` to `*-bak` and `*-bak*`
3. Add `~*`
4. Add `#auto_saved_files#`

**Links to documentation supporting these rule changes:**
- **1, 2, 4**: [TechOverflow](https://techoverflow.net/2020/06/13/what-gitignore-to-use-for-kicad-projects/) notes the KiCad-generated gitignore. Changes 1, 2, and 4 make this repo's file more consistent with the KiCad recommendation.
- **3**: [Reddit](https://www.reddit.com/r/KiCad/comments/1coyhjr/question_about_lck_files_generated_in_kicad_801/) notes the introduction of lock files in KiCad v8.

Another Credit: https://github.com/github/gitignore/pull/4176#issuecomment-1379664803 for one of this PR's changes.