### PR TITLE
Refine minitoc entries in TeX.gitignore

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -176,13 +176,13 @@ acs-*.bib
 *.ind
 
 # minitoc
-*.maf
-*.mlf
-*.mlt
-*.mtc[0-9]*
-*.slf[0-9]*
-*.slt[0-9]*
-*.stc[0-9]*
+*.maf*([0-9])
+*.mlf*([0-9])
+*.mlt*([0-9])
+*.mtc*([0-9])
+*.slf*([0-9])
+*.slt*([0-9])
+*.stc*([0-9])
 
 # minted
 _minted*


### PR DESCRIPTION
Updated minitoc patterns to include versioning. `TeX.gitignore` now ignores both numbered and non-numbered minitoc files. 

The changes were made to include:
1. Numbered `.maf`, `.mlf`, `.mlt`, and `.mtc` files;
2. Non-numbered `.slf`, `.slt`, and `.stc` files.

### Reasons for making this change

I  was working on my thesis in LaTex (I moved it from Overleaf to VSCode + LaTeXWorkshop to prevent network issues) and noticed that over 10 of the minidoc types its build produced were still being committed rather than ignored. When I investigated, I realized that the glob patterns weren't matching with files:
1. Ending in numbers (e.g.: it matched with `main.maf` but not `main.maf1`) in some cases;
2. And files that did not end in numbers (e.g.: it matched with `main.mtc` 1 through 8, like `main.mtc2`, but not with `main.mtc`).

As my build produces a large number of minitoc files, some of them already part of the thesis template I was supplied and which I am thus reluctant to change, I think it would be valuable for the community to edit these patterns to match more usefull-to-ignore files.

### Links to documentation supporting these rule changes

- [The template mentioned](https://www.overleaf.com/read/rzpyxphnnxbj)
- Testing the glob pattern done on [Glob Tool](https://www.digitalocean.com/community/tools/glob?comments=true&glob=%2A.mlt%2A%28%5B0-9%5D%29&matches=false&tests=%2F%2F%20This%20will%20match%20as%20it%20ends%20with%20%27.mlt%27&tests=main.mlt&tests=%2F%2F%20This%20won%27t%20match%21&tests=%2Ftest%2Fsome%2Fglobs&tests=%2F%2F%20This%20will%20match%20as%20it%20ends%20with%20%27mlt%27%20plus%20a%20number&tests=main.mlt2):
<img width="1853" height="801" alt="image" src="https://github.com/user-attachments/assets/079f010d-d863-4680-b58e-af340fb836a9" />


### If this is a new template
N/A

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
