### PR TITLE
Zig.gitignore add *.o

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,2 +1,3 @@
 .zig-cache/
 zig-out/
+*.o


### PR DESCRIPTION



### Reasons for making this change


If you run `zig build-exe myfile.zig` it will generate myfile.o in addition to the executable in the current directory. I think those should be ignored even though they are usually in the zig-out directory if you use the proper build system.

$ zig version
0.14.1

### Links to documentation supporting these rule changes

https://ziglang.org/learn/build-system/


### Merge and Approval Steps
- [*] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
