### PR TITLE
Add Daml.gitignore template

### DIFF
--- a/Daml.gitignore
+++ b/Daml.gitignore
@@ -1,0 +1,45 @@
+# Daml.gitignore
+# Recommended .gitignore template for Daml (Digital Asset Modelling Language) projects.
+# Website: https://www.digitalasset.com/developers
+# Documentation: https://docs.daml.com
+
+# === Daml build artefacts ===
+.daml/
+.daml/dist/
+.daml/state/
+.daml/package-database/
+.daml/ledger/
+.daml/dependencies/
+.daml/deploy/
+
+# === Sandbox / JSON API logs & state ===
+sandbox.log
+json-api.log
+navigator.log
+sandbox-state/
+ledger-state/
+
+# === IDE / Editor junk ===
+.idea/
+.vscode/
+*.iml
+*.swp
+*~
+
+# === OS / Misc ===
+.DS_Store
+Thumbs.db
+
+# === Environment & credentials ===
+.env
+*.jwt
+*.pem
+*.key
+*.crt
+
+# === Temporary files ===
+tmp/
+logs/
+*.log
+*.bak
+*.tmp


### PR DESCRIPTION
### Reasons for making this change

Daml (Digital Asset Modelling Language) is an open-source smart contract language used to build distributed ledger applications.
This template helps Daml developers avoid committing build artefacts, ledger state files, IDE settings, and private credentials that are generated by daml build, daml start, and related commands.


### Links to documentation supporting these rule changes

- Daml Documentation: https://docs.daml.com
- Daml SDK GitHub: https://github.com/digital-asset/daml

Example .gitignore references:
- https://github.com/digital-asset/daml/blob/main/.gitignore
- https://github.com/digital-asset/create-daml-app/blob/main/.gitignore

Link to application or project’s homepage:
https://www.digitalasset.com/developers