### PR TITLE
Add dedicated Cursor.gitignore template for Cursor AI editor exclusions

### DIFF
--- a/Global/Cursor.gitignore
+++ b/Global/Cursor.gitignore
@@ -1,0 +1,3 @@
+.vscode/*
+.cursorignore
+.cursorindexingignore

--- a/Global/Cursor.gitignore
+++ b/Global/Cursor.gitignore
@@ -1,3 +1,2 @@
-.vscode/*
 .cursorignore
 .cursorindexingignore


### PR DESCRIPTION
Description:  

This PR introduces a standalone `Cursor.gitignore` template to centralize exclusion rules for [Cursor](https://cursor.com), an AI-powered editor with cross-language adoption (beyond Python).  

**Why a Dedicated Template?**  
1. Broader Scope Than Python  
   • Unlike [PR4633](https://github.com/github/gitignore/pull/4633) (which focused on Python-specific ignores), this template covers *all languages* where Cursor is used (JavaScript, Go, Rust, etc.).  

   • Cursor’s AI features (e.g., codebase indexing) require consistent ignore rules across ecosystems.  


2. Editor-Specific Security Needs  
   • `.cursorignore` often contains user/team-specific paths (e.g., `local_dev/`, `*.env.local`).  

   • `.cursorindexingignore` restricts AI analysis of sensitive directories (e.g., `node_modules/`, `vendor/`).  


3. Precedent for Editor-Specific Templates  
   • Similar to `Global/JetBrains.gitignore` and `Global/VisualStudioCode.gitignore`, this follows GitHub’s pattern for editor-agnostic rules.  


**Key Differences from Previous PR**  
| Feature               | Previous PR (#PR_NUMBER)       | This PR                          |  
|-----------------------|--------------------------------|----------------------------------|  
| Scope             | Python-only                   | All languages                   |  
| File Location     | `Python.gitignore`            | `Global/Cursor.gitignore`       |  
| Use Case         | Python project hygiene        | Cross-editor team collaboration |  

**Documentation & Validation**  
• Official Cursor Docs: [Ignore Files](https://docs.cursor.com/context/ignore-files) | [Indexing Guide](https://docs.cursor.com/context/codebase-indexing)  

• Screenshot: Default Cursor ignore behavior:  

  ![Example](https://github.com/user-attachments/assets/f341d3c9-ea4f-44a4-840a-ef827235472b)  


**Checklist**  
• [x] Verified no overlap with existing global templates.  

• [x] Confirmed compliance with [contribution guidelines](https://github.com/github/gitignore/blob/main/CONTRIBUTING.md).  

• [ ] Awaiting CI validation.  


---
