### PR TITLE
Ignore GitHub Copilot migration files in Jetbrains IDEs

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -81,3 +81,6 @@ http-client.private.env.json
 # Apifox Helper cache
 .idea/.cache/.Apifox_Helper
 .idea/ApifoxUploaderProjectSetting.xml
+
+# Github Copilot persisted session migrations, see: https://github.com/microsoft/copilot-intellij-feedback/issues/712#issuecomment-3322062215
+.idea/**/copilot.data.migration.*.xml


### PR DESCRIPTION
Add GitHub Copilot session migration files to .gitignore

### Reasons for making this change

When using the Github Copilot in Jetbrains IDEs, it adds following files to the .idea folder:
- copilot.data.migration.agent.xml
- copilot.data.migration.ask.xml
- copilot.data.migration.ask2agent.xml
- copilot.data.migration.edit.xml

These are being used to track the migration of persisted sessions and should be ignored.
Microsoft plans to remove these files sometime in the future, but until then they keep confusing people in our teams and in the community.

### Links to documentation supporting these rule changes

https://github.com/microsoft/copilot-intellij-feedback/issues/712#issuecomment-3322062215

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
