### PR TITLE
Added files & folders to ignore that are generated by message brokers (python related)

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -65,6 +65,11 @@ db.sqlite3-journal
 instance/
 .webassets-cache
 
+# Redis 
+*.rdb
+*.aof
+*.pid
+
 # Scrapy stuff:
 .scrapy
 

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -65,11 +65,6 @@ db.sqlite3-journal
 instance/
 .webassets-cache
 
-# Redis 
-*.rdb
-*.aof
-*.pid
-
 # Scrapy stuff:
 .scrapy
 
@@ -135,6 +130,19 @@ __pypackages__/
 # Celery stuff
 celerybeat-schedule
 celerybeat.pid
+
+# Redis 
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
 
 # SageMath parsed files
 *.sage.py


### PR DESCRIPTION
### Reasons for making this change

Message brokers like Redis, RabbitMQ, and ActiveMQ generate runtime and persistence files that should be ignored in version control.  

If these files are accidentally committed, they can **interfere** with production servers running these services by **overriding** or **corrupting** the expected runtime state.

<!---
Please provide some background for this change.
--->
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

**Redis:**
https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/#rdb-advantages

**RabbitMQ:**
https://www.cloudamqp.com/blog/rabbitmq-directories-and-files-part-2-data-directory.html
https://www.rabbitmq.com/docs/relocate

**ActiveMQ:**
https://activemq.apache.org/components/classic/documentation/kahadb


<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### Link to application or project’s homepage:
**Redis:**
https://redis.io/

**RabbitMQ:**
https://www.rabbitmq.com/

**ActiveMQ:**
https://activemq.apache.org/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
