### PR TITLE
Update Delphi.gitignore to remove modules folder

### DIFF
--- a/Delphi.gitignore
+++ b/Delphi.gitignore
@@ -77,6 +77,3 @@ __recovery/
 
 # Castalia statistics file (since XE7 Castalia is distributed with Delphi)
 *.stat
-
-# Boss dependency manager vendor folder https://github.com/HashLoad/boss
-modules/


### PR DESCRIPTION
Remove Boss dependency manager vendor folder from ignore. This is interfering with projects that contains a "modules" folder regardless of Boss dependency being present.

### Reasons for making this change

This is a very broad term thats conflicting with projects that contains a modules folder regardless if boss dependency manager is being used. I've already lost source code because of this rule. I do not believe 3rd party tool rules should be applied to official delphi ignore rules by default.

### Links to documentation supporting these rule changes

No link.

### If this is a new template

Link to application or project’s homepage: none.

### Merge and Approval Steps
- [*] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [*] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
