### PR TITLE
[Qt/QML] Added .qmlls.ini to ignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -31,6 +31,7 @@ Makefile*
 *build-*
 *.qm
 *.prl
+*.qmlls.ini
 
 # Qt unit tests
 target_wrapper.*


### PR DESCRIPTION

### Reasons for making this change

The **.qmlls.ini** files are auto generated files for qt creator qml language tool.

#### Note from official [documentation](https://doc.qt.io/qt-6/cmake-variable-qt-qml-generate-qmlls-ini.html) 

>> Warning: The files generated by QT_QML_GENERATE_QMLLS_INI are only valid for the current configuration and should be ignored by your version control system. For Git, add **/.qmlls.ini to your top-level project .gitignore, for example. The globbing is required because .qmlls.ini files are generated in all source subdirectories that define QML Modules.

### Links to documentation supporting these rule changes

See documentation [QT_QML_GENERATE_QMLLS_INI](https://doc.qt.io/qt-6/cmake-variable-qt-qml-generate-qmlls-ini.html)


### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
