### PR TITLE
Added nextjs.gitignore

### DIFF
--- a/nextjs.gitignore
+++ b/nextjs.gitignore
@@ -1,0 +1,49 @@
+# Logs
+logs/
+*.log
+
+# Dependency directories
+node_modules/
+
+# Environment variables
+.env
+.env.*.local
+
+# Build output
+.next/
+out/
+
+# Static files
+.cache/
+
+# Testing
+coverage/
+*.lcov
+
+# Editor settings
+.vscode/
+.idea/
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Package manager files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Next.js specific
+.next/cache/
+.next/static/
+
+# Storybook
+storybook-static/
+
+# Miscellaneous
+*.tmp
+*.seed
+*.pid.lock
+
+# TypeScript
+*.tsbuildinfo


### PR DESCRIPTION
**Reasons for making this change: **
I added a `.gitignore` template for Next.js projects to streamline the development workflow. This change ensures that common build files, dependency directories, environment variables, logs, and other unnecessary files are excluded from version control. By including this template, developers can quickly set up a clean and efficient Next.js project without worrying about irrelevant files being tracked.

This will improve collaboration by reducing the chances of unintentionally committing sensitive or unnecessary files to the repository.

**Links to documentation supporting these rule changes:**
- [Next.js Documentation](https://nextjs.org/docs)
- [Gitignore Documentation](https://git-scm.com/docs/gitignore)
