### PR TITLE
Ignore unneeded *.blend1 blender files

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -11,6 +11,10 @@
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
 
+# By default unity supports Blender asset imports, *.blend1 blender files do not need to be commited to version control.
+*.blend1
+*.blend1.meta
+
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data
 /[Mm]emoryCaptures/


### PR DESCRIPTION
**Reasons for making this change:**
By default, the Unity game engine supports the importing of Blender *.blend files and converts them to FBX internally (see documentation link below). Sometimes, blender stores *.blend1 files as a backup copy of your current blender file *.blend. Due to the nature of version control, redundant *.blend1 files do not need to be committed.

**Links to documentation supporting these rule changes:**
[Unity supported file formats](https://docs.unity3d.com/Manual/3D-formats.html)