### PR TITLE
Ignore marimo cache in Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -193,3 +193,8 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/


### PR DESCRIPTION
### Reasons for making this change

Marimo is an [open-source](https://github.com/marimo-team/marimo) reactive notebook for Python — reproducible, git-friendly, SQL built-in, executable as a script, and shareable as an app.
As of writing this script, it has over 13.8k starts on Github and growing.

### Links to documentation supporting these rule changes

This [link](https://github.com/marimo-team/marimo/blob/main/.gitignore) to the `.gitignore` file in the project itself contains all the files that are added by this PR to `.gitignore`.

### Explain why you’re making a change
With the growing number of users that are adapting marimo as a replacement for ipython-notebook, ignoring these caching directories can help with proper versioning and less clutter between commits.

### Merge and Approval Steps
- [X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [X] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
