### PR TITLE
Updated to KiCAD v8

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -2,28 +2,20 @@
 # Format documentation: https://kicad.org/help/file-formats/
 
 # Temporary files
-*.000
 *.bak
-*.bck
-*.kicad_pcb-bak
-*.kicad_sch-bak
 *-backups
 *.kicad_prl
-*.sch-bak
-*~
-_autosave-*
-*.tmp
-*-save.pro
-*-save.kicad_pcb
 fp-info-cache
+\#auto_saved_files#
 
-# Netlist files (exported from Eeschema)
-*.net
+# Lock Files
+*.kicad_sch.lck
+*.kicad_pcb.lck
 
 # Autorouter files (exported from Pcbnew)
-*.dsn
-*.ses
+# *.dsn
+# *.ses
 
-# Exported BOM files
-*.xml
-*.csv
+# Exported BOM files (Optional)
+# *.xml
+# *.csv

--- a/community/KiCAD5.gitignore
+++ b/community/KiCAD5.gitignore
@@ -1,0 +1,29 @@
+# For PCBs designed using KiCad: https://www.kicad.org/
+# Format documentation: https://kicad.org/help/file-formats/
+
+# Temporary files
+*.000
+*.bak
+*.bck
+*.kicad_pcb-bak
+*.kicad_sch-bak
+*-backups
+*.kicad_prl
+*.sch-bak
+*~
+_autosave-*
+*.tmp
+*-save.pro
+*-save.kicad_pcb
+fp-info-cache
+
+# Netlist files (exported from Eeschema)
+*.net
+
+# Autorouter files (exported from Pcbnew)
+*.dsn
+*.ses
+
+# Exported BOM files
+*.xml
+*.csv


### PR DESCRIPTION
**Reasons for making this change:**
I'm a KiCAD user, and the gitignore that keeps popping up as the first google hit is 3-4 major versions old.  And many of the temporary and lock files have changed namings.  
