### PR TITLE
Handle source folders inside subprojects in Gradle.gitignore

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,6 +1,6 @@
 .gradle
 **/build/
-!src/**/build/
+!**/src/**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
**Reasons for making this change:**

Subprojects, traditionally in a Gradle project, can also have a build directory inside the default source set directory. 

**Links to documentation supporting these rule changes:**

https://docs.gradle.org/current/userguide/multi_project_builds.html