### PR TITLE
Jupyterlabs LSP virtual documents directory

### DIFF
--- a/community/Python/JupyterNotebooks.gitignore
+++ b/community/Python/JupyterNotebooks.gitignore
@@ -8,5 +8,9 @@
 profile_default/
 ipython_config.py
 
+# Jupyter lab virtual documents
+# https://jupyterlab-lsp.readthedocs.io/en/2.x/Configuring.html#virtual_documents_dir
+.virtual_documents/
+
 # Remove previous ipynb_checkpoints
 #   git rm -r .ipynb_checkpoints/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

General User of Jupyter labs lsp. .virtual_documents folder is created when lsp plugins gets loaded. There is no gitignore for Jupter labs so submmitting here as the next best place.

**Links to documentation supporting these rule changes:**

https://jupyterlab-lsp.readthedocs.io/en/2.x/Configuring.html#virtual_documents_dir

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
