### PR TITLE
Create Luau.gitignore

### DIFF
--- a/Luau.gitignore
+++ b/Luau.gitignore
@@ -1,0 +1,9 @@
+# Code coverage
+coverage.out
+
+# Profiling
+profile.out
+profile.svg
+
+# Time trace
+trace.json


### PR DESCRIPTION
As far as I can tell, there is no official documentation outlining which files should be ignored when using the [Luau](https://github.com/luau-lang/luau) language. However, there are a few files that can be generated by Luau (or by `perfgraph`, a recommended tool included in the language repository), namely coverage.out, [profile.out, profile.svg](https://luau.org/profile), and trace.json—the latter specifically requiring the compiler to be built with `LUAU_ENABLE_TIME_TRACE` enabled. All of these files have been included in this PR.

Luau is also commonly used alongside a tool called [Rojo](https://github.com/rojo-rbx/rojo) and an LSP like JohnnyMorganz's [luau-lsp](https://github.com/JohnnyMorganz/luau-lsp). Developers generally choose to ignore files like *.rbxlx.lock, *.rbxl.lock, and sourcemap.json. But I think this would require a separate PR (perhaps a Rojo.gitignore?).

I’m not affiliated with the Luau project, but I believe this .gitignore file could be quite helpful to others, just as it has been to me.