### PR TITLE
chore(links): replace URLs with HTTPS for better security

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ the following resources are a great place to start:
 - The [Ignoring Files article][help] on the GitHub Help site.
 - The [gitignore(5)][man] manual page.
 
-[man]: http://git-scm.com/docs/gitignore
+[man]: https://git-scm.com/docs/gitignore
 [help]: https://help.github.com/articles/ignoring-files
 [chapter]: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
-[progit]: http://git-scm.com/book
+[progit]: https://git-scm.com/book
 
 ## Folder structure
 


### PR DESCRIPTION
### Reasons for making this change
URLs to "http://git-scm.com/book" can be upgraded to "https" for better security and a safer browsing experience. This small tweak makes the web a little more secure 😎


<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

N/A

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

N/A

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
