### PR TITLE
Add .aws-sam/ to VisualStudio.gitignore to ignore AWS SAM build artifacts

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -355,6 +355,9 @@ ASALocalRun/
 # MSBuild Binary and Structured Log
 *.binlog
 
+# AWS SAM Build and Temporary Artifacts folder
+.aws-sam
+
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 


### PR DESCRIPTION
### Reasons for making this change

This pull request adds the .aws-sam/ directory to the VisualStudio.gitignore file.

The .aws-sam/ folder is generated by the [AWS Serverless Application Model (SAM)](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) during local builds and deployments. It typically contains build artifacts and intermediate files that should not be committed to source control.

Adding this path helps developers using AWS SAM with .NET projects avoid accidentally including build output in their Git repositories.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
