### PR TITLE
Update Node.gitignore to include VitePress

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -103,9 +103,13 @@ dist
 # vitepress build output
 .vitepress/dist
 
-# vuepress v2.x / vitepress temp and cache directory
+# vuepress v2.x temp and cache directory
 .temp
 .cache
+
+# vitepress temp and cache directory
+.vitepress/temp
+.vitepress/cache
 
 # Docusaurus cache and generated files
 .docusaurus

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -101,15 +101,15 @@ dist
 .vuepress/dist
 
 # vitepress build output
-.vitepress/dist
+**/.vitepress/dist
 
 # vuepress v2.x temp and cache directory
 .temp
 .cache
 
 # vitepress temp and cache directory
-.vitepress/temp
-.vitepress/cache
+**/.vitepress/temp
+**/.vitepress/cache
 
 # Docusaurus cache and generated files
 .docusaurus

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -100,7 +100,10 @@ dist
 # vuepress build output
 .vuepress/dist
 
-# vuepress v2.x temp and cache directory
+# vitepress build output
+.vitepress/dist
+
+# vuepress v2.x / vitepress temp and cache directory
 .temp
 .cache
 

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -100,15 +100,14 @@ dist
 # vuepress build output
 .vuepress/dist
 
-# vitepress build output
-**/.vitepress/dist
-
 # vuepress v2.x temp and cache directory
 .temp
 .cache
 
-# vitepress temp and cache directory
-**/.vitepress/temp
+# vitepress build output
+**/.vitepress/dist
+
+# vitepress cache directory
 **/.vitepress/cache
 
 # Docusaurus cache and generated files


### PR DESCRIPTION
Include VitePress

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

I noticed that VuePress is included in the current gitignore. VuePress has been succeeded by VitePress. This change includes files to be ignored in a VitePress project.
