### PR TITLE
Add C++ properties file to Visual Studio gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -32,13 +32,14 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
-# Visual Studio 2015/2017 cache/options directory
+# Visual Studio cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
-# Visual Studio 2017 auto generated files
+# Visual Studio auto generated files
 Generated\ Files/
+CppProperties.json
 
 # MSTest test Results
 [Tt]est[Rr]esult*/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

This file is autogenerated based on the project solution and per-user IntelliSense settings, and probably shouldn't be committed to a repository.

Also removed specific versioning in comments because they apply broadly to any recent VS version.

**Links to documentation supporting these rule changes:**

https://learn.microsoft.com/en-us/cpp/build/cppproperties-schema-reference

https://learn.microsoft.com/en-us/visualstudio/extensibility/workspaces#workspace-settings