### PR TITLE
macOS: ignore iCloud placeholders (*.icloud) and .apdisk

### DIFF
--- a/Global/macOS.gitignore
+++ b/Global/macOS.gitignore
@@ -22,3 +22,8 @@ Icon[]
 Network Trash Folder
 Temporary Items
 .apdisk
+# iCloud placeholders
+*.icloud
+
+# Finder metadata on network shares
+.apdisk


### PR DESCRIPTION
This PR adds two common macOS artifacts to Global/macOS.gitignore:

- `*.icloud` — iCloud Drive placeholder files created for items not fully downloaded locally.
- `.apdisk` — Finder metadata files created on SMB/AFP network shares.

Both are user/environment-specific and shouldn't be committed to repositories. No other patterns are changed.
