### PR TITLE
feat(LangChain.gitignore): ignore LangGraph

### DIFF
--- a/LangChain.gitignore
+++ b/LangChain.gitignore
@@ -1,0 +1,6 @@
+# gitignore template for LangChain products, e.g., LangGraph, LangSmith
+# website: https://www.langchain.com/
+# website: https://www.langchain.com/langgraph
+
+# LangGraph
+.langgraph_api/


### PR DESCRIPTION
### Reasons for making this change

The LangGraph CLI generates checkpoints and other pickle files locally that do not need to be committed to the repo. 

<img width="488" alt="Screenshot 2025-04-30 at 9 17 59 AM" src="https://github.com/user-attachments/assets/925740fa-771d-46f8-9970-e88e6bb75b46" />

### Links to documentation supporting these rule changes

- [LangGraph CLI](https://langchain-ai.github.io/langgraph/cloud/reference/cli/?h=langgraph_api)
- [LangGraph .gitignore](https://github.com/langchain-ai/langgraph/blob/main/.gitignore)

### If this is a new template

- [LangGraph docs](https://langchain-ai.github.io/langgraph/)

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing - **How do I do this?**
- [ ] Get a review and Approval from one of the maintainers - *Pending...*