### PR TITLE
Create new Nextjs.gitignore

### DIFF
--- a/Nextjs.gitignore
+++ b/Nextjs.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
Reasons for making this change:

This PR adds a .gitignore file specifically configured for Next.js projects. As part of the project setup, it ensures that unnecessary or sensitive files (such as node_modules, .next, and .env files) are not tracked by Git, helping to keep the repository clean and secure.

Links to documentation supporting these rule changes:
[GitHub .gitignore Template for Node](https://github.com/github/gitignore/blob/main/Node.gitignore)

If this is a new template:

Link to application or project’s homepage:
[Next.js Repositories](https://github.com/vercel/next.js)
[Next.js Homepage](https://nextjs.org/)