### PR TITLE
optimize and more readable obsidian extended gitignore

### DIFF
--- a/community/Obsidian/NotesAndExtendedConfiguration.gitignore
+++ b/community/Obsidian/NotesAndExtendedConfiguration.gitignore
@@ -30,9 +30,7 @@
 # contain metadata (manifest.json), application code (main.js), stylesheets
 # (styles.css), and user-configuration data (data.json).
 # We only want to track data.json, so we:
-# 1. exclude everything under the plugins directory recursively,
-# 2. unignore the plugin directories themselves, which then allows us to
-# 3. unignore the data.json files
-.obsidian/plugins/**/*
-!.obsidian/plugins/*/
+# 1. exclude everything that the plugin folders contain,
+# 2. unignore data.json in the plugin folders
+.obsidian/plugins/*/**
 !.obsidian/plugins/*/data.json


### PR DESCRIPTION
### Reasons for making this change

the old extended obsidian gitignore had 3 options that wouldnt immediately make sense to some users, i have optimzed them to 2 and made them more readable

the updated documentation might need to be changed, just leave a suggestion
### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
