### PR TITLE
feat: Add Gleam (1.5.x) gitignore

### DIFF
--- a/Gleam.gitignore
+++ b/Gleam.gitignore
@@ -1,0 +1,4 @@
+*.beam
+*.ez
+/build
+erl_crash.dump


### PR DESCRIPTION
this is useful for developers that init a gleam project into an existing git repo where the `gleam new` tool will refrain from populating the .gitignore file. This situation may occur for users of devenv.nix or flake.nix.

**Reasons for making this change:**
There is no clear way to force the `gleam new` CLI tool to populate a valid .gitignore when running the CLI tool from inside a git repo. Since I manage my build tooling with devenv.nix which already spawns a git repo, I needed a different way to figure out how to get a sufficiently decent default .gitignore for my Gleam project. As I didn't find anything or any relevant open PR (searched for any PR matching the filter: `gleam`) to inform this, I reckoned that having this recorded in the .gitignore repo provides folks a reference in case they run into a similar problem.

**Links to documentation supporting these rule changes:**
- https://gleam.run = language homepage
- https://gleam.run/writing-gleam/ = docs outlining file structure to be expected upon running `gleam new` which includes the .gitignore
- https://github.com/gleam-lang/gleam/blob/fcfc553/compiler-cli/src/new.rs#L116-L120 for the source that defines what goes into the .gitignore that the `gleam new` tool populates
