### PR TITLE
Create Expo.gitignore

### DIFF
--- a/community/JavaScript/Expo.gitignore
+++ b/community/JavaScript/Expo.gitignore
@@ -21,9 +21,6 @@ node_modules/
 *.tmp              # temp files created during bundling
 *.log              # build or Metro logs
 
-# macOS system files
-.DS_Store
-
 # Environment variables
 .env
 .env.local

--- a/community/JavaScript/Expo.gitignore
+++ b/community/JavaScript/Expo.gitignore
@@ -1,0 +1,35 @@
+# .gitignore template for Expo
+# website: https://expo.dev/
+# docs: https://docs.expo.dev/workflow/expo-cli/
+#
+# Rationale:
+# node_modules/ is always ignored
+# .expo/, .expo-shared/ are Expo’s local state and project-settings cache (see docs)
+#  Metro caches/logs are *.expo, *.tunnel, *.cache, *.tmp, *.log
+
+# Node modules
+node_modules/
+
+# Expo local state and caches
+.expo/             # runtime state (Metro bundler, dev-client data, tunnels)
+.expo-shared/      # shared project settings (app.json edits, etc.)
+
+# Metro bundler caches/logs
+*.expo             # generic Expo temp files
+*.tunnel           # Expo DevTools tunnels
+*.cache            # Metro cache folder
+*.tmp              # temp files created during bundling
+*.log              # build or Metro logs
+
+# macOS system files
+.DS_Store
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Package manager logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
### Reasons for making this change

_adding expo specific .gitignore helps new and existing expo projects avoid accidentally committing generated caches, local state, and logs. In expo's managed workflow, several directories like .expo/, .expo-shared/ and temporary files are created at runtime or during bundling, and none of these should be versioned._
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

_https://docs.expo.dev/workflow/expo-cli/#configuration describes the purpose of .expo/ and .expo-shared/ as runtime caches and project settings._

_https://docs.expo.dev/bare/using-expo-client/#metro-bundler explains where Metro stores cache files, temp bundles, and logs_

also, see the official:
_https://github.com/expo/expo/blob/main/.gitignore_

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: https://expo.dev/


### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
