### PR TITLE
Update Godot.gitignore to ignore export_credentials.cfg

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -4,7 +4,7 @@
 # Godot-specific ignores
 .import/
 export.cfg
-export_presets.cfg
+export_credentials.cfg
 
 # Imported translations (automatically generated from CSV files)
 *.translation


### PR DESCRIPTION
As of [May 2023](https://github.com/godotengine/godot/pull/76165), `export_presets.cfg` no longer contains sensitive information in Godot. Sensitive information now resides in `export_credentials.cfg`

**Reasons for making this change:**
<!-- Include your relationship to the project and what you expect to get from this change. -->

When starting to use Godot, I searched for `.gitignore` files and found this repository. I saw that it was out of date compared to changes made to Godot that are nearly two years old as of the time of making this PR.

**Links to documentation supporting these rule changes:**

[This Godot Pull Request](https://github.com/godotengine/godot/pull/76165) shows the change being made to no longer store sensitive information in `export_presets.cfg`, and instead place them in `export_crednetials.cfg`. [Here is the completed proposal](https://github.com/godotengine/godot-proposals/issues/1156). Quoting the proposal:

> Godot stores export settings including which resources to bundle, app icons, export capabilities in the `export_presets.cfg`. These settings are a core part of development, and we normally want to include these in source control. Unfortunately Godot also stores the keystore credentials in the same export file. This means we either have to commit credentials to our repo, or we have to manually recreate the presets between developers, and somehow sync changes. Both are really bad options. [...] It would be better to have keystore credentials in their own config file alongside `exports_presets.cfg`. Something like `exports_credentials.cfg` or similar.

