### PR TITLE
Add OpenTofu to community

### DIFF
--- a/community/OpenTofu.gitignore
+++ b/community/OpenTofu.gitignore
@@ -1,0 +1,42 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tofu
+override.tf.json
+override.tofu.json
+*_override.tf
+*_override.tofu
+*_override.tf.json
+*_override.tofu.json
+
+# Ignore transient lock info files created by tofu apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+# !example_override.tofu
+
+# Include tfplan files to ignore the plan output of command: tofu plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I'm a heavy user - basically just easier addition of OpenTofu-specific extensions, now that the project has extended that part of Terraform.
Theoretically these could be added to Terraform.gitignore, but as the OpenTofu project progresses there may be more differences that aren't worth having both sides. Open to suggestion though.

**Links to documentation supporting these rule changes:**

* https://opentofu.org/docs/intro/whats-new/#override-files-for-opentofu-keeping-compatibility
* https://opentofu.org/docs/language/files/#file-extension
* https://opentofu.org/docs/language/files/override/

If this is a new template:

 - **Link to application or project’s homepage**: https://opentofu.org/
