### PR TITLE
Add latexindent.pl backups to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -267,6 +267,9 @@ TSWLatexianTemp*
 *.bak
 *.sav
 
+# latexindent.pl
+*.bak[0-9]*
+
 # Texpad
 .texpadtmp
 


### PR DESCRIPTION
**Reasons for making this change:**

I use this template as my basis for LaTeX projects. This is a pretty standard LaTeX tool (and this .gitignore seems to be a bit of a kitchen-sink).

**Links to documentation supporting these rule changes:**

https://latexindentpl.readthedocs.io/en/stable/sec-default-user-local.html#backup-and-log-file-preferences shows that by default, latexindent.pl (part of the standard CTAN installation and the de facto LaTeX formatter) backups will be called `myfile.bak1`, `myfile.bak2`, etc.
