### PR TITLE
Update Gradle.gitignore

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -14,6 +14,9 @@ gradle-app.setting
 # Cache of project
 .gradletasknamecache
 
+# Kotlin compilation data
+.kotlin
+
 # Eclipse Gradle plugin generated files
 # Eclipse Core
 .project


### PR DESCRIPTION
**Reasons for making this change:**
Kotlin 2.0 added a new data directory called `.kotlin` for Gradle projects. I am not sure whether this should be in the Kotlin or the Gradle template as it's only for Gradle projects and the Kotlin template is a symlink to Java

**Links to documentation supporting these rule changes:**

https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects

