### PR TITLE
chore: change `zig-cache/` to `.zig-cache/`

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/


### PR DESCRIPTION
[Zig](https://github.com/ziglang/zig), as a growing and popular programming language, has gained a significant following. To enable the community to use Zig, having a `.gitignore` available would be great.

The directories to be ignored are `.zig-cache/` and `zig-out/`, with the recent update (Zig 0.13.0) changing `.zig-cache/` from its previous name (`zig-cache/`).

**Links to documentation supporting these rule changes:**

- [Zig GitHub Repository](https://github.com/ziglang/zig)
- [Zig Programming Language Homepage](https://ziglang.org/)