### PR TITLE
added gitignore for firebase

### DIFF
--- a/Firebase.gitignore
+++ b/Firebase.gitignore
@@ -1,0 +1,44 @@
+# Firebase build and deployment files
+/firebase-debug.log
+/firebase-debug.*.log
+.firebaserc
+
+# Firebase Hosting
+/firebase.json
+*.cache
+hosting/.cache
+
+# Firebase Functions
+/node_modules/
+/functions/node_modules/
+/functions/.env
+/functions/package-lock.json
+
+# Firebase Emulators
+/firebase-*.zip
+/.firebase/
+/emulator-ui/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.idea/
+.vscode/
+*.sublime*
+
+# Environment files (local configs)
+.env
+.env.*
+.env.local
+.env.development
+.env.production
+.env.test
+.env.staging

--- a/Firebase.gitignore
+++ b/Firebase.gitignore
@@ -9,7 +9,6 @@
 hosting/.cache
 
 # Firebase Functions
-/node_modules/
 /functions/node_modules/
 /functions/.env
 /functions/package-lock.json
@@ -25,20 +24,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# OS-specific files
-.DS_Store
-Thumbs.db
-
-# IDE files
-.idea/
-.vscode/
-*.sublime*
-
 # Environment files (local configs)
-.env
-.env.*
-.env.local
-.env.development
-.env.production
-.env.test
-.env.staging
+/.env.*


### PR DESCRIPTION

**Reasons for making this change:**  
As a developer working with Firebase, it is essential to exclude sensitive files, auto-generated content, and irrelevant build artifacts from version control to enhance security and streamline repository management. This `.gitignore` template is tailored to Firebase projects, ensuring best practices for file exclusion.

This change aims to provide the Firebase development community with a pre-configured `.gitignore` file, saving time and reducing potential errors.

**Links to documentation supporting these rule changes:**  
- [Firebase Documentation - Sensitive Configuration](https://firebase.google.com/docs/projects/learn-more#sensitive-data)
- [Git Documentation - Ignoring Files](https://git-scm.com/docs/gitignore) 
- [Best Practices for Firebase Security Rules](https://firebase.google.com/docs/rules)

If this is a new template:  
- **Link to application or project’s homepage**: [Firebase Official Homepage](https://firebase.google.com/)

