### PR TITLE
Update macOS.gitignore

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -4,10 +4,10 @@
 .LSOverride
 Icon[]
 
-# Thumbnails
+# Resource forks
 ._*
 
-# Files that might appear in the root of a volume
+# Files and directories that might appear in the root of a volume
 .DocumentRevisions-V100
 .fseventsd
 .Spotlight-V100

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -43,3 +43,9 @@ TheVolumeSettingsFolder
 .quota.user
 .quota.ops.group
 .quota.ops.user
+
+# TimeMachine
+Backups.backupdb
+.MobileBackups
+.MobileBackups.trash
+MobileBackups.trash

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -50,3 +50,4 @@ Backups.backupdb
 .MobileBackups
 .MobileBackups.trash
 MobileBackups.trash
+tmbootpicker.efi

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -21,6 +21,7 @@ Icon[]
 .hotfiles.btree
 .vol
 .file
+.disk_label*
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -22,6 +22,7 @@ Icon[]
 .vol
 .file
 .disk_label*
+lost+found
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -18,6 +18,7 @@ Icon[]
 .com.apple.timemachine.supported
 .PKInstallSandboxManager
 .PKInstallSandboxManager-SystemSoftware
+.hotfiles.btree
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -35,3 +35,9 @@ TheVolumeSettingsFolder
 .FBCIndex
 .FBCSemaphoreFile
 .FBCLockFolder
+
+# Quota system
+.quota.group
+.quota.user
+.quota.ops.group
+.quota.ops.user

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -19,6 +19,8 @@ Icon[]
 .PKInstallSandboxManager
 .PKInstallSandboxManager-SystemSoftware
 .hotfiles.btree
+.vol
+.file
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -16,6 +16,8 @@ Icon[]
 .VolumeIcon.icns
 .com.apple.timemachine.donotpresent
 .com.apple.timemachine.supported
+.PKInstallSandboxManager
+.PKInstallSandboxManager-SystemSoftware
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -15,6 +15,7 @@ Icon[]
 .Trashes
 .VolumeIcon.icns
 .com.apple.timemachine.donotpresent
+.com.apple.timemachine.supported
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -23,6 +23,7 @@ Icon[]
 .file
 .disk_label*
 lost+found
+.HFS+ Private Directory Data[]
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -22,3 +22,12 @@ Icon[]
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Mac OS 6 to 9
+Desktop DB
+Desktop DF
+TheFindByContentFolder
+TheVolumeSettingsFolder
+.FBCIndex
+.FBCSemaphoreFile
+.FBCLockFolder


### PR DESCRIPTION
### Reasons for making this change

This is a continuation of #2901, to add missing metadata and system files.

Changes I made:

* Fixed/updated links
* Omitted the HFS+ hardlink directories commit (https://github.com/github/gitignore/pull/2901/commits/0b29bbec71f5fde17f5365e2150af562c83383ec)
* Added a commit to ignore `.HFS+ Private Directory Data\r` (one of the rules from the omitted commit) using the same character class notation as for `Icon\r`

### Links to documentation supporting these rule changes

Links are in each commit's description. (There are a few commits without supporting links; while there are lots of links for Stack Exchange/Apple Support Community/Reddit for these, I wasn't able to find any official documentation.)

### If this is a new template

Not a new template.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
