### PR TITLE
Create Nestjs.gitignore

### DIFF
--- a/Nestjs.gitignore
+++ b/Nestjs.gitignore
@@ -1,0 +1,24 @@
+# Nestjs specific
+/dist
+/node_modules
+/build
+/tmp
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# dotenv environment variable files
+.env
+.env.development
+.env.test
+.env.production
+
+# temp directory
+.temp
+.tmp


### PR DESCRIPTION
### **Reasons for making this change**  
This PR introduces a `.gitignore` file tailored for NestJS projects to exclude unnecessary or sensitive files (e.g., build artifacts, logs, env files) from version control.  

**Changes Included**  
1. **NestJS-Specific Ignore Rules**:  
   - Build/output directories (`/dist`, `/build`, `/tmp`)  
   - Dependency folders (`/node_modules`)  
2. **Common Exclusions**:  
   - Log files (`*.log`, `npm-debug.log*`, etc.)  
   - Environment files (`.env`, `.env.*`)  
   - Temporary directories (`.temp`, `.tmp`)   

### **Links to documentation supporting these rule changes**  
- **NestJS Project Structure**: Official docs recommend excluding `/dist` and `.env` files ([NestJS Deployment Docs](https://docs.nestjs.com/techniques/configuration)).  
- **GitHub’s Node.gitignore**: Similar patterns for Node.js projects ([Reference](https://github.com/github/gitignore/blob/main/Node.gitignore)).  
