### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -10,6 +10,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+*.log
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data


### PR DESCRIPTION
### Reasons for making this change

.log files sometimes generate in the root dir.

### Links to documentation supporting these rule changes

Java compile errors for android usually store log files in the root dir.

### Merge and Approval Steps
- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
