### PR TITLE
add .ansible/ folder to ansible.gitignore

### DIFF
--- a/Global/Ansible.gitignore
+++ b/Global/Ansible.gitignore
@@ -1,1 +1,2 @@
 *.retry
+.ansible/


### PR DESCRIPTION
Reasons for making this change

Ansible  temporary files in the .ansible/ directory. These files should not be committed to version control to avoid unnecessary repository clutter.

Links to documentation supporting these rule changes
	•	[Ansible Configuration - Local Cache](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-local-tmp)

If this is a new template

Link to application or project’s homepage: https://www.ansible.com/