### PR TITLE
Ignore .vsconfig when outside of .vs dir

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -26,6 +26,8 @@
 
 # Visual Studio cache directory
 .vs/
+# Sometimes .vsconfig is located outside the .vs/ directory and won't be picked up by the ignore pattern above.
+.vsconfig
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
Sometimes .vsconfig is located outside the .vs/ directory and won't be picked up by the ignore pattern above. Confirmed on Unity 6.
