### PR TITLE
Update documentation link for pdm, use recommended includes/excludes

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -110,11 +110,10 @@ ipython_config.py
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
 #pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
+#pdm.toml
 .pdm-python
 .pdm-build/
 


### PR DESCRIPTION
Update deeplink to PDM's documentation surrounding including / excluding files. Documentation also slightly contradicts current ignored files, it recommends to **in**clude project-local configuration in `pdm.toml` (not `.pdm.toml`).

### Reasons for making this change

After using this ignore-file, I noticed it mentioned `.pdm.toml`, while my local `pdm` created `pdm.toml`.
Looking up the difference, noticed that the included / excluded files didn't match the recommendations in the project's documentation.

### Links to documentation supporting these rule changes
- [Domain used for the configuration linked from the project's README](https://github.com/pdm-project/pdm);
- [Name of configuration file for project-local configuration](https://pdm-project.org/en/latest/usage/config/#configure-the-project);
- [Recommendations for working with version control](https://pdm-project.org/en/latest/usage/project/#working-with-version-control);

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
