### PR TITLE
Add Cursor AI rule files (.cursorrules, .cursor/rules) to gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -172,3 +172,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Cursor
+#  Cursor is a code editor integrated with LLM. `.cursorrules` is its project-level configuration file, 
+#  refer to https://docs.cursor.com/context/rules, which is used to customize the code generation rules of AI
+.cursorrules
+.cursor/rules


### PR DESCRIPTION
Reasons for making this change

Cursor's `.cursorrules` and `.cursor/rules` files contain critical AI context definitions that:
1. Standardize AI-generated code - Enforce project-specific patterns, architecture constraints, and security rules
2. Maintain team consistency - Preserve approved LLM behaviors across all contributors
3. Prevent accidental leakage - Avoid exposing sensitive AI prompt templates or model context
These are developer-environment artifacts (not build outputs) that should remain local like `.vscode/`.

Links to documentation supporting these rule changes

1. Official Cursor docs:  
   [Rules Configuration Guide](https://docs.cursor.com/context/rules)  
   [Cursor Website](https://www.cursor.com)