### PR TITLE
Add IDE-specific rules to node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -122,13 +122,36 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# IDEs and editors
+.vscode/
+.history/
+.idea/
+*.iml
+.project
+.classpath
+.settings/
+nbproject/
+*.xcworkspace
+*.xcuserstate
+*.xccheckout
+*.xcodeproj
+.gradle/
+local.properties
+*.sublime-project
+*.sublime-workspace
+*.swp
+*.swo
+.atom/
+*.sln.iml
+*.pidb
+*.userprefs
+cmake-build-*/
+.DS_Store
+Thumbs.db
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-
-# IDE
-.idea/
-.vs/

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -123,31 +123,31 @@ dist
 .vscode-test
 
 # IDEs and editors
-.vscode/
-.history/
-.idea/
-*.iml
-.project
-.classpath
-.settings/
-nbproject/
-*.xcworkspace
-*.xcuserstate
-*.xccheckout
-*.xcodeproj
-.gradle/
-local.properties
-*.sublime-project
-*.sublime-workspace
-*.swp
-*.swo
-.atom/
-*.sln.iml
-*.pidb
-*.userprefs
-cmake-build-*/
-.DS_Store
-Thumbs.db
+# .vscode/
+# .history/
+# .idea/
+# *.iml
+# .project
+# .classpath
+# .settings/
+# nbproject/
+# *.xcworkspace
+# *.xcuserstate
+# *.xccheckout
+# *.xcodeproj
+# .gradle/
+# local.properties
+# *.sublime-project
+# *.sublime-workspace
+# *.swp
+# *.swo
+# .atom/
+# *.sln.iml
+# *.pidb
+# *.userprefs
+# cmake-build-*/
+# .DS_Store
+# Thumbs.db
 
 # yarn v2
 .yarn/cache

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -128,3 +128,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# IDE
+.idea/
+.vs/


### PR DESCRIPTION
**Reasons for making this change:**
By adding specific rules to ignore these files in the .gitignore file, we can maintain a cleaner repository and avoid accidental commits of unnecessary files.

_TODO_

[link of my repo I use this new template](https://github.com/QuentinBerhet/node_chatApp)
