### PR TITLE
Node: Add react-router

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -139,3 +139,7 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# React Router
+.react-router/
+# build/


### PR DESCRIPTION
### Reasons for making this change

react-router is a widely used library/framework for making routing based react applications. this PR adds react-router v7 framework mode's gitignore folders

### Links to documentation supporting these rule changes

- [reactrouter.com](https://reactrouter.com/)
- [.gitignore in default template](https://github.com/remix-run/react-router-templates/blob/4de6220f247744bee45112af027c7fc4437b128e/default/.gitignore)

React router has added **framework mode** on v7 which is based on Vite.

React router documentation unfortunately does not mention both of these:

- `.react-router` folder houses autogenerated `.ts` files (per-route) for type checking
- React router puts build output into the `build` folder (as opposed to `dist` with vite)

I have added `.react-router` into the gitignore but I am unsure about including the `build` folder. Should I keep it like this, include it or remove it? Currently its commented out (so if anyone needs to, they can uncomment it)

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
