### PR TITLE
feat(Jetbrains.gitignore): Add GoLand thats missing in Jetbrains IDE …

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,4 +1,4 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Covers JetBrains IDEs: IntelliJ, GoLand, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff


### PR DESCRIPTION
**Reasons for making this change:**

I happened to observe that Jetbrains IDE for Go Programming Language is not listed in the head comment of the supported list of IDEs of Jetbrains that supports the `Jetbrains.gitignore`. This PR fixes it.

**Links to documentation supporting these rule changes:**

- [GoLand by Jetbrains](https://www.jetbrains.com/go/)
