### PR TITLE
Add .gitignore template for Solidity + Remix

### DIFF
--- a/Solidity-Remix.gitignore
+++ b/Solidity-Remix.gitignore
@@ -1,0 +1,15 @@
+# Remix compiler artifacts
+**/artifacts/
+**/artifacts/**
+
+# Remix plugin state folders
+deps/
+states/
+
+# Debug info
+*.dbg.json
+*.tsbuildinfo
+
+# Optional
+.env
+.env.local


### PR DESCRIPTION
### Reasons for making this change

Remix IDE is widely used for writing and deploying Solidity smart contracts directly from the browser. When syncing with GitHub or compiling, it automatically creates `artifacts/`, `deps/`, and `states/` directories in each source folder.

These are **Remix-specific build and state folders**, not meant to be committed to Git repositories. This template ensures Solidity developers using Remix have a clean repository, ignoring generated folders that only Remix understands.

### Links to documentation supporting these rule changes

- https://remix-ide.readthedocs.io/en/latest/import.html
- https://github.com/ethereum/remix-project
- https://remix.ethereum.org

You can also observe these folders being generated automatically when importing Solidity files and compiling in Remix IDE.

### If this is a new template

Link to application or project’s homepage: https://remix.ethereum.org

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers

