### PR TITLE
add pixi configure in python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -111,6 +111,12 @@ ipython_config.py
 .pdm-python
 .pdm-build/
 
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 


### PR DESCRIPTION
**Reasons for making this change:**

[pixi](https://github.com/prefix-dev/pixi) is package manager.
I want to append pixi support for this project.
This appendix is almost same as previous ones, pyenv, pipenv(#2977) pdm(##3976), poetry(#3853).

I append two lines.
First one is for `pixi.lock`. It just follows precedent cases(pipenv, poetry, pdm).
I don't think there is any problem to append this line.

Second one is for `.pixi`.
 `pixi` create `.pixi` directory, just like Python's venv module creates one in the .venv directory. It is recommended not to include this directory in version control in pixi system.

### More detail of `.pixi`
This change doesn't cause any trouble.
When initialize pixi project (by `pixi init` command), pixi automatically add the .pixi directory to user's .gitignore file. ([If already exist ".pixi" in user's .gitignore, pixi doesn't change anything.](https://github.com/prefix-dev/pixi/blob/4653639f930621f55f8e2a5c3455f563bc900501/src/cli/init.rs#L468-L471))
But user may use this project's template after initialized pixi.
So appending '.pixi' in this project's template is reasonable.

 - **Links to documentation supporting these rule changes:**
https://prefix.dev/docs/pixi/cli#init

 - **Link to application or project’s homepage**: https://pixi.sh/latest/

