### PR TITLE
Fix "build" source folder being ignored (Gradle)

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -1,6 +1,6 @@
 .gradle
 **/build/
-!src/**/build/
+!**/src/**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I used the template and my files in `buildSrc/src/**/build/` (my package name includes `build`) were being ignored. I tried around and found out that with this change they are no longer ignored. This was originally introduced in #3370, but the previous configuration only works if `src` is a top level directory.

**Links to documentation supporting these rule changes:**

> If there is a separator at the beginning or **middle** (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself.

From https://git-scm.com/docs/gitignore, emphasizes mine.