### PR TITLE
feat(Julia): ignore all Manifest files

### DIFF
--- a/Julia.gitignore
+++ b/Julia.gitignore
@@ -21,4 +21,4 @@ docs/site/
 # It records a fixed state of all packages used by the project. As such, it should not be
 # committed for packages, but should be committed for applications that require a static
 # environment.
-Manifest.toml
+Manifest*.toml


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

End user of the Julia programming language.
The next minor version Julia 1.11 will support Manifest files which are version specific.
To ignore all possible files, match them with an astrerisk `*`.

**Links to documentation supporting these rule changes:**

[NEWS.md](https://github.com/JuliaLang/julia/blob/v1.11.0-beta2/NEWS.md),
under `New language features`:
> `Manifest.toml` files can now be renamed in the format `Manifest-v{major}.{minor}.toml` to be preferentially picked up by the given julia version. i.e. in the same folder, a `Manifest-v1.11.toml` would be used by v1.11 and `Manifest.toml` by every other julia version. This makes managing environments for multiple julia versions at the same time easier.

If this is a new template:

 - **Link to application or project’s homepage**: [julialang.org](https://julialang.org/)
