### PR TITLE
Create AltiumDesigner.gitignore

### DIFF
--- a/AltiumDesigner.gitignore
+++ b/AltiumDesigner.gitignore
@@ -1,0 +1,41 @@
+### Altium Designer ###
+
+# Preview folders
+__Previews/
+**/__Previews/
+
+# Project history
+History/
+**/History/
+
+# Project logs
+Project Logs*/
+*.log
+
+# Auto-generated outputs
+Project Outputs*/
+Simulation Outputs*/
+Generated/
+*/Generated/
+
+# Auto-conversion notices
+*.PcbDoc.htm
+*.SchDocPreview
+
+# Access lock files (for DBLib sources)
+*.ldb
+
+# Archives and temporary files
+*.zip
+*.rar
+*.7z
+*.bak
+*.tmp
+
+# Excel reports (BOM, etc.)
+*.xlsx
+*.xls
+
+# System temporary files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This .gitignore for PCB Designers in AltiumDesigner Software

### Reasons for making this change

Version Control for PCB Designers with git and some software need have some untrackable files and folders 

### Links to documentation supporting these rule changes

[Git-based Version Control](https://www.altium.com/documentation/altium-designer/using-external-version-control/git?srsltid=AfmBOoogiGixrveMPS9E5OmkadeUo0HoMvSMG77XzWdVCExocNQkFEHw)

### If this is a new template

No , It's Standard Template for Git Ignore

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
