### PR TITLE
Add .env to gitignore for dotenv files

### DIFF
--- a/Dotnet.gitignore
+++ b/Dotnet.gitignore
@@ -37,8 +37,7 @@ ScaffoldingReadMe.txt
 *.snupkg
 
 # dotenv environment variables file
-.env*
-!.env.example
+.env
 
 # Others
 ~$*

--- a/Dotnet.gitignore
+++ b/Dotnet.gitignore
@@ -36,6 +36,9 @@ ScaffoldingReadMe.txt
 # NuGet Symbol Packages
 *.snupkg
 
+# dotenv environment variables file
+.env*
+
 # Others
 ~$*
 *~

--- a/Dotnet.gitignore
+++ b/Dotnet.gitignore
@@ -38,6 +38,7 @@ ScaffoldingReadMe.txt
 
 # dotenv environment variables file
 .env*
+!.env.example
 
 # Others
 ~$*


### PR DESCRIPTION
### Reasons for making this change

.env files are commonly used to hold "secrets" so it is important to ignore these files for git.

### Links to documentation supporting these rule changes

Many of the other .gitignores here include an entry for .env files:

https://github.com/search?q=repo%3Agithub%2Fgitignore%20.env&type=code

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
