### PR TITLE
Ignore mise local lock files

### DIFF
--- a/Global/mise.gitignore
+++ b/Global/mise.gitignore
@@ -7,5 +7,8 @@ mise.local.toml
 .mise/*.local.toml
 mise/*.local.toml
 
+# https://mise.jdx.dev/dev-tools/mise-lock.html#local-lockfiles
+mise.local.lock
+
 # https://mise.jdx.dev/configuration.html#tool-versions
 #.tool-versions

--- a/Global/mise.gitignore
+++ b/Global/mise.gitignore
@@ -7,5 +7,10 @@ mise.local.toml
 .mise/*.local.toml
 mise/*.local.toml
 
+# https://mise.jdx.dev/dev-tools/mise-lock.html#local-lockfiles
+# https://mise.jdx.dev/dev-tools/mise-lock.html#environment-specific-lockfiles
+mise.local.lock
+mise.*.local.lock
+
 # https://mise.jdx.dev/configuration.html#tool-versions
 #.tool-versions


### PR DESCRIPTION
### Reasons for making this change

Like mise local configs, local lockfiles should not be added to git.

<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

https://mise.jdx.dev/dev-tools/mise-lock.html#local-lockfiles

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: not a new template, but https://mise.jdx.dev

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
