### PR TITLE
Create VBA.gitignore

### DIFF
--- a/VBA.gitignore
+++ b/VBA.gitignore
@@ -1,3 +1,6 @@
+# Hidden metadata files created by macOS (Desktop Services Store)
+.DS_Store
+
 # Office temporary files
 ~$*
 

--- a/VBA.gitignore
+++ b/VBA.gitignore
@@ -1,0 +1,34 @@
+# Office temporary files
+~$*
+
+# The following sections constitute a list of Office file extensions that support VBA.
+# If you want to exclude Office files from your repo, uncomment the corresponding file extensions.
+
+# Excel (xls, xlsb, xlsm, xlt, xltm, xla, xlam)
+#*.[xX][lL][sS]
+#*.[xX][lL][sS][bB]
+#*.[xX][lL][sS][mM]
+#*.[xX][lL][tT]
+#*.[xX][lL][tT][mM]
+#*.[xX][lL][aA]
+#*.[xX][lL][aA][mM]
+
+# Word (doc, docm, dot, dotm)
+#*.[dD][oO][cC]
+#*.[dD][oO][cC][mM]
+#*.[dD][oO][tT]
+#*.[dD][oO][tT][mM]
+
+# Access (accdb, accde, mdb, mde)
+#*.[aA][cC][cC][dD][bB]
+#*.[aA][cC][cC][dD][eE]
+#*.[mM][dD][bB]
+#*.[mM][dD][eE]
+
+# PowerPoint (ppt, pptm, pot, potm, pps, ppsm)
+#*.[pP][pP][tT]
+#*.[pP][pP][tT][mM]
+#*.[pP][oO][tT]
+#*.[pP][oO][tT][mM]
+#*.[pP][pP][sS]
+#*.[pP][pP][sS][mM]

--- a/VBA.gitignore
+++ b/VBA.gitignore
@@ -1,9 +1,9 @@
 # Office temporary files
 ~$*
 
-# Access database lock files
-*.laccdb
-*.ldb
+# Access database lock files (laccdb, ldb)
+*.[lL][aA][cC][cC][dD][bB]
+*.[lL][dD][bB]
 
 # The following sections constitute a list of Office file extensions that support VBA.
 # If you want to exclude Office files from your repo, uncomment the corresponding file extensions.

--- a/VBA.gitignore
+++ b/VBA.gitignore
@@ -1,6 +1,10 @@
 # Office temporary files
 ~$*
 
+# Access database lock files
+*.laccdb
+*.ldb
+
 # The following sections constitute a list of Office file extensions that support VBA.
 # If you want to exclude Office files from your repo, uncomment the corresponding file extensions.
 
@@ -19,7 +23,8 @@
 #*.[dD][oO][tT]
 #*.[dD][oO][tT][mM]
 
-# Access (accdb, accde, mdb, mde)
+# Access (accda, accdb, accde, mdb, mde)
+#*.[aA][cC][cC][dD][aA]
 #*.[aA][cC][cC][dD][bB]
 #*.[aA][cC][cC][dD][eE]
 #*.[mM][dD][bB]

--- a/VBA.gitignore
+++ b/VBA.gitignore
@@ -1,5 +1,3 @@
-# Hidden metadata files created by macOS (Desktop Services Store)
-.DS_Store
 
 # Office temporary files
 ~$*


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Adding a gitignore template for VBA projects.

**Links to documentation supporting these rule changes:**

* [Office temporary files](https://support.microsoft.com/en-us/topic/description-of-how-word-creates-temporary-files-66b112fb-d2c0-8f40-a0be-70a367cc4c85) (see owner file section)
* [Office file formats](https://learn.microsoft.com/en-us/deployoffice/compat/office-file-format-reference)

If this is a new template:

 - **Link to application or project’s homepage**: [Getting started with VBA in Office | Microsoft Learn](https://learn.microsoft.com/en-us/office/vba/library-reference/concepts/getting-started-with-vba-in-office)