### PR TITLE
Ignore vscode cache directory

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code cache directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
**Reasons for making this change:**
VSCode is widely used with Unity, but it generates a `.vscode/` folder containing user-specific settings (e.g., extensions, debug configurations). Including this in version control can cause unnecessary conflicts and bloat. Ignoring it keeps the repository clean and avoids sharing editor preferences.