### PR TITLE
Add Cursor editor ignore files to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -173,8 +173,9 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-# Cursor
-#  Cursor is a code editor integrated with LLM. `.cursorrules` is its project-level configuration file, 
-#  refer to https://docs.cursor.com/context/rules, which is used to customize the code generation rules of AI
-.cursorrules
-.cursor/rules
+# Cursor  
+#  Cursor is an AI-powered code editor.`.cursorignore` specifies files/directories to 
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -172,3 +172,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Cursor
+#  Cursor is a code editor integrated with LLM. `.cursorrules` is its project-level configuration file, 
+#  refer to https://docs.cursor.com/context/rules, which is used to customize the code generation rules of AI
+.cursorrules
+.cursor/rules


### PR DESCRIPTION
### Reasons for making this change

This change adds `.cursorignore` and `.cursorindexingignore` to Python.gitignore because:

1. Security Protection  
   These files commonly contain references to sensitive paths (`.env`, `config/secrets/`, local debug files) that should never be committed. Unlike `.gitignore`, they're designed for editor-specific exclusions.

2. Editor Ecosystem Standard  
   Cursor (an AI-powered editor growing in Python development) follows VS Code's ignore handling paradigm. We already ignore similar editor files (`.vscode/`, `.idea/`).

3. Dual-Purpose Ignore Files  
   • `.cursorignore`: User-specific patterns (equivalent to personal `.gitignore`)  

   • `.cursorindexingignore`: Controls AI feature access (prevents analysis of generated code/assets)  

### Links to documentation supporting these rule changes

1. Official Cursor ignore file documentation:  
   https://docs.cursor.com/context/ignore-files  
2. Official Cursor suggestion to exclude:  
   https://docs.cursor.com/context/codebase-indexing
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/f341d3c9-ea4f-44a4-840a-ef827235472b" />



### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers