### PR TITLE
Add VizTracer report to Python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VizTracer report
+result.json


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

VizTracer is a logging/debugging/profiling tool for Python. A `result.json` file will be generated as a report when using VizTracer to trace python code execution.

**Links to documentation supporting these rule changes:**

https://viztracer.readthedocs.io/en/latest/basic_usage.html#basic-usage

If this is a new template:

 - **Link to application or project’s homepage**: https://github.com/gaogaotiantian/viztracer
