### PR TITLE
Create Angular.gitignore

### DIFF
--- a/Angular.gitignore
+++ b/Angular.gitignore
@@ -1,0 +1,94 @@
+# Angular
+# Build output
+/dist/
+/out-tsc/
+/tmp/
+/coverage/
+/e2e/test-output/
+/.angular/
+
+# Node modules
+/node_modules/
+
+# Dependency directories
+/.npm/
+/.yarn/
+
+# Package lock and yarn lock files
+/package-lock.json
+/yarn.lock
+
+# Environment files
+/.env
+
+# TypeScript cache files
+*.tsbuildinfo
+
+# Debug log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE directories and files
+/.idea/
+/.vscode/
+/project-folder/.idea/
+/project-folder/.vscode/
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.bak
+*.swp
+*~
+
+# Build artifacts from Angular CLI
+/.angular-cli.json
+.angular/
+
+# Angular CLI cache
+/.ng/
+
+# VS Code settings
+.vscode/settings.json
+
+# System files
+*.sublime-workspace
+*.sublime-project
+
+# Logs
+/logs
+/debug.log
+*.log
+
+# Temporary files from editor or operating system
+*~.nfs*
+
+# JetBrains IDE (e.g., WebStorm) files
+/.idea/
+
+# End-to-end testing
+/cypress/
+
+# Firebase hosting files
+firebase.json
+
+# Jest snapshot files
+*.snap
+
+# Webpack config
+webpack.config.js
+webpack.prod.js
+webpack.dev.js
+
+# Coverage output directory
+/coverage/
+
+# Test files
+*.spec.ts
+*.test.ts
+
+# Miscellaneous
+/.angular/

--- a/Angular.gitignore
+++ b/Angular.gitignore
@@ -1,94 +1,28 @@
-# Angular
-# Build output
+# Angular specific
 /dist/
 /out-tsc/
 /tmp/
 /coverage/
 /e2e/test-output/
 /.angular/
+.angular/
 
-# Node modules
+# Node modules and dependency files
 /node_modules/
-
-# Dependency directories
-/.npm/
-/.yarn/
-
-# Package lock and yarn lock files
 /package-lock.json
 /yarn.lock
 
 # Environment files
 /.env
 
-# TypeScript cache files
+# Angular CLI and build artefacts
+/.angular-cli.json
+/.ng/
+
+# TypeScript cache
 *.tsbuildinfo
 
-# Debug log files
+# Logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# IDE directories and files
-/.idea/
-/.vscode/
-/project-folder/.idea/
-/project-folder/.vscode/
-
-# OS-specific files
-.DS_Store
-Thumbs.db
-
-# Temporary files
-*.bak
-*.swp
-*~
-
-# Build artifacts from Angular CLI
-/.angular-cli.json
-.angular/
-
-# Angular CLI cache
-/.ng/
-
-# VS Code settings
-.vscode/settings.json
-
-# System files
-*.sublime-workspace
-*.sublime-project
-
-# Logs
-/logs
-/debug.log
-*.log
-
-# Temporary files from editor or operating system
-*~.nfs*
-
-# JetBrains IDE (e.g., WebStorm) files
-/.idea/
-
-# End-to-end testing
-/cypress/
-
-# Firebase hosting files
-firebase.json
-
-# Jest snapshot files
-*.snap
-
-# Webpack config
-webpack.config.js
-webpack.prod.js
-webpack.dev.js
-
-# Coverage output directory
-/coverage/
-
-# Test files
-*.spec.ts
-*.test.ts
-
-# Miscellaneous
-/.angular/


### PR DESCRIPTION
**Reasons for making this change:**
This change was made to enhance the .gitignore file for Angular projects, ensuring that commonly ignored files and directories such as build artifacts, node modules, and IDE configuration files are excluded from version control. This helps improve the cleanliness of the repository and prevents unnecessary files from being tracked, making the project easier to manage.

**Links to documentation supporting these rule changes:**
[Angular CLI documentation](https://angular.dev/cli)
[GitHub’s official guide on .gitignore files](https://docs.github.com/en/github/using-git/ignoring-files)
[Node.js documentation on npm and yarn dependencies](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json)

