### PR TITLE
Add .uv-cache to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -99,6 +99,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 # uv.lock
+.uv-cache/
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.


### PR DESCRIPTION
Adding a .uv-cache/ directory similar to other env caches

### Reasons for making this change
Uv is getting more popular, I had to add it myself and I'd expect other engineers to have this need too. 

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
