### PR TITLE
Update VisualStudio.gitignore - remove *.vbp extension

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -310,9 +310,6 @@ node_modules/
 # Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
 *.vbw
 
-# Visual Studio 6 auto-generated project file (contains which files were open etc.)
-*.vbp
-
 # Visual Studio 6 workspace and project file (working project files containing files to include in project)
 *.dsw
 *.dsp


### PR DESCRIPTION
Remove *.vbp extension.

### Reasons for making this change

Such files are the main Visual Basic 6 Project Files and should not be ignored. It's like ignoring .csproj or .vbproj files in .NET projects.

### Links to documentation supporting these rule changes

https://www.google.com/search?q=what+are+.vbp+files

### If this is a new template

### Merge and Approval Steps
- [X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
