### PR TITLE
Nix.gitignore: direnv

### DIFF
--- a/community/Nix.gitignore
+++ b/community/Nix.gitignore
@@ -1,3 +1,6 @@
 # Ignore build outputs from performing a nix-build or `nix build` command
 result
 result-*
+
+# Ignore direnv folder
+.direnv/


### PR DESCRIPTION
Ignore a direnv folder inside a nix-based repository.

**Reasons for making this change:**

Nix (especially flakes) are often used in conjunction with direnv or https://github.com/nix-community/nix-direnv
