### PR TITLE
Update Unity.gitignore to support Unity 6

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -70,3 +70,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Unity 6 specific
+/.utmp


### PR DESCRIPTION
Adds `/.utmp` folder to be ignored at the root as it is generated from Unity 6 upwards.
