### PR TITLE
Fix typo "wrappper" --> "wrapper" in Gradle.gitignore

### DIFF
--- a/Gradle.gitignore
+++ b/Gradle.gitignore
@@ -8,7 +8,7 @@ gradle-app.setting
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
-# Avoid ignore Gradle wrappper properties
+# Avoid ignore Gradle wrapper properties
 !gradle-wrapper.properties
 
 # Cache of project


### PR DESCRIPTION
### Reasons for making this change

Fixes a small typo in a comment in Gradle.gitignore.

### Links to documentation supporting these rule changes

N/A

### If this is a new template

N/A

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
