### PR TITLE
Configure stalebot in dry-run mode

### DIFF
--- a/.github/workflow/stale.yml
+++ b/.github/workflow/stale.yml
@@ -1,0 +1,32 @@
+name: Stale
+
+# **What it does**: Close pull requests after no updates for 180 days.
+# **Why we have it**: This repository gets a lot of PRs, and the maintainers team is small.
+#                     This helps reduce the open PRs to ones that are most desired by the community.
+# **Who does it impact**: Contributors and maintainers of github/gitignore.
+
+on:
+  schedule:
+    - cron: '20 16 * * *' # Run every day at 16:20 UTC / 8:20 PST
+
+permissions:
+  actions: write
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          stale-pr-message: 'This PR is stale because there have been no updates in 90 days. It will close after 180 days of inactivity. Leave a comment if you want to keep it open :smile:'
+          close-pr-message: 'This PR has been closed because it was inactive for 180 days. If you want to continue working on it, please open a new PR.'
+          days-before-stale: 90
+          days-before-close: 180
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'keep'
+          close-issue-reason: not_planned
+          ascending: true # Sort PRs by last updated date in ascending order
+          debug-only: true # Set to true to test the action without actually closing any PRs


### PR DESCRIPTION
@github/gitignore-maintainers is having trouble identifying active/desirable PRs to review. With the backlog of open PRs nearing 500, we've decided to configure stalebot in a permissive manner to help us identify the PRs that the community wants the most.

For now, this is configured to run daily in "dry-run" mode. We intend to take it out of dry-run mode and post a Discussion for feedback next week 🙂 