### PR TITLE
Updated UnrealEngine.gitignore with common IDE cache/user files

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -1,6 +1,14 @@
 # Visual Studio 2015 user specific files
 .vs/
 
+# JetBrain Rider (and other common IDEs) Generated Cache
+.idea
+
+# Common IDE Local User files
+*.csproj
+*.sln.DotSettings
+*.sln.DotSettings.user
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
**Reasons for making this change:**
Unreal Engine supports a variety of IDEs for it's development. The current gitignore includes common Visual Studio files in the gitignore, the file doesn't include arguably the second most common choice for development i.e. [JetBrains Rider](https://www.jetbrains.com/lp/rider-unreal/). 


