### PR TITLE
Ignore macOS .DS_Store file for VisualStudio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -398,3 +398,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# macOS Desktop Services Store
+.DS_Store


### PR DESCRIPTION
Development on macOS often leads to having a .DS_Store file that needs to be ignored. For information about the .DS_Store file, refer to https://wikipedia.org/wiki/.DS_Store.