### PR TITLE
Add generated libtool file and .libs/ directories

### DIFF
--- a/Autotools.gitignore
+++ b/Autotools.gitignore
@@ -31,7 +31,9 @@ autom4te.cache
 
 # https://www.gnu.org/software/libtool/
 
+/libtool
 /ltmain.sh
+.libs/
 
 # http://www.gnu.org/software/texinfo
 


### PR DESCRIPTION
* libtool is a generated script. See https://www.sourceware.org/autobook/autobook/autobook_49.html ("You must then arrange for your project build process to create an instance of libtool on the user’s machine [...]"). Also documented in the generated script itself ("Generated automatically by config.status [...] NOTE: Changes made to this file will be lost: look at ltmain.sh")

* .libs/ directories are created by libtool; see https://www.gnu.org/software/libtool/manual/libtool.html ("Note that Libtool automatically created .libs directory upon its first execution, where PIC library object files will be stored.")
