### PR TITLE
feat(go.gitignore): Add code coverage and IDE files

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -28,5 +28,5 @@ go.work.sum
 .env
 
 # Editor/IDE
-.idea/
-.vscode/
+# .idea/
+# .vscode/

--- a/Go.gitignore
+++ b/Go.gitignore
@@ -11,8 +11,11 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Code coverage profiles and other test artifacts
 *.out
+coverage.*
+*.coverprofile
+profile.cov
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
@@ -23,3 +26,7 @@ go.work.sum
 
 # env file
 .env
+
+# Editor/IDE
+.idea/
+.vscode/


### PR DESCRIPTION
**Reasons for making this change:**

I’ve noticed a couple of things missing from the Go `.gitignore` template that many of us deal with daily:

1. **Code coverage files**: Whenever we run tests, files like `*.out` and `*.coverprofile` pop up. These are temporary and don’t really belong in version control.  
2. **IDE/editor files**: Directories like `.idea/` and `.vscode/` are personal to each developer’s setup and don’t add much value to the repo itself. This is _by-default_ commented out. So, we're providing an option for developers (just like we do for `vendor/` files).

Just cleaner repos, happier teams!

**Links to documentation supporting these rule changes:**

`.idea` / `.vscode` files are unlikely to provide any value to the Go developers, in the real world scenario. There isn't a documentation that supports this, specifically for Go, but here we go:

- https://github.com/flutter/flutter/issues/15555
- https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems