### PR TITLE
Run stale workflow without debug-only mode

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,3 @@ jobs:
           exempt-pr-labels: 'keep'
           close-issue-reason: not_planned
           ascending: true # Sort PRs by last updated date in ascending order
-          debug-only: true # Set to true to test the action without actually closing any PRs


### PR DESCRIPTION
### Reasons for making this change

Removing the stale workflow's `debug-only` setting so that it will start processing PRs.

The debug-only runs were processing the oldest 9 PRs before hitting the operation limit. I believe this will be a reasonable number for us to monitor for now.

### Merge and Approval Steps
- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
