### PR TITLE
Remove Cursor files from Python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -194,13 +194,6 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-# Cursor
-#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
-#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
-#  refer to https://docs.cursor.com/context/ignore-files
-.cursorignore
-.cursorindexingignore
-
 # Marimo
 marimo/_static/
 marimo/_lsp/


### PR DESCRIPTION
This reverts commit 9cabb94d2ac2ce0884a114d45683d9be9a45080c.

### Reasons for making this change

https://github.com/github/gitignore/pull/4633 was a bad change. Cursor rules belong in a global gitignore file, and were added to one in https://github.com/github/gitignore/pull/4639.

### Links to documentation supporting these rule changes

https://github.com/github/gitignore/pull/4633

### Merge and Approval Steps

- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers