### PR TITLE
Exclude Directory.Build.rsp from VisualStudio.gitignore template

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -82,6 +82,8 @@ StyleCopReport.xml
 *.pgc
 *.pgd
 *.rsp
+# but not Directory.Build.rsp, as it configures directory-level build defaults
+!Directory.Build.rsp
 *.sbr
 *.tlb
 *.tli


### PR DESCRIPTION
**Reasons for making this change:**

`Directory.Build.rsp` is a documented file that allows setting default arguments to command line builds. However, the .gitignore template ignores _all_ `*.rsp` files. which causes confusion:

1. Devs write an .rsp file and if they aren't being attentive forget to commit it
2. Adding it to git requires `git add --force`, which some devs mistake for a destructive or not-recommended action

Thus, explicitly allow the `Directory.Build.rsp` file.

**Links to documentation supporting these rule changes:**

- https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-response-files?view=vs-2022#directorybuildrsp