### PR TITLE
Create Hexo.gitignore

### DIFF
--- a/community/Hexo.gitignore
+++ b/community/Hexo.gitignore
@@ -2,16 +2,13 @@
 # website: https://hexo.io/
 # Recommended: Node.gitignore
 
-# Ignore generated files and directories
-.tmp*
+# Ignore generated directory
 public/
 
-# Ignore temp files and lock files
+# Ignore temp files
 tmp/
-yarn.lock
-package-lock.json
-pnpm-lock.yaml
+.tmp*
 
-# Add any additional patterns here
+# additional files
 db.json
 .deploy*/

--- a/community/Hexo.gitignore
+++ b/community/Hexo.gitignore
@@ -1,24 +1,18 @@
 # gitignore template for Hexo sites
+# website: https://hexo.io/
+# Recommended: Node.gitignore
+
 # Ignore generated files and directories
-.DS_Store
 .tmp*
 dist/
 public/
 coverage/
 
-# Ignore dependencies and lock files
-node_modules/
+# Ignore temp files and lock files
 tmp/
 yarn.lock
 package-lock.json
 pnpm-lock.yaml
-
-# Ignore IDE specific files and directories
-.idea/
-.vscode
-
-# Ignore code coverage output
-.nyc_output/
 
 # Add any additional patterns here
 db.json

--- a/community/Hexo.gitignore
+++ b/community/Hexo.gitignore
@@ -1,0 +1,22 @@
+# gitignore template for Hexo sites
+# Ignore generated files and directories
+.DS_Store
+.tmp*
+dist/
+coverage/
+
+# Ignore dependencies and lock files
+node_modules/
+tmp/
+yarn.lock
+package-lock.json
+pnpm-lock.yaml
+
+# Ignore IDE specific files and directories
+.idea/
+.vscode
+
+# Ignore code coverage output
+.nyc_output/
+
+# Add any additional patterns here

--- a/community/Hexo.gitignore
+++ b/community/Hexo.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .tmp*
 dist/
+public/
 coverage/
 
 # Ignore dependencies and lock files
@@ -20,3 +21,5 @@ pnpm-lock.yaml
 .nyc_output/
 
 # Add any additional patterns here
+db.json
+.deploy_git/

--- a/community/Hexo.gitignore
+++ b/community/Hexo.gitignore
@@ -4,9 +4,7 @@
 
 # Ignore generated files and directories
 .tmp*
-dist/
 public/
-coverage/
 
 # Ignore temp files and lock files
 tmp/
@@ -16,4 +14,4 @@ pnpm-lock.yaml
 
 # Add any additional patterns here
 db.json
-.deploy_git/
+.deploy*/


### PR DESCRIPTION
**Reasons for making this change:**
Add .gitignore file for the popular static site generator Hexo.

**Links to documentation supporting these rule changes:**
[.gitignore at Hexo example](https://github.com/hexojs/hexo-starter/blob/master/.gitignore)
[.gitignore at hexo/site](https://github.com/hexojs/site/blob/master/.gitignore)

If this is a new template: 

 - **Link to application or project’s homepage**: [Hexo](https://hexo.io/)
