### PR TITLE
feat: add turbo repo to node gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -139,3 +139,6 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Turbo Repo
+.turbo


### PR DESCRIPTION
### Reasons for making this change
[Turbo Repo](https://turborepo.com/) is a widely used node monorepo tool used with various frameworks and packages.
The `.turbo` directory contains build artifacts, logs, and cache data generated locally by the Turborepo CLI. Adding `.turbo` to `.gitignore` prevents accidental commits of large or irrelevant files, keeps the repository clean, and follows the official Turborepo recommendation for managing this directory.

### Links to documentation supporting these rule changes
- `turborepo` guide on ignore the `.turbo` directory - https://turborepo.com/docs/getting-started/add-to-existing-repository#edit-gitignore

### If this is a new template
Not applicable. This is an update to an existing template.
Link to application or project’s homepage: https://turborepo.com/docs/getting-started/add-to-existing-repository#edit-gitignore

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
