### PR TITLE
Add Dotter.gitnore

### DIFF
--- a/community/Dotter.gitignore
+++ b/community/Dotter.gitignore
@@ -1,0 +1,6 @@
+# local files are for host-specific overrides
+.dotter/local.toml
+
+# ignore caches
+.dotter/cache.toml
+.dotter/cache


### PR DESCRIPTION
### Reasons for making this change

[Dotter][https://github.com/SuperCuber/dotter] is a dotfiles manager tool written in Rust.
Its setup guide recommends ignoring local override files and the default cache files.

### Links to documentation supporting these rule changes

https://github.com/SuperCuber/dotter/wiki/Setup-and-Configuration

### If this is a new template

Link to application or project’s homepage: https://github.com/SuperCuber/dotter

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
