### PR TITLE
Unity: MacOS files ignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -72,3 +72,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# OS-specific
+.DS_Store


### PR DESCRIPTION
**Reasons for making this change:**

When Unity projects are being opened through MacOS's Finder file exporer, it's often the case that these files appear. It's pretty common to ignore them for code bases.

**Links to documentation supporting these rule changes:**

https://en.wikipedia.org/wiki/.DS_Store