### PR TITLE
Update Unity.gitignore to ignore *.slnx files

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -43,6 +43,7 @@ ExportedObj/
 *.csproj
 *.unityproj
 *.sln
+*.slnx
 *.suo
 *.tmp
 *.user


### PR DESCRIPTION
### Reasons for making this change

Unity now defaults to generating a `slnx` file instead of a `sln` file

https://docs.unity3d.com/Packages/com.unity.ide.visualstudio@2.0/changelog/CHANGELOG.html

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
