### PR TITLE
Created Microchip_MPLAB_X_IDE.gitignore file.

### DIFF
--- a/community/embedded/Microchip_MPLAB_X_IDE.gitignore
+++ b/community/embedded/Microchip_MPLAB_X_IDE.gitignore
@@ -1,0 +1,27 @@
+#=============================================================================
+# Microchip MPLAB X IDE .gitignore file.
+#
+# MPLABX: https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide
+#
+# MPLABX Version Control:-
+# https://developerhelp.microchip.com/xwiki/bin/view/software-tools/ides/x/version-control/working-with-version-control/
+#-----------------------------------------------------------------------------
+
+# MPLAB X (NetBeans) Project files
+**/*.X/nbproject/private/
+**/*.X/nbproject/Makefile-*
+**/*.X/nbproject/Package-*
+!**/*.X/nbproject/*.xml
+
+# MPLAB X Generated Files and Build Output
+**/*.X/.generated_files/
+**/*.X/build/
+**/*.X/dist/
+**/*.X/debug/
+
+# MPLAB Code Configurator (MCC)
+**/*.X/mcc_generated_files/
+**/*.X/mcc-manifest-*.yml
+
+#-----------------------------------------------------------------------------
+


### PR DESCRIPTION
### Reasons for making this change

I required a .gitignore file for the MPLAB X IDE (https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide) and there wasn't one in this repo.
Google search found many people asking for one and then having to make their own.

### Links to documentation supporting these rule changes

https://developerhelp.microchip.com/xwiki/bin/view/software-tools/ides/x/version-control/working-with-version-control/
I created the .gitignore file whilst working with the MPLAB X IDE given the guidelines above.

### If this is a new template

The repository that is using this latest version is not yet public.

### Merge and Approval Steps
- [ X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [NO CI YET - LOCAL BUILDS. DID CHECKOUT FROM SCRATCH AND BUILDS] Ensure CI is passing
- [ HOW?] Get a review and Approval from one of the maintainers
