### PR TITLE
Update VirtualEnv.gitignore

### DIFF
--- a/Global/VirtualEnv.gitignore
+++ b/Global/VirtualEnv.gitignore
@@ -8,5 +8,7 @@
 [Ll]ocal
 [Ss]cripts
 pyvenv.cfg
-.venv
+.venv/
+venv/
+.python-version
 pip-selfcheck.json

--- a/Global/VirtualEnv.gitignore
+++ b/Global/VirtualEnv.gitignore
@@ -1,5 +1,16 @@
 # Virtualenv
 # https://realpython.com/python-virtual-environments-a-primer/#the-virtualenv-project
+.venv/
+venv/
+.python-version
+
+# pyenv: Simple Python Version Management
+pyvenv.cfg
+
+# pip: package installer for Python
+pip-selfcheck.json
+
+# Custom python interpreter
 .Python
 [Bb]in
 [Ii]nclude
@@ -7,8 +18,3 @@
 [Ll]ib64
 [Ll]ocal
 [Ss]cripts
-pyvenv.cfg
-.venv/
-venv/
-.python-version
-pip-selfcheck.json


### PR DESCRIPTION
### Reasons for making this change

Add extra rules

### Links to documentation supporting these rule changes

- .venv -> .venv/ to denote its a directory
- venv/ is also typical, when users prefer to keep the directory visible
- .python-version is a file that defines which python version (or environment in case of using pyenv), ie https://pydevtools.com/handbook/explanation/what-is-a-python-version-file/

### Comments

I think these entries should not be here:
- .Python: looks more of distribution/packaging and present on https://github.com/github/gitignore/blob/main/Global/VirtualEnv.gitignore and i dont think it has anything to do with virtual envs
- [Bb]in, [Ii]nclude, [Ll]ib, [Ll]ib64, [Ll]ocal, [Ss]cripts: this does not seem to have anything to do with python's virtualenv spec. some of these entries might actually conflict with code in projects, ie, bin and scripts
- pip-selfcheck.json: not specific to python virtualenv, but rather python dependencies using pip

Perhaps some of them should be moved to https://github.com/github/gitignore/blob/main/Python.gitignore and some entirely removed