### PR TITLE
fixes spelling for word `entire` in Python.gitignore in the VS Code section

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -177,7 +177,7 @@ cython_debug/
 #  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#  you could uncomment the following to ignore the enitre vscode folder
+#  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
 # Ruff stuff:


### PR DESCRIPTION
### Reasons for making this change

`entire` was spelled `enitre`

### Links to documentation supporting these rule changes

https://www.merriam-webster.com/dictionary/entire

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
