### PR TITLE
Fix Python.gitignore for celery-beat 

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -128,7 +128,7 @@ ipython_config.py
 __pypackages__/
 
 # Celery stuff
-celerybeat-schedule
+celerybeat-schedule*
 celerybeat.pid
 
 # Redis


### PR DESCRIPTION
### Reasons for making this change

celery beat creates the following 3 files for running `celery -A sampleproject worker -B --loglevel=INFO`.
```text
$ file celerybeat-schedule*
celerybeat-schedule:     SQLite 3.x database, last written using SQLite version 3047001, writer version 2, read version 2, file counter 2, database pages 3, cookie 0x1, schema 4, UTF-8, version-valid-for 2
celerybeat-schedule-shm: SQLite Write-Ahead Log shared memory, counter 10, page size 4096, 20 frames, 3 pages, frame checksum 0x7f59ff13, salt 0x55b59b42d325d3a6, header checksum 0xa485f19a, read-mark[1] 0x14
celerybeat-schedule-wal: SQLite Write-Ahead Log, version 3007000
```
The current `.gitignore` ignores only `celerybeat-schedule`. This PR adds support to cover all files added per default by celery-beat.

### Links to documentation supporting these rule changes

https://docs.celeryq.dev/en/v5.5.2/reference/cli.html#cmdoption-celery-beat-s
https://github.com/search?q=celerybeat-schedule*&type=code

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
