### PR TITLE
Update Node.gitignore with ignore for bun files

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -128,3 +128,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# bun
+bun.lockb
+**/*.bun


### PR DESCRIPTION
**Reasons for making this change:**
Bun is an new JavaScript runtime with an new package manger and has a lock file named bun.lockb which is not use case for small projects.
