### PR TITLE
Update Android.gitignore changing output.json line

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -13,7 +13,7 @@ captures/
 .externalNativeBuild/
 .cxx/
 *.apk
-output.json
+output-metadata.json
 
 # IntelliJ
 *.iml


### PR DESCRIPTION
When generating an apk, two files are created, an apk that is already being ignored and a json file that appears to have been previously called **output.json**. In Android Studio Koala | 2024.1.1 Patch 1 when generating an apk, the file that is generated along with the apk is called **output-metada.json**.



