### PR TITLE
Add Lefthook.gitignore

### DIFF
--- a/Global/Lefthook.gitignore
+++ b/Global/Lefthook.gitignore
@@ -1,0 +1,12 @@
+# https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md#config-file
+/.lefthook-local.json
+/.lefthook-local.toml
+/.lefthook-local.yaml
+/.lefthook-local.yml
+/lefthook-local.json
+/lefthook-local.toml
+/lefthook-local.yaml
+/lefthook-local.yml
+
+# https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md#source_dir_local
+/.lefthook-local/

--- a/Global/Lefthook.gitignore
+++ b/Global/Lefthook.gitignore
@@ -1,4 +1,4 @@
-# https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md#config-file
+# https://lefthook.dev/configuration/#config-file-name
 /.lefthook-local.json
 /.lefthook-local.toml
 /.lefthook-local.yaml
@@ -7,6 +7,10 @@
 /lefthook-local.toml
 /lefthook-local.yaml
 /lefthook-local.yml
+/.config/lefthook-local.json
+/.config/lefthook-local.toml
+/.config/lefthook-local.yaml
+/.config/lefthook-local.yml
 
-# https://github.com/evilmartians/lefthook/blob/master/docs/configuration.md#source_dir_local
+# https://lefthook.dev/configuration/source_dir_local.html
 /.lefthook-local/


### PR DESCRIPTION

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I'm a lefthook user. Lefthook supports local config overrides that should not be checked into git.

**Links to documentation supporting these rule changes:**

See links in the comments of the added gitignore.

If this is a new template:

 - **Link to application or project’s homepage**: https://lefthook.dev
