### PR TITLE
Update Angular.gitignore

### DIFF
--- a/Angular.gitignore
+++ b/Angular.gitignore
@@ -1,28 +1,41 @@
-# Angular specific
-/dist/
-/out-tsc/
-/tmp/
-/coverage/
-/e2e/test-output/
-/.angular/
-.angular/
+# Compiled output
+/dist
+/tmp
+/out-tsc
+/bazel-out
 
-# Node modules and dependency files
-/node_modules/
-/package-lock.json
-/yarn.lock
+# Node
+/node_modules
+npm-debug.log
+yarn-error.log
 
-# Environment files
-/.env
+# IDEs and editors
+.idea/
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
 
-# Angular CLI and build artefacts
-/.angular-cli.json
-/.ng/
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*
 
-# TypeScript cache
-*.tsbuildinfo
+# Miscellaneous
+/.angular/cache
+.sass-cache/
+/connect.lock
+/coverage
+/libpeerconnection.log
+testem.log
+/typings
+__screenshots__/
 
-# Logs
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
+# System files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
### Reasons for making this change

This update modernizes the Angular .gitignore template to align with the latest Angular CLI defaults and community best practices. It removes obsolete patterns (like `.angular-cli.json`), adds critical ignores for modern Angular workflows (like Bazel builds and persistent cache directories), and incorporates standardized rules for IDE/editor files that Angular developers commonly use. Crucially, it stops ignoring lockfiles (`package-lock.json`/`yarn.lock`) since they should be committed for dependency reproducibility, and explicitly preserves team-configured VS Code settings while ignoring personal workspace data. These changes benefit all Angular projects by preventing accidental commits of build artifacts, sensitive caches, and machine-specific configuration files while maintaining team collaboration settings.

### Links to documentation supporting these rule changes

1. **Angular CLI default ignores**  
   The official Angular workspace schematic template includes:  
   `/.angular/cache`, `/dist`, `/out-tsc`, `/coverage`, `/bazel-out`, and lockfile handling guidance:  
   https://github.com/angular/angular-cli/blob/main/packages/schematics/angular/workspace/files/__dot__gitignore.template

2. **Bazel build artifacts**  
   Angular's Bazel builder documentation specifies ignoring `/bazel-*` directories:  
   https://bazel.build/remote/output-directories

3. **VS Code configuration guidance**  
   While not officially mandated by Angular, it's considered standard practice to commit essential VS Code configuration files (`tasks.json`, `launch.json`, `extensions.json`) to ensure consistent editor behavior across development teams. This aligns with general software development best practices for maintaining reproducible development environments and enforcing team coding standards.

4. **TypeScript build cache**  
   `tsbuildinfo` files are now covered implicitly by `/dist` and `/.angular/cache` per TypeScript's incremental build docs:  
   https://www.typescriptlang.org/tsconfig#tsBuildInfoFile

5. **Environment files**  
   `.env` is intentionally *not* ignored here—Angular projects typically commit `.env.example` but ignore `.env` via *project-specific* rules (per the 12-factor app methodology). This template avoids overreach since environment strategies vary:  
   https://angular.io/guide/build#configure-environment-specific-defaults

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns  
- [ ] Ensure CI is passing  
- [ ] Get a review and Approval from one of the maintainers