### PR TITLE
Add CC-BY-NC-ND 4.0 global .gitignore template

### DIFF
--- a/gitignore
+++ b/gitignore
@@ -1,0 +1,37 @@
+# Ignore macOS system files
+.DS_Store
+
+# Ignore Windows thumbnail cache
+Thumbs.db
+
+# Node.js dependencies
+node_modules/
+
+# Python bytecode and environments
+__pycache__/
+*.py[cod]
+*.env
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+
+# Build output directories
+dist/
+build/
+
+# Environment files
+.env
+.env.local
+
+# IDE and editor folders
+.vscode/
+.idea/
+
+# Miscellaneous
+*.tmp
+*.swp
+
+# Exception: track your LICENSE file
+!LICENSE


### PR DESCRIPTION
### What’s changed
• Introduce a brand-new global `.gitignore` template  
  optimized for projects licensed under CC-BY-NC-ND 4.0.  
• Covers OS files, editors, common build/output dirs, logs, env files, etc.  

### Why this matters
For CC-BY-NC-ND projects you often still need a sane ignore list.  
This prevents committing temp files, credentials, binaries, and IDE cruft.  

### How to use
Place the file at the root of your repository and name it `.gitignore`.  
No further configuration needed—Git will automatically exclude the listed patterns.

**License:** CC-BY-NC-ND 4.0  
**Original author:** Luka Pejić
