### PR TITLE
Add extra ignored files for TC 3.1.4026

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -15,7 +15,9 @@
 *.tmcRefac
 *.library
 *.project.~u
+*.sln.~u
 *.tsproj.bak
+*.tspproj.bak
 *.xti.bak
 LineIDs.dbg
 LineIDs.dbg.bak
@@ -23,3 +25,4 @@ _Boot/
 _CompileInfo/
 _Libraries/
 _ModuleInstall/
+.vs/


### PR DESCRIPTION
**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

When opening a Twincat 3 project in TcXaeShell 3.1.4026.12, some files needed to be added to the .gitignore.

**Links to documentation supporting these rule changes:**

The official suggested [.gitignore](https://infosys.beckhoff.com/content/1033/tc3_sourcecontrol/14604066827.html) does not ignore the temporary generated files by the TcXeaShell 3.1.4026.

