### PR TITLE
TeX: Add support for spelling package

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -204,6 +204,7 @@ _minted*
 
 # spelling
 *.spell.bad
+*.spell.txt
 
 # svg
 svg-inkscape/

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -203,7 +203,7 @@ _minted*
 *.wrt
 
 # spelling
-*.bad
+*.spell.bad
 
 # svg
 svg-inkscape/

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -202,6 +202,9 @@ _minted*
 # scrwfile
 *.wrt
 
+# spelling
+*.bad
+
 # svg
 svg-inkscape/
 


### PR DESCRIPTION
**Reasons for making this change:**

I am using TeX, lualatex in particular.  The LaTeX package [spelling](https://ctan.org/pkg/spelling) offers to highlight mis-spelled words. The list of the mis-spelled words is put into a file `<jobname>.spell.bad`. These are generated by spell checker - and thus should not be versioned.

Moreover, all words of the document are put into `<jobname>.spell.txt`, which also should be ignored.

**Links to documentation supporting these rule changes:**

http://mirrors.ctan.org/macros/luatex/generic/spelling/spelling-doc.pdf -> pages 3 and 8

![image](https://github.com/user-attachments/assets/d0065d86-20dc-413d-b442-531a0fe8cd27)

![image](https://github.com/user-attachments/assets/a42d1ddb-c681-4bb7-89e5-71469ec0f852)

