### PR TITLE
Fix broken links to Git book

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the following resources are a great place to start:
 
 [man]: http://git-scm.com/docs/gitignore
 [help]: https://help.github.com/articles/ignoring-files
-[chapter]: https://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
+[chapter]: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
 [progit]: http://git-scm.com/book
 
 ## Folder structure

--- a/community/Alteryx.gitignore
+++ b/community/Alteryx.gitignore
@@ -29,7 +29,7 @@ CASS.ini
 *.gzlc
 
 ## gitignore reference sites
-# https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#Ignoring-Files
+# https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
 # https://git-scm.com/docs/gitignore
 # https://help.github.com/articles/ignoring-files/
 


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I found that one of the links to the Git book was broken. I wanted to fix it.

**Links to documentation supporting these rule changes:**

Old link was broken: https://git-scm.com/book/en/Git-Basics-Recording-Changes-to-the-Repository#_ignoring

New link is working: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring

If this is a new template:

 - **Link to application or project’s homepage**: None
