### PR TITLE
Adding uv tool folders to python ignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -152,6 +152,11 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# python uv tool folders
+bin/
+lib64
+CACHEDIR.TAG
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore


### PR DESCRIPTION
**Reasons for making this change:**

When creating a project with python [uv](https://github.com/astral-sh/uv) tool this folders aren't be ignored

