### PR TITLE
Updated NCrunch cache path for v4.16+

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -153,6 +153,7 @@ coverage*.info
 
 # NCrunch
 _NCrunch_*
+.NCrunch_*
 .*crunch*.local.xml
 nCrunchTemp_*
 


### PR DESCRIPTION
### Reasons for making this change

NCrunch updated the default location of the cache storage directory in version 4.16

### Links to documentation supporting these rule changes

> "Adjusted the default path for NCrunch's cache storage directory so that this now starts with a period instead of an underscore. For example, '_NCrunch_Solution' will now be '.NCrunch_Solution'. Solutions using the old path will continue to use the old path unless this is manually renamed. This change has been made to prevent VS from automatically including the files from NCrunch's cache storage directory in projects that may be stored adjacent to the solution file."
> https://www.ncrunch.net/download/showChangeLog?version=4.16
> 

### If this is a new template
Not a new template

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
