### PR TITLE
feat: Add mcp.json to Visual Studio gitignore exceptions

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -412,6 +412,7 @@ FodyWeavers.xsd
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/mcp.json
 !.vscode/*.code-snippets
 
 # Local History for Visual Studio Code

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -407,13 +407,7 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # VS Code files for those working on multiple tools
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/mcp.json
-!.vscode/*.code-snippets
+!.vscode/*
 
 # Local History for Visual Studio Code
 .history/


### PR DESCRIPTION
### Reasons for making this change

As mcp's are becoming more common, sharing a workspace configuration of mcp servers is becoming more and more common with the mcp.json file. (https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server)

Adding this file as an exclusion to the default template so that it can be utilized by the editors and shared via source control.

This file can also be picked up by Visual Studio as seen [here](https://learn.microsoft.com/visualstudio/ide/mcp-servers?view=vs-2022&WT.mc_id=8B97120A00B57354#file-locations-for-automatic-discovery-of-mcp-configuration)

### Links to documentation supporting these rule changes

- https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server
- https://learn.microsoft.com/visualstudio/ide/mcp-servers?view=vs-2022&WT.mc_id=8B97120A00B57354#file-locations-for-automatic-discovery-of-mcp-configuration

VSCode itself commits this file: https://github.com/microsoft/vscode/blob/main/.vscode/mcp.json

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
