### PR TITLE
feat: Add .vscode directory to Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -27,6 +27,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Visual Studio Code configure directory
+.vscode/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
### Reasons for making this change

Visual Studio Code (VS Code) is a popular alternative IDE for Unity development alongside Visual Studio. The `.vscode` directory typically contains user-specific workspace settings, configurations (like `settings.json`, `tasks.json`, `launch.json`), recommended extensions (`extensions.json`), and sometimes temporary files or build artifacts generated by VS Code extensions (e.g., C# extension).

These files are specific to a developer's local environment and editor setup. Committing them to version control can lead to:

*   Unnecessary merge conflicts.
*   Cluttering the repository history.
*   Overwriting other developers' local settings.

Adding `.vscode/` ensures these editor-specific files are ignored by default, promoting a cleaner repository for teams and individuals who choose to use VS Code for their Unity projects. This aligns with the common practice of ignoring IDE-specific configuration directories.


### Links to documentation supporting these rule changes

[Unity Development with VS Code](https://code.visualstudio.com/docs/other/unity)
[Visual Studio Code Editor](https://docs.unity3d.com/2022.3/Documentation/Manual/com.unity.ide.vscode.html)
[Visual Studio and VScode, which one is better for Unity? - Unity Engine - Unity Discussions](https://discussions.unity.com/t/visual-studio-and-vscode-which-one-is-better-for-unity/874323)

### Merge and Approval Steps
- [x] ~~Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns~~
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
