### PR TITLE
Remove trailing whitespace

### DIFF
--- a/GitHubPages.gitignore
+++ b/GitHubPages.gitignore
@@ -11,7 +11,7 @@ _site/
 /vendor
 
 # Specific ignore for GitHub Pages
-# GitHub Pages will always use its own deployed version of pages-gem 
+# GitHub Pages will always use its own deployed version of pages-gem
 # This means GitHub Pages will NOT use your Gemfile.lock and therefore it is
 # counterproductive to check this file into the repository.
 # Details at https://github.com/github/pages-gem/issues/768

--- a/IAR.gitignore
+++ b/IAR.gitignore
@@ -12,24 +12,24 @@
 thumbs.db
 *.~*
 
-# IAR Settings  
-**/settings/*.crun  
-**/settings/*.dbgdt  
-**/settings/*.cspy  
-**/settings/*.cspy.*  
-**/settings/*.xcl  
-**/settings/*.dni  
-**/settings/*.wsdt  
-**/settings/*.wspos  
+# IAR Settings
+**/settings/*.crun
+**/settings/*.dbgdt
+**/settings/*.cspy
+**/settings/*.cspy.*
+**/settings/*.xcl
+**/settings/*.dni
+**/settings/*.wsdt
+**/settings/*.wspos
 
-# IAR Debug Exe  
-**/Exe/*.sim  
+# IAR Debug Exe
+**/Exe/*.sim
 
-# IAR Debug Obj  
-**/Obj/*.pbd  
-**/Obj/*.pbd.*  
-**/Obj/*.pbi  
-**/Obj/*.pbi.*  
+# IAR Debug Obj
+**/Obj/*.pbd
+**/Obj/*.pbd.*
+**/Obj/*.pbi
+**/Obj/*.pbi.*
 
 # IAR project "Debug" directory
 Debug/

--- a/Packer.gitignore
+++ b/Packer.gitignore
@@ -5,9 +5,9 @@ packer_cache/
 crash.log
 
 # https://www.packer.io/guides/hcl/variables
-# Exclude all .pkrvars.hcl files, which are likely to contain sensitive data, 
-# such as password, private keys, and other secrets. These should not be part of 
-# version control as they are data points which are potentially sensitive and 
+# Exclude all .pkrvars.hcl files, which are likely to contain sensitive data,
+# such as password, private keys, and other secrets. These should not be part of
+# version control as they are data points which are potentially sensitive and
 # subject to change depending on the environment.
 #
 *.pkrvars.hcl

--- a/Perl.gitignore
+++ b/Perl.gitignore
@@ -38,4 +38,4 @@ inc/
 /local/
 /.carmel/
 # cpanfile.snapshot should generally be ignored for library code, otherwise included
-# cpanfile.snapshot 
+# cpanfile.snapshot

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -131,7 +131,7 @@ __pypackages__/
 celerybeat-schedule
 celerybeat.pid
 
-# Redis 
+# Redis
 *.rdb
 *.aof
 *.pid
@@ -195,9 +195,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 

--- a/SSDT-sqlproj.gitignore
+++ b/SSDT-sqlproj.gitignore
@@ -1,5 +1,5 @@
 ## Ignore Visual Studio SSDT sqlproj specific temporary files, build results, etc
-## 
+##
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/SSDT-sqlproj.gitignore
 # Build output

--- a/Terraform.gitignore
+++ b/Terraform.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json

--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -46,9 +46,9 @@ LineIDs.dbg.bak
 **/_Repository/
 
 
-# To include a specific library directory (i.e. third party/custom libs), 
+# To include a specific library directory (i.e. third party/custom libs),
 # use pattern `!/**/_Libraries/<directory name>/` i.e. `!/**/_Libraries/www.tcunit.org/`
-# 
+#
 
 # VS Shell project specific files and folders
 **/.vs/

--- a/community/DotNet/Umbraco.gitignore
+++ b/community/DotNet/Umbraco.gitignore
@@ -21,7 +21,7 @@
 
 ## The [Mm]edia/ folder contains content. Content may vary by environment and should therefore not be added to source control.
 ## Uncomment this line if you think it fits the way you work on your project.
-## **/[Mm]edia/ 
+## **/[Mm]edia/
 
 # Don't ignore Umbraco packages (VisualStudio.gitignore mistakes this for a NuGet packages folder)
 # Make sure to include details from VisualStudio.gitignore BEFORE this

--- a/community/NasaSpecsIntact.gitignore
+++ b/community/NasaSpecsIntact.gitignore
@@ -1,9 +1,9 @@
 # gitignore template for Nasa SpecsIntact (SI)
 # Website: https://specsintact.ksc.nasa.gov/
 #
-# Recommended: 
+# Recommended:
 # MicrosoftOffice.gitignore
-# 
+#
 
 # SpecsIntact (SI) Locking file; this would lock everyone out.
 *.se$
@@ -20,14 +20,14 @@ SUBMVER.*
 TTLDIFFS.*
 
 # SpecsIntact files that change a lot and don't actually affect SI
-# PULL.TBL is an auto-generated file to help speed SI loading. 
+# PULL.TBL is an auto-generated file to help speed SI loading.
 PULL.TBL
 pulltbl.bck
 
 # Tailoring information.
 # Keep tailor.tag; it is a list of tailoring options in SI.
 
-# JOB.OTL informs SI where a spec section came from. 
+# JOB.OTL informs SI where a spec section came from.
 # Keeping the old one isn't useful in git.
 JOB.OTL.OLD
 
@@ -35,6 +35,6 @@ JOB.OTL.OLD
 # notebooks, and if so, OneNote will litter the SI folder with these.
 *.onetoc*
 
-# Log files, typically tagfix or other auto generated logs that aren't useful 
+# Log files, typically tagfix or other auto generated logs that aren't useful
 # outside of the user that made them and clutter up the index.
 *.log

--- a/community/OpenTofu.gitignore
+++ b/community/OpenTofu.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json

--- a/community/UiPath.gitignore
+++ b/community/UiPath.gitignore
@@ -1,4 +1,4 @@
-# gitignore template for RPA development using UiPath Studio 
+# gitignore template for RPA development using UiPath Studio
 # website: https://www.uipath.com/product/studio
 #
 # Recommended: n/a

--- a/community/libogc.gitignore
+++ b/community/libogc.gitignore
@@ -25,7 +25,7 @@ icon.png
 lib/
 deps/
 obj/
-  
+
 # Ignore operating system-specific files
 $RECYCLE.BIN/
 .Trash-1000/

--- a/ecu.test.gitignore
+++ b/ecu.test.gitignore
@@ -3,7 +3,7 @@
 #   * all directories are related to the default directories, please adapt the .gitignore if you use customized directories
 
 # Dynamic workspace settings
-#   * We don't recommend to ignore the .workspace directory, because of important 
+#   * We don't recommend to ignore the .workspace directory, because of important
 #     * project specific settings
 #     * local user settings
 .workspace/ETdrive.xml


### PR DESCRIPTION
### Reasons for making this change

I noticed there was trailing whitespace in the python gitignore I wanted to use and that led me to notice trailing whitespace in many of the gitignores. I removed the trailing whitespace and made this PR.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
