### PR TITLE
Add mise.gitignore

### DIFF
--- a/Global/mise.gitignore
+++ b/Global/mise.gitignore
@@ -1,0 +1,13 @@
+# https://mise.jdx.dev/profiles.html#profiles
+/.config/mise/config.local.toml
+/.config/mise/config.*.local.toml
+/.mise.local.toml
+/.mise.*.local.toml
+/.mise/config.local.toml
+/.mise/config.*.local.toml
+/mise.local.toml
+/mise/config.local.toml
+/mise/config.*.local.toml
+
+# https://mise.jdx.dev/configuration.html#tool-versions
+#/.tool-versions


### PR DESCRIPTION


**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I'm a mise user. Local mise configs should not be checked into git.

The upstream project spells "mise" consistently in lowercase, therefore I opted to add the file in all lowercase, too.

**Links to documentation supporting these rule changes:**

See comments in the added .gitignore

If this is a new template:

 - **Link to application or project’s homepage**: https://mise.jdx.dev/
