### PR TITLE
Ignore Godot  *.tmp files

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -6,6 +6,7 @@
 .import/
 export.cfg
 export_credentials.cfg
+*.tmp
 
 # Imported translations (automatically generated from CSV files)
 *.translation


### PR DESCRIPTION
### Reasons for making this change
[Godot](https://godotengine.org/) creates a bunch of `*.tmp` files which can be committed by mistake.

It was well described before me and approved even, but never merged:
- #4414 - approved, has conflicts, abandoned
- #4483 - approved, messed with other ignores, closed

### Links to documentation supporting these rule changes
There is a [never ending issue](https://github.com/godotengine/godot/issues/82270) in the Godot repo

