### PR TITLE
Ignore lock file in KiCad

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -27,3 +27,6 @@ fp-info-cache
 # Exported BOM files
 *.xml
 *.csv
+
+# Lock file
+*.lck


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Ignore all lock files. These are only used when one of the editors are opened and are deleted when closed.

**Links to documentation supporting these rule changes:**

Doxygen link - https://docs.kicad.org/doxygen/lockfile_8h.html
