### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -71,3 +71,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Android temporary build files
+/.utmp/


### PR DESCRIPTION
**Reasons for making this change:**
With the new release of Unity 6 it appears a new temporary folder is created when building for Android. It can be safely deleted.

**Links to documentation supporting these rule changes:**
Unfortunately it is not documented. This [stackoverflow link talk about it](https://github.com/Unity-Technologies/a11y-public-sample/blob/main/.gitignore)
Note that even [Unity samples project](https://github.com/Unity-Technologies/a11y-public-sample/blob/main/.gitignore) ignore this as well

