### PR TITLE
Add nomedia file to Godot.gitignore

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,5 +1,6 @@
 # Godot 4+ specific ignores
 .godot/
+.nomedia
 
 # Godot-specific ignores
 .import/


### PR DESCRIPTION
### Reasons for making this change

`.nomedia` files are automatically created after PR https://github.com/godotengine/godot/pull/104970. This file is only needed for Android Editor and automatically generated if missing. There's no need to add this to version control.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
