### PR TITLE
Add pixi to python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -117,6 +117,13 @@ ipython_config.py
 .pdm-python
 .pdm-build/
 
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi/
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 


### PR DESCRIPTION
### Reasons for making this change

pixi is a new package manager that builds on the conda ecosystem and is often used for python projects.

GitHub: https://github.com/prefix-dev/pixi/

### Links to documentation supporting these rule changes

https://pixi.sh/

```
$ pixi init
✔ Created /.../pixi.toml
$ cat .gitignore
# pixi environments
.pixi
*.egg-info
```

https://github.com/prefix-dev/pixi/blob/df5d8ef7bf3dfab7315ec3fe92a851b7ae3ed033/.gitignore#L6

### If this is a new template

Link to application or project’s homepage: https://pixi.sh/

### Merge and Approval Steps
- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
