### PR TITLE
Update Node.gitignore for Vim

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Vim files added unintentionally
+*.swp


### PR DESCRIPTION
Vim can create *.swp binary files that should be temporary. They should be pruned preferably.