### PR TITLE
Restore trailing newline in Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -173,8 +173,8 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-# Cursor  
-#  Cursor is an AI-powered code editor.`.cursorignore` specifies files/directories to 
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
 #  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore


### PR DESCRIPTION
### Reasons for making this change
@covracer spotted this where I missed it in https://github.com/github/gitignore/pull/4633

### Links to documentation supporting these rule changes
N/A just formatting changes

### If this is a new template

N/A

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
