### PR TITLE
Unity Visual Scripting auto generated files

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -71,3 +71,9 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Visual Scripting auto-generated files
+/[Aa]ssets/Unity.VisualScripting.Generated/VisualScripting.Flow/UnitOptions.db
+/[Aa]ssets/Unity.VisualScripting.Generated/VisualScripting.Flow/UnitOptions.db.meta
+/[Aa]ssets/Unity.VisualScripting.Generated/VisualScripting.Core/Property Providers
+/[Aa]ssets/Unity.VisualScripting.Generated/VisualScripting.Core/Property Providers.meta


### PR DESCRIPTION
**Reasons for making this change:**
These files are re-generated frequently and do not have to be committed according to documentation.

**Links to documentation supporting these rule changes:**
https://docs.unity3d.com/Packages/com.unity.visualscripting@1.9/manual/vs-version-control.html
