### PR TITLE
Add ARM64EC support to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -26,6 +26,7 @@ x86/
 [Ww][Ii][Nn]32/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
+[Aa][Rr][Mm]64[Ee][Cc]/
 bld/
 [Bb]in/
 [Oo]bj/


### PR DESCRIPTION
**Reasons for making this change:**

Adds ignore entry for ARM64EC MSVC output

**Links to documentation supporting these rule changes:**

https://learn.microsoft.com/en-us/windows/arm/arm64ec