### PR TITLE
Add ignore for .vsconfig

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -40,6 +40,7 @@
 *.sdf
 *.VC.db
 *.VC.opendb
+.vsconfig
 
 # Precompiled Assets
 SourceArt/**/*.png


### PR DESCRIPTION
The engine generates the file during the build.

**Reasons for making this change:**

I'm a game developer working professionally on game projects developed in Unreal Engine.
Also, I try to work on different UE projects and plugins in my spare time.

The Unreal Engine generates the .vsconfig file during the build process.
I don't want to update or ignore the file when working on different projects.

The file is generated each time you regenerate the solution file, and you should not add it to your VCS.

**Links to documentation supporting these rule changes:**

".vsconfig" is mentioned in the UE documentation - https://dev.epicgames.com/documentation/en-us/unreal-engine/build-configuration-for-unreal-engine
> $ bVsConfigFile : Whether to write a .vsconfig file next to the sln to suggest components to install.

https://github.com/EpicGames/UnrealEngine/blob/40eea367040d50aadd9f030ed5909fc890c159c2/Engine/Source/Programs/UnrealBuildTool/ProjectFiles/VisualStudio/VCProjectFileGenerator.cs
The file is generated in the function `UnrealBuildTool.VCProjectFileGenerator.WritePrimaryProjectFile` the file is generated
The function `UnrealBuildTool.VCProjectFileGenerator.CleanProjectFiles` shows that the file is removed together with "*.sln" and "*.suo" files.