### PR TITLE
Update Python.gitignore (pixi)

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -122,7 +122,8 @@ ipython_config.py
 #pixi.lock
 #   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
 #   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
+.pixi/*
+!.pixi/config.toml
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/


### PR DESCRIPTION
### Reasons for making this change

That's what pixi itself currently adds to .gitignore when using "pixi init" (in addition to the already existing line).
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

https://github.com/prefix-dev/pixi/pull/4108

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
