### PR TITLE
Add sveltekit build and dist

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -95,8 +95,10 @@ dist
 .temp
 .cache
 
-# Sveltekit cache directory
+# Sveltekit cache and build directories
 .svelte-kit/
+build/
+dist/
 
 # vitepress build output
 **/.vitepress/dist


### PR DESCRIPTION
### Reasons for making this change

This update excludes the `dist/` and `build/` directories from version control.

Why:
- `build/`: This folder is generated when running vite build in SvelteKit apps. It’s a temporary output used for deployment and doesn’t need to be tracked in Git.
- `dist/`: This is commonly used in Svelte libraries or packages as the output directory for compiled code. Like build/, it’s a generated artifact and should not be committed.

Tracking these folders can cause unnecessary noise in the repository, potential merge conflicts, and confusion over what’s source vs. what’s generated.

These directories should be reproducible from source using build commands (pnpm build, turbo build, etc.), so there’s no need to keep them in version control.

### Links to documentation supporting these rule changes

- https://svelte.dev/docs/kit/building-your-app
- https://svelte.dev/docs/kit/packaging

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers