### PR TITLE
Add .pnpm-store to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -125,6 +125,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# pnpm
+.pnpm-store
+
 # yarn v3
 .pnp.*
 .yarn/*


### PR DESCRIPTION
### Reasons for making this change

Due to current bugs in pnpm, it sometimes creates .pnpm-store directory at project root instead of global pnpm cache dir. Since it's chache, it is not needed in git repo, and it has enormous size, like that of node_modules/

### Links to documentation supporting these rule changes

In [this](https://github.com/DavidWells/pnpm-workspaces-example/blob/master/.gitignore) 51 start repo with pnpm workspace example we can see that .pnpm-store is ignored

Related issues:
<https://github.com/pnpm/pnpm/issues/7050#issuecomment-1998668286>
<https://github.com/gravitational/teleport/issues/46019>
<https://github.com/gravitational/teleport/pull/54701>
<https://github.com/pnpm/pnpm/issues/7100>

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
