### PR TITLE
Create MuleSoft.gitignore

### DIFF
--- a/MuleSoft.gitignore
+++ b/MuleSoft.gitignore
@@ -1,0 +1,10 @@
+/target/
+.classpath
+*.pom
+.project
+
+.mule/project.json
+
+.tooling-project
+/.settings
+/.vscode


### PR DESCRIPTION
**Reasons for making this change:**
Adding .gitignore file for MuleSoft 4 Applications.

**Links to documentation supporting these rule changes:**
https://developer.mulesoft.com/tutorials-and-howtos/quick-start/developing-your-first-mule-application/


