### PR TITLE
Update JetBrains.gitignore to ignore Apifox Helper cache folders

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -76,3 +76,7 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Apifox Helper cache
+.idea/.cache/.Apifox_Helper
+.idea/ApifoxUploaderProjectSetting.xml


### PR DESCRIPTION
### Reasons for making this change

The [[Apifox](https://www.apifox.cn/)](https://www.apifox.cn) JetBrains plugin generates cache files under the `.idea/` directory, including:

* `.idea/.cache/.Apifox_Helper`
* `.idea/ApifoxUploaderProjectSetting.xml`

These files are automatically generated and store plugin-specific state, such as temporary upload settings and runtime cache. They are not useful for version control and may cause unnecessary diffs or conflicts when shared across different developer environments.

Adding these entries helps keep repositories clean and IDE-independent.

### Links to documentation supporting these rule changes

* [[Apifox Official Website](https://www.apifox.cn/)](https://www.apifox.cn)
* [[Apifox Helper Plugin on JetBrains Marketplace](https://plugins.jetbrains.com/plugin/20549-apifox-helper)](https://plugins.jetbrains.com/plugin/20549-apifox-helper)
* Verified behavior via JetBrains IDE with Apifox Helper Plugin installed
* Consistent with existing `.idea/` ignore patterns in `JetBrains.gitignore`

### If this is a new template

N/A

