### PR TITLE
Update MATLAB.gitignore to exclude .MATLABDriveTag

### DIFF
--- a/Global/MATLAB.gitignore
+++ b/Global/MATLAB.gitignore
@@ -29,3 +29,6 @@ codegen/
 
 # Octave session info
 octave-workspace
+
+# MATLAB Drive tag file
+.MATLABDriveTag


### PR DESCRIPTION
This change adds .MATLABDriveTag to the .gitignore file.
.MATLABDriveTag is a system file generated by MATLAB Drive for internal synchronization purposes.
Excluding it from Git ensures a cleaner repository and avoids unnecessary version control of system-generated files.