### PR TITLE
feat: ignore .vscode folder

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -33,6 +33,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
### Reasons for making this change

Visual Studio is available only for Windows but not for Mac and Unix based OS.
So, for those cases, developers must use Visual Studio Code - the open source IDE.
By the way, VSCode generates a cash folder `.vscode` with some JSON settings in the root project, that could be ignored on Git.

### Links to documentation supporting these rule changes

You can confirm VSCode is the option available for Mac and Unix: https://visualstudio.microsoft.com/pt-br/downloads/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
