### PR TITLE
Remove /bin from Eclipse IDE.

### DIFF
--- a/Global/Eclipse.gitignore
+++ b/Global/Eclipse.gitignore
@@ -1,5 +1,4 @@
 .metadata
-bin/
 tmp/
 *.tmp
 *.bak


### PR DESCRIPTION
### Reasons for making this change

Many PHP/Composer tool packages include a **bin** folder for their functionality... This .gitignore entry ensures that these folders are ignored, preventing them from being tracked in version control. As a result, they will not be included in remote repositories.

So I THINK this entry should be removed., if Eclipse IDE used as editor for PHP projects.

### Links to documentation supporting these rule changes
Projects/Packages that have **bin** folder:

https://github.com/squizlabs/PHP_CodeSniffer
https://github.com/overtrue/phplint
https://github.com/laravel/installer
etc...

### If this is a new template


### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
