### PR TITLE
SECURITY ISSUE: JENKINS_HOME.gitignore must ignore credentials.xml

### DIFF
--- a/JENKINS_HOME.gitignore
+++ b/JENKINS_HOME.gitignore
@@ -18,10 +18,11 @@
 !/.gitignore
 !/*.xml
 
-# Ignore all files in jobs subdirectories except for folders.
+# Ignore all files in jobs subdirectories except for folders and job config.
 # Note: git doesn't track folders, only file content.
 jobs/**
 !jobs/**/
+!jobs/**/config.xml
 
 # Uncomment the following line to save next build numbers with config.
 

--- a/JENKINS_HOME.gitignore
+++ b/JENKINS_HOME.gitignore
@@ -4,11 +4,12 @@
 #  http://jenkins-ci.org/
 #  https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins
 #
-# Note: secret.key is purposefully not tracked by git. This should be backed up
-# separately because configs may contain secrets which were encrypted using the
-# secret.key.  To back up secrets use 'tar -czf /tmp/secrets.tgz secret*' and
-# save the file separate from your repository.  If you want secrets backed up
-# with configuration, then see the bottom of this file for an example.
+# Note: secret.key and credentials.xml are purposefully not tracked by git. 
+# They should be backed up separately because configs may contain secrets which
+# were encrypted using the secret.key.  To back up secrets use 
+# 'tar -czf /tmp/secrets.tgz secret*' and save the files separate from your
+# repository.  If you want secrets backed up with configuration, then see the
+# bottom of this file for an example.
 
 # Ignore all JENKINS_HOME except jobs directory, root xml config, and
 # .gitignore file.
@@ -40,7 +41,12 @@ jobs/**/*workspace
 
 # Security warning: If secrets are included with your configuration, then an
 # adversary will be able to decrypt all encrypted secrets within Jenkins
-# config.  Including secrets is a bad practice, but the example is included in
+# config.
+
+# Ignore credentials.xml, as it can contain encrypted secrets.
+**/credentials.xml
+
+# Including secrets is a bad practice, but the example is included in
 # case someone still wants it for convenience.  Uncomment the following line to
 # include secrets for decryption with repository configuration in Git.
 


### PR DESCRIPTION
JENKINS_HOME.gitignore must ignore credentials.xml, as that file may contain encrypted secrets.

Also, job config should be included.

**Reasons for making this change:**

I am a Jenkins user. I decided to use this JENKINS_HOME.gitignore as I version controlled my jenkins configuration.

1. Then I discovered that credentials.xml, which contains encrypted passwords, private ssh keys, and other secrets. In general, it is bad practice and a security issue to include any secrets or credentials-- encrypted or not-- in git repositories. (And in this case, they can be [decrypted very easily](https://devops.stackexchange.com/questions/2191/how-to-decrypt-jenkins-passwords-from-credentials-xml)).
2. I also discovered that the job configurations were being ignored. Job config.xml files are important, sometimes containing a lot of intricate configuration, and in fact sometimes contain `<script>{code}</script>` which literally contains code. Code should be included in version control.

**Links to documentation supporting these rule changes:**

1. Not documented. Just enter any credential into a jenkins instance, and look at the credentials.xml file. You will see your encrypted credential. The need for this change is self-evident.
2. https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins


