### PR TITLE
Added .DS_Store to the files to ignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -201,3 +201,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# MacOS
+.DS_Store


### PR DESCRIPTION
### Reasons for making this change

Using this template on MacOS is adding several useless .DS_Store files to the repositories.


### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
