### PR TITLE
feat(nix): add .direnv

### DIFF
--- a/community/Nix.gitignore
+++ b/community/Nix.gitignore
@@ -1,3 +1,6 @@
 # Ignore build outputs from performing a nix-build or `nix build` command
 result
 result-*
+
+# Ignore automatically generated direnv output
+.direnv


### PR DESCRIPTION
very commonly used to enter Nix devshells (see https://github.com/nix-community/nix-direnv for more info)

**Reasons for making this change:**

I frequently use direnv with Nix devshells, and ignoring this automatically generated output by default would be a nice addition. The `.envrc` file is the only thing that needs to be committed for direnv to work.

**Links to documentation supporting these rule changes:**

See https://github.com/direnv/direnv/blob/master/.gitignore for an example (notice `.direnv` entry)
