### PR TITLE
Update TwinCAT3.gitignore

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -1,25 +1,49 @@
-# gitignore template for TwinCAT3
+### TwinCAT3 ###
 # website: https://www.beckhoff.com/twincat3/
-#
-# Recommended: VisualStudio.gitignore
 
-# TwinCAT files
+# TwinCAT PLC
+*.plcproj.bak
+*.plcproj.orig
 *.tpy
 *.tclrs
+*.library
 *.compiled-library
 *.compileinfo
-# Don't include the tmc-file rule if either of the following is true:
-#   1. You've got TwinCAT C++ projects, as the information in the TMC-file is created manually for the C++ projects (in that case, only (manually) ignore the tmc-files for the PLC projects)
-#   2. You've created a standalone PLC-project and added events to it, as these are stored in the TMC-file.
-*.tmc
-*.tmcRefac
-*.library
-*.project.~u
-*.tsproj.bak
-*.xti.bak
+*.asm
+*.core
 LineIDs.dbg
 LineIDs.dbg.bak
-_Boot/
-_CompileInfo/
-_Libraries/
-_ModuleInstall/
+
+# TwinCAT C++ and shared types
+# ignoring the TMC file is only useful for plain PLC programming
+# as soon as shared data types (via tmc), C++ or in general TcCom-Module are used, the TMC file has to be part of the repository
+*.tmc
+*.tmcRefac
+
+# TwinCAT project files
+*.tsproj.bak
+*.tsproj.b?k
+*.tsproj.orig
+*.xti.bak
+*.xti.bk?
+*.xti.orig
+*.xtv
+*.xtv.bak
+*.xtv.bk?
+
+# Multiuser specific
+**/.TcGit/
+
+# exclude not required folders
+**/_Boot/
+**/_CompileInfo/
+**/_Libraries/
+**/_ModuleInstall/
+**/_Deployment/
+**/_Repository/
+
+# VS Shell project specific files and folders
+**/.vs/
+*.~u
+*.project.~u
+*.suo


### PR DESCRIPTION
### Reasons for making this change

A recent major revision from Beckhoff (Build 4026) added several new suggested lines to gitignore. All previous items are still present, however the new file has been copied verbatim from TwinCAT documentation. 

### Links to documentation supporting these rule changes

https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_sourcecontrol/14604066827.html&id=

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->



### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
