### PR TITLE
Update Cake comment line to match other comment lines

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -328,8 +328,8 @@ __pycache__/
 *.pyc
 
 # Cake - Uncomment if you are using it
-# tools/**
-# !tools/packages.config
+#tools/**
+#!tools/packages.config
 
 # Tabs Studio
 *.tss


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I was looking at the `.gitignore` for a .NET project when I noticed that the "uncomment these" lines for Cake had an extra space in comparison to that of other tools and exclusion recommendations. This change is hardly anything but nevertheless it's something I noticed 😁

**Links to documentation supporting these rule changes:**

_This is not a major change and so does not require docs, just something I noticed_ 😅
