### PR TITLE
Add header note in Unity.gitignore about using Global editor/OS templates

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -2,6 +2,9 @@
 #
 # Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore
 #
+# Recommended: add any editor/OS/tool-specific ignore rules from the Global/ templates as needed.
+# See: https://github.com/github/gitignore/tree/main/Global
+#
 .utmp/
 /[Ll]ibrary/
 /[Tt]emp/


### PR DESCRIPTION
### Summary
Add a short header comment to `Unity.gitignore` that points users to the` Global/` templates (JetBrains/Rider, Visual Studio, etc.). This helps prevent editor/OS noise from being committed into Unity repositories.

### Problem / Context
Many Unity projects accidentally commit IDE-specific and user-local files (e.g., .idea/, .vs/, editor caches). This clutters diffs, inflates repos, and leaks local settings. The repository already separates technology templates from editor/OS rules (kept under `Global/`), but Unity users often miss this and try to add those rules into the Unity template itself.

### Real-world evidence (screenshots)

- Screenshots — repo polluted with IDE configs (.idea/**, .vs/**, Rider/VS artifacts) , noisy diffs from user-local files, accidental commits of machine-specific artifacts after onboarding a new teammate
<img width="1119" height="406" alt="Screenshot 2025-09-22 171023" src="https://github.com/user-attachments/assets/87112288-cec9-4968-b3ac-a0d9d487c5b7" />
<img width="2101" height="516" alt="Screenshot 2025-09-22 171204" src="https://github.com/user-attachments/assets/dbf6da13-d40b-4fda-9191-80b4c8089c63" />
<img width="1123" height="475" alt="Screenshot 2025-09-22 171246" src="https://github.com/user-attachments/assets/1169780e-1c7b-4d13-9d62-5d3af45020b5" />
<img width="1124" height="414" alt="Screenshot 2025-09-22 171910" src="https://github.com/user-attachments/assets/f024a27d-4e58-41a7-8ab3-55e7b279737b" />
<img width="1114" height="978" alt="Screenshot 2025-09-22 172610" src="https://github.com/user-attachments/assets/1986f3bb-9460-4c1d-929f-63dbf766bbd4" />


Proposed change (documentation-only)
Add a non-intrusive header note to `Unity.gitignore:`
```
#
# Get latest from https://github.com/github/gitignore/blob/main/Unity.gitignore
#
+ # Recommended: add any editor/OS/tool-specific ignore rules from the Global/ templates as needed.
+ # See: https://github.com/github/gitignore/tree/main/Global
+ #
.utmp/
/[Ll]ibrary/
/[Tt]emp/
```
### Why this approach

- Respects repository policy: technology-specific rules live in the tech template, editor/OS rules in Global/.
- Zero behavior change for existing users; it’s guidance only.
- Prevents common mistakes without duplicating editor rules into every technology template.

### Before / After

- Before: Users often overlook Global/ templates; Unity repos end up with .idea/, .vs/, and other local artifacts.
- After: Clear nudge at the top of the Unity template to combine it with relevant `Global/ `templates, reducing noise and repo size.

### Scope & Impact

- Files changed: `Unity.gitignore` (comment-only).
- No ignore-rule changes; no breaking behavior.
- Benefits all Unity users, regardless of IDE.

### Alternatives considered

- Adding `.idea/ `/ `.vs/` directly into Unity.gitignore: rejected to keep editor/OS rules centralized in Global/.
- Editing only the repo README: helpful, but developers usually copy Unity.gitignore straight from the file, so an inline hint is more effective.