### PR TITLE
ignore `cmake-build-debug` generated by CMake in CLion IDE

### DIFF
--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -12,4 +12,8 @@ _deps
 CMakeUserPresets.json
 
 # CLion
-cmake-build-*
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#cmake-build-*

--- a/CMake.gitignore
+++ b/CMake.gitignore
@@ -10,3 +10,6 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
+
+# CLion
+cmake-build-*


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

The `cmake-build-debug` directory is typically generated by the CLion IDE (or other IDEs that use CMake) for managing build files in debug mode. Here are some common reasons to ignore it in version control:

1. **Auto-generated files**: The `cmake-build-debug` folder contains generated files from CMake that are used to compile your project in debug mode. These files can be easily regenerated from source, making them unnecessary for version control.

2. **Platform-specific files**: The build directory often includes platform-specific binaries, paths, and configurations, which might vary across different development environments (e.g., different operating systems, compilers, or IDE configurations).

3. **Large binaries and object files**: The debug build directory frequently holds binaries, object files, and other large intermediate files that can bloat your repository if included in version control. Ignoring these files helps keep your repository lightweight.

4. **Avoiding merge conflicts**: Binary files in the build directory can cause unnecessary merge conflicts when multiple people work on the project and each builds locally. Ignoring the build directory reduces the likelihood of these conflicts.

5. **Sensitive configuration information**: Some build configurations may include paths or sensitive environment details specific to your local setup. Excluding this directory helps maintain privacy and keeps these configurations local.

6. **Consistency across environments**: Different developers may have different setups, so each person's build directory might differ. Ignoring `cmake-build-debug` encourages each developer to generate their own build files tailored to their local environment.

For these reasons, adding `cmake-build-debug` to your `.gitignore` is generally recommended.

**Links to documentation supporting these rule changes:**

Reference links below 

1. https://intellij-support.jetbrains.com/hc/en-us/community/posts/206020944-What-should-I-gitignore-Can-I-gitignore-cmake-build-debug
2. https://stackoverflow.com/questions/75274647/which-folders-i-should-put-in-gitignore-file-after-creating-a-project-with-clio

If this is a new template:

 - **Link to application or project’s homepage**: _TODO_
