### PR TITLE
Update Python.gitignore for ruff linter default cache directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Ruff
+.ruff_cache/


### PR DESCRIPTION
Added exclusion for ruff linter default cache folder. The .ruff_cache folder is created when you execute `ruff check` without specifying a cache dir

Documentation for the cache-dir default creation. https://docs.astral.sh/ruff/settings/#cache-dir
