### PR TITLE
Update for Kotlin 2.x.x

### DIFF
--- a/Kotlin.gitignore
+++ b/Kotlin.gitignore
@@ -1,1 +1,27 @@
-Java.gitignore
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+# Kotlin Gradle plugin data, see https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
+.kotlin/


### PR DESCRIPTION
Ignore Kotlin data directory for Kotlin Gradle plugin.

Since [Kotlin.gitignore](https://github.com/github/gitignore/compare/main...daniel-shuy:feature/kotlin-2?expand=1#diff-95805b2135e2a321ff81ec20ca118652d7240305c0cea566b2b6a7813bd02a01) was a symlink to `Java.gitignore`, I deleted the symlink and re-created [Kotlin.gitignore](https://github.com/github/gitignore/compare/main...daniel-shuy:feature/kotlin-2?expand=1#diff-95805b2135e2a321ff81ec20ca118652d7240305c0cea566b2b6a7813bd02a01) as a file and copied the contents from [Java.gitignore](https://github.com/daniel-shuy/gitignore-1/blob/29d931584421f77a7d0bdaa43b0b75be50fae435/Java.gitignore).

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

As of Kotlin `2.0.0`, the Kotlin Gradle plugin stores Kotlin data in `.kotlin` instead of `.gradle/kotlin`

**Links to documentation supporting these rule changes:**

https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects

