### PR TITLE
Added .atfi extension for package attachfile2

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -59,6 +59,9 @@ acs-*.bib
 # amsthm
 *.thm
 
+# attachfile2
+*.atfi
+
 # beamer
 *.nav
 *.pre


### PR DESCRIPTION
This PR is proposing to add `*.atfi` to `TeX.gitignore` for package _attachfile2_.

**Reasons for making this change:**
`*.atfi` is an auxiliary file generated by _attachfile2_ package

**Links to documentation supporting these rule changes:** 
[https://ctan.org/pkg/attachfile2?lang=en](https://ctan.org/pkg/attachfile2?lang=en)

**If this is a new template:**
Not a new template.