### PR TITLE
Add poetry.toml to Python.gitignore (optional Poetry config file)

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -106,6 +106,7 @@ ipython_config.py
 #   commonly ignored for libraries.
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
+#poetry.toml
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.


### PR DESCRIPTION
### Reasons for making this change

This change adds `.poetry.toml` to the Python `.gitignore` file.

`.poetry.toml` is a configuration file used by [Poetry](https://python-poetry.org/), a widely adopted dependency management and packaging tool in the Python ecosystem. While `.poetry.toml` is typically used for local configuration (e.g. virtualenv location or group settings), it often contains machine-specific paths and preferences that should not be committed to version control. This makes it a good candidate for inclusion in `.gitignore`.

The change follows the convention already applied in the template for similar tools like Pipenv and PDM, where their lock/config files are commented out or ignored based on user/project preference.

### Links to documentation supporting these rule changes

- [Poetry configuration documentation](https://python-poetry.org/docs/configuration/#file-location)
- [Example `.poetry.toml` file in Poetry documentation](https://python-poetry.org/docs/configuration/)
- [Discussion on excluding `.poetry.toml` in real-world repositories](https://github.com/python-poetry/poetry/issues/4167)

### If this is a new template

_Not a new template; this is a change to the existing Python template._

### Merge and Approval Steps

- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns  
- [x] Ensure CI is passing  
- [ ] Get a review and approval from one of the maintainers
