### PR TITLE
Update R.gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -47,3 +47,19 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
+
+# renv dependency management
+renv/
+.renvignore
+!renv/activate.R
+
+# Quarto 
+.quarto/
+/_site/
+/_book/
+/_output/
+*_files/
+/_extensions/
+/_*.local
+
+/_freeze/

--- a/R.gitignore
+++ b/R.gitignore
@@ -20,6 +20,7 @@
 
 # RStudio files
 .Rproj.user/
+.Rbuildignore
 
 # produced vignettes
 vignettes/*.html
@@ -28,7 +29,7 @@ vignettes/*.pdf
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth
 
-# knitr and R markdown default cache directories
+# Quarto, knitr and R markdown default cache directories
 *_cache/
 /cache/
 
@@ -62,4 +63,6 @@ renv/
 /_extensions/
 /_*.local
 
-/_freeze/
+# **Optional**
+# Depends on if you need others to reproduce your computational environment (https://quarto.org/docs/projects/code-execution.html#using-freeze)
+#/_freeze/


### PR DESCRIPTION
### Reasons for making this change

I've noticed that the current version has not taken the use of [Quarto](https://quarto.org/) or [renv](https://rstudio.github.io/renv/articles/renv.html) ignore rules into consideration. The file is also missing the [RStudio](https://posit.co/download/rstudio-desktop/) project file `.Rbuildignore`.

Both Quarto and renv create cache and/or library directories that should not be checked in to git.

### Links to documentation supporting these rule changes

If enabled, Quarto creates a `_freeze` directory that stores computations to reduce the need to re-compute code. Users may or may not want to add this to their `.gitignore` files depending on if you need others to reproduce your computational environment ([source](https://quarto.org/docs/projects/code-execution.html#using-freeze)). 
- Quarto *should* automatically add `.local` to your `.gitignore` to ensure that `.local` files are not committed ([source](https://quarto.org/docs/projects/quarto-projects.html#local-config)), but to be better safe than sorry I have added a pattern for this.
- Output directories can be ignored ([source](https://quarto.org/docs/publishing/github-pages.html#ignoring-output)).
- `renv` and `.renvignore` but not `renv/activate.R` ([source](https://rstudio.github.io/renv/articles/renv.html#collaboration))
- `.Rbuildignore` is missing from the RStudio patterns

### Merge and Approval Steps

- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers