### PR TITLE
Update `uv` lockfile handling instructions in documentation comments

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -86,7 +86,7 @@ ipython_config.py
 #   Similar to Pipfile.lock and poetry.lock, it is recommended to include `.uv.lock` in version control.
 #   This ensures reproducibility, especially for binary packages. However, for libraries or packages that run in multiple environments,
 #   you might prefer to ignore this file and check it in only if necessary.
-# .uv.lock
+# uv.lock
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -82,6 +82,12 @@ target/
 profile_default/
 ipython_config.py
 
+# uv
+#   Similar to Pipfile.lock and poetry.lock, it is recommended to include `.uv.lock` in version control.
+#   This ensures reproducibility, especially for binary packages. However, for libraries or packages that run in multiple environments,
+#   you might prefer to ignore this file and check it in only if necessary.
+# .uv.lock
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:


### PR DESCRIPTION

Improved the documentation comment regarding `.uv.lock` file inclusion in version control. The updated comment now emphasizes the importance of including `.uv.lock` for binary package reproducibility while also advising on ignoring it for libraries or packages that run in multiple environments.

**Reasons for making this change:**
As a contributor, I aim to enhance clarity in documentation to promote effective dependency management and reproducibility.

**Links to documentation supporting these rule changes:**

- [Managing lockfiles with UV](https://docs.astral.sh/uv/concepts/projects/sync/) – Detailed guidelines on creating, updating, and handling `.uv.lock` files.
- [Dependency lockfile practices](https://docs.astral.sh/uv/pip/compile/) – Insights into how to manage dependencies effectively with lockfiles.
- [Best practices for using UV with dependency bots](https://docs.astral.sh/uv/guides/integration/dependency-bots/) – Recommended practices for keeping dependencies up-to-date with `.uv.lock` files.
