### PR TITLE
Ignore in-tree pnpm store

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -40,6 +40,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+.pnpm-store/
 
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/


### PR DESCRIPTION
### Reasons for making this change

Under some conditions (when there is no user directory or inside a dev container) the pnpm store is placed inside the source tree.

### Links to documentation supporting these rule changes

https://pnpm.io/settings#store-settings

### If this is a new template

https://pnpm.io

### Merge and Approval Steps
- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
