### PR TITLE
Added "*.bcf-SAVE-ERROR" to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -28,6 +28,7 @@
 *.bbl
 *.bbl-SAVE-ERROR
 *.bcf
+*.bcf-SAVE-ERROR
 *.blg
 *-blx.aux
 *-blx.bib


### PR DESCRIPTION
**Reasons for making this change:**

".bcf" stands for "biblatex control file".
Files with this suffix are already getting ignored.
If there is an error, another file with the suffix "*.bcf-SAVE-ERROR" is created, which should also be ignored.

**Links to documentation supporting these rule changes:**

This kind of error file seems to be a "cousin" of files with the suffix "*.bbl-SAVE-ERROR" which has been added fairly recently: https://github.com/github/gitignore/pull/4442

I've seen files with both suffixes, so I'm adding the rule for the one that is currently still missing.