### PR TITLE
Add .loc to TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -67,6 +67,7 @@ acs-*.bib
 
 # changes
 *.soc
+*.loc
 
 # comment
 *.cut


### PR DESCRIPTION
Add `*.loc` (auxiliary files generated by the `changes` package) to TeX.gitignore

### Reasons for making this change

The `changes` package generates auxiliary files with extensions `.loc` and `.soc`. The former is currently not included in `TeX.gitignore`.

### Links to documentation supporting these rule changes

https://ctan.org/pkg/changes (Section 4.6.13)

### If this is a new template

Link to application or project’s homepage: N/A

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
