### PR TITLE
Ignore all .terraform directories

### DIFF
--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -1,5 +1,5 @@
 # Local .terraform directories
-**/.terraform/*
+.terraform/
 
 # .tfstate files
 *.tfstate


### PR DESCRIPTION
Changes to using the `foo/` trailing separator naming pattern to ensure that the directory itself will be ignored at all depths.

### Reasons for making this change

The current pattern ignores files inside the directory, but not the directory itself. This change makes it so the directory itself is ignored, and as a bonus, is cleaner as well.

### Links to documentation supporting these rule changes

I got my inspiration from the [Python.gitignore template](https://github.com/github/gitignore/blob/main/Python.gitignore) in this repository; it ignores the "\_\_pycache\_\_" directory (and others) by using the trailing separator method as well.

### Merge and Approval Steps
- [X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
