### PR TITLE
Use a character class to ignore Icon\r directories

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -2,9 +2,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
-
-# Icon must end with two \r
-Icon
+Icon[]
 
 # Thumbnails
 ._*


### PR DESCRIPTION
**Reasons for making this change:**
Years ago, `Icon^M^M` was added as a macOS rule. This gets parsed as `Icon^M`, which ignores macOS `Icon\r` / `Icon^M` directories.

A strange byproduct of this rule is that when Ripgrep's commonly used `ignore` crate parses gitinore rules, [it strips trailing whitespace that is not a literal space character](https://github.com/BurntSushi/ripgrep/blob/de4baa10024f2cb62d438596274b9b710e01c59b/crates/ignore/src/gitignore.rs#L446-L448).

This means that if you have the current `Icon^M^M` rule in your global gitignore tool, Ripgrep, and any Rust-based directory scanning tool that uses the `ignore` crate, will be unable to see any directory named `Icon` — which happens to occur frequently in React codebases.

This change switches to using a character class like `[^M]` (literal CR surrounded by square brackets).

This prevents the rule from ending in whitespace, and thus makes `Icon` directories visible to Ripgrep and Rust-based directory scanning tools again.

**Why not change Ripgrep**

This is old code in Ripgrep, and is widely deployed. It also seems reasonable to see a carriage return at the end of a gitignore rule as not part of the rule. What Ripgrep/ignore is doing is fairly reasonable. Having a `.gitignore` line that ends in two `\r\r` is pretty odd. I think the character class solution with brackets is a reasonable solution.