### PR TITLE
Update Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -137,3 +137,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Vite-specific
+.vite/
+.env*.local

--- a/Node.gitignore
+++ b/Node.gitignore
@@ -134,10 +134,7 @@ dist
 !.yarn/sdks
 !.yarn/versions
 
-# Vite logs files
+# Vite files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
-
-# Vite-specific
 .vite/
-.env*.local


### PR DESCRIPTION
# Add Vite-specific entries to Node.gitignore

## Reasons for making this change

Vite is a popular frontend build tool frequently used with frameworks like Vue, React, and Svelte. While many of its common patterns are already covered in the `Node.gitignore` file (such as `dist/`, `.cache`, `.env.*`), a few Vite-specific entries are not yet included.

This change adds:

- `.vite/` — the directory used by Vite for development cache  
- `.env*.local` — common in Vite projects for local environment overrides

This follows feedback from @wirecat on [PR #4680](https://github.com/github/gitignore/pull/4680), recommending that Vite-related rules be integrated into `Node.gitignore` instead of creating a new Vite-specific template.

## Links to documentation supporting these rule changes

- Vite cache directory: https://vitejs.dev/config/shared-options.html#cachedir  
- Environment variable handling: https://12factor.net/config  
- Vite project homepage: https://vitejs.dev/

## If this is a new template

_Not applicable. This is an update to an existing template._

## Merge and Approval Steps

- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and approval from one of the maintainers
