### PR TITLE
CppCustom.gitignore template for C++ projects

### DIFF
--- a/CppCustom.gitignore
+++ b/CppCustom.gitignore
@@ -1,0 +1,18 @@
+# Ignore build artifacts
+*.o
+*.obj
+*.exe
+
+# Ignore build directories
+/build/
+/bin/
+/Debug/
+/Release/
+
+# Ignore IDE-specific files
+*.vcxproj*
+*.user
+
+# Ignore temporary files
+*.tmp
+*.swp


### PR DESCRIPTION
Added a new .gitignore template named CppCustom.gitignore. This file is designed to ignore common C++ build artifacts, IDE-specific files, and temporary files.
