### PR TITLE
Increase stale operations per run to 300

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,3 +29,4 @@ jobs:
           exempt-pr-labels: 'keep'
           close-issue-reason: not_planned
           ascending: true # Sort PRs by last updated date in ascending order
+          operations-per-run: 300


### PR DESCRIPTION
Increasing the stale operations per run to 300 (from the default of 30) so that folks get feedback quicker after commenting on their PRs.

Right now it could take close to a month from the time someone gets the stale label for it to be auto-removed due to activity.