### PR TITLE
Add TestFramework and fix Addressables in Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -74,12 +74,18 @@ mono_crash.*
 # Crashlytics generated file
 crashlytics-build.properties
 
-# Packed Addressables
-/[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/*/*.bin*
+# TestRunner generated files
+InitTestScene*.unity*
 
-# Temporary auto-generated Android Assets
-/[Aa]ssets/[Ss]treamingAssets/aa.meta
-/[Aa]ssets/[Ss]treamingAssets/aa/*
+# Addressables default ignores, before user customizations
+/ServerData
+/[Aa]ssets/StreamingAssets/aa*
+/[Aa]ssets/AddressableAssetsData/link.xml*
+/[Aa]ssets/Addressables_Temp*
+# By default, Addressables content builds will generate addressables_content_state.bin
+# files in platform-specific subfolders, for example:
+# /Assets/AddressableAssetsData/OSX/addressables_content_state.bin
+/[Aa]ssets/AddressableAssetsData/*/*.bin*
 
 # Visual Scripting auto-generated files
 /[Aa]ssets/Unity.VisualScripting.Generated/VisualScripting.Flow/UnitOptions.db


### PR DESCRIPTION
### Reasons for making this change

This was originally a [3+ year old PR](https://github.com/github/gitignore/pull/4118) that I'd accidentally closed while trying to update.

* Add more complete Addressables ignores (e.g. `ServerData`, `link.xml`)
* Fix incorrect comment about Android Assets (`aa` refers to Addressable Assets)
* Add auto-generated `InitTestScene*` files from Unity's Test Framework

### Links to documentation supporting these rule changes

Official Unity packages do not perfectly document their ignorable files, unfortunately.

* Addressables artifacts: [doc link](https://docs.unity3d.com/Packages/com.unity.addressables@2.6/manual/build-artifacts-included.html)
* Test Framework `InitTestScene*` artifacts: [forum link](https://discussions.unity.com/t/scene-testing/719799)

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
