### PR TITLE
Add *.lcov to Python gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *.cover
 *.py.cover
+*.lcov
 .hypothesis/
 .pytest_cache/
 cover/


### PR DESCRIPTION
When pytest is run with `--cov-report=lcov`, `*.lcov` files will be created. These should be gitignored.