### PR TITLE
Add .vscode/ to Maven.gitignore file

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -15,3 +15,7 @@ buildNumber.properties
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+### VS Code ###
+.vscode/
+


### PR DESCRIPTION
What I added:
Added the following to Maven.gitignore to ignore VS Code-specific files:
```
### VS Code ###
.vscode/
```
Why:
This repository is very helpful, and I use `Maven.gitignore` often. Every time I use it with VS Code, I need to manually add `.vscode/`to the file. I thought it would be useful to fork the repo and make this change so it can help others as well.

Thank you for considering this update! 

