### PR TITLE
Add CMake's TryRunResults.cmake

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -10,3 +10,4 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
+TryRunResults.cmake


### PR DESCRIPTION
**Reasons for making this change:**

This file is generated when cmake is in cross-compilation mode and try_run or check_source_runs are used in CMake code without setting cache variables before so the user is aware what needs to be adjusted for the target system.

**Links to documentation supporting these rule changes:**

https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING_EMULATOR.html

