### PR TITLE
add libogc.gitignore (wii homebrew development)

### DIFF
--- a/community/libogc.gitignore
+++ b/community/libogc.gitignore
@@ -1,0 +1,40 @@
+# Ignore build directories and files
+build/
+*.dol
+*.elf
+
+# Ignore Wii-specific metadata files
+meta.xml
+icon.png
+
+# Ignore temporary files created by compilers
+*.o
+*.bin
+*.map
+
+# Ignore editor or IDE-specific files
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+
+# Ignore backup or temporary files
+*~
+*.bak
+*.swp
+*.tmp
+
+# Ignore log files
+*.log
+
+# Ignore libraries and dependencies
+lib/
+deps/
+obj/
+  
+# Ignore operating system-specific files
+$RECYCLE.BIN/
+.Trash-1000/
+.Spotlight-V100/
+.fseventsd/
+.DS_Store

--- a/community/libogc.gitignore
+++ b/community/libogc.gitignore
@@ -1,16 +1,10 @@
-# Ignore build directories and files
+# Ignore build directories
 build/
-*.dol
-*.elf
 
 # Ignore Wii-specific metadata files
 meta.xml
 icon.png
 
-# Ignore temporary files created by compilers
-*.o
-*.bin
-*.map
 
 # Ignore editor or IDE-specific files
 .vscode/
@@ -38,3 +32,60 @@ $RECYCLE.BIN/
 .Spotlight-V100/
 .fseventsd/
 .DS_Store
+
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+*.o
+*.bin
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+*.dol
+*.elf
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf


### PR DESCRIPTION
**Reasons for making this change:**
as a dev who recently worked with libogc on wii projects, i’ve noticed that the existing .gitignore file for plain C is minimal and does not account for several common temporary system files generated during the build process, nor the compiled executable for the Wii. By creating a brand new .gitignore file just for libogc, this issue can be fixed. And wii homebrew development is not common, so it's in the community directory. that's all

**Links to documentation supporting these rule changes:**
https://wiibrew.org/wiki/DevkitPPC
https://wiibrew.org/wiki/Libogc
not so good but it works

If this is a new template:

 - **Link to application or project’s homepage**: 
https://github.com/devkitPro/libogc


let me know if you have any suggestions