### PR TITLE
Added gitignore for Perl's Carton to Global

### DIFF
--- a/Global/Carton.gitignore
+++ b/Global/Carton.gitignore
@@ -1,0 +1,2 @@
+## Local directort of Perl modules for Carton
+local/


### PR DESCRIPTION
I am a user of [Carton](https://metacpan.org/pod/Carton). Carton is a dependency manager for Perl, much like Bundler for Ruby.

Carton creates a local directory with the dependency file tree named local/ just as for example: node_modules.

Carton installation documentation recommends adding this particular directory to: .gitignore, see: https://metacpan.org/pod/Carton#Initializing-the-environment

```
echo local/ >> .gitignore
```

Carton is widely used for Perl development and on the same level as the other tools listed in the Perl gitignore file, but as requested in my PR (#4437) this belongs in `Global/`, so here is a PR accommodating to this.
