### PR TITLE
Add __marimo__/cache/ to Python .gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -80,7 +80,8 @@ target/
 
 # marimo notebook
 #   marimo maintains a cache of binary data in __marimo__/cache/
-__marimo__/cache/
+#   in directories containing notebooks.
+**/__marimo__/cache/
 
 # IPython
 profile_default/

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -78,6 +78,10 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# marimo notebook
+#   marimo maintains a cache of binary data in __marimo__/cache/
+__marimo__/cache/
+
 # IPython
 profile_default/
 ipython_config.py


### PR DESCRIPTION
**Reasons for making this change:**

The [marimo Python notebook](https://github.com/marimo-team/marimo) maintains a cache of binary data in `__marimo__/cache/`, and it recommends all users add this directory to their `.gitignore`, since this data cannot be meaningfully versioned. 

I am one of the core maintainers of marimo, I would like to make it automatic for our users who use GitHub to have `.gitignore` that works well with `marimo`.

**Links to documentation supporting these rule changes:** https://docs.marimo.io/api/caching.html#caching-variables-to-disk