### PR TITLE
Update Python.gitignore to ignore pixi

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -129,6 +129,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.pixi
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Ignore pixi directory https://github.com/prefix-dev/pixi/blob/main/.gitignore

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Ignore `.pixi` directory from git.

**Links to documentation supporting these rule changes:**

See here https://github.com/prefix-dev/pixi/blob/main/.gitignore & here http://8.217.189.46:8067/prefix-dev/pixi/issues/2115
