### PR TITLE
Add rye to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -101,6 +101,15 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
+# Rye - Python packaging and dependency management tool
+# .python-version - Contains the Python version for the project
+# .rye/ - Contains virtual environments, tooling and cached packages
+# requirements.lock - Lock file containing exact versions of all dependencies
+.python-version
+.rye/
+requirements.lock
+requirements-dev.lock
+
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
 #pdm.lock


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

Adding Rye-specific entries to ensure proper version control behavior when using Rye as the Python package manager. This prevents committing virtual environments, lock files, and version specifications that should be managed locally.

**Links to documentation supporting these rule changes:**

- [Rye Documentation](https://rye.astral.sh/guide//)

If this is a new template:

 - **Link to application or project's homepage**: [Rye - An Experimental Package Management Solution](https://rye.astral.sh)