### PR TITLE
feat: support nuxt 4

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -81,6 +81,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+.output
 
 # Gatsby files
 .cache/


### PR DESCRIPTION
### Reasons for making this change

Since version 3, Nuxt.js has changed its output directory from `dist` to `.output` (Now version 4 has been released).

It's helpful to add `.output` to Node.gitignore.

### Links to documentation supporting these rule changes

Nuxt document [here](https://nuxt.com/docs/4.x/api/commands/build).

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
