### PR TITLE
Aded /.utemp/ in Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -9,6 +9,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+/.utmp/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data


### PR DESCRIPTION
This folder is created when using Unity 6, i personaly added it in my projects.

This folder contains folders like "Debug", "RelWithDebInfo" and "tools".

It doesn appear on every single unity version but it happens only in Unity 6.

**Reasons for making this change:**
I added this folder because it doesnt affect project in any way and it creates temporary files.

**Links to documentation supporting these rule changes:**
I didnt found any. It just happened to me multiple times and i had to manualy add it in .gitignore