### PR TITLE
Removed trailing whitespace

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -195,9 +195,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 


### PR DESCRIPTION
### Reasons for making this change

Aligns with Python style guidance
PEP 8 explicitly advises avoiding trailing whitespace, noting that trailing whitespace is visually indistinguishable and can be confusing, especially when editors or tools auto-trim it. 
[PEP 8](https://pep8.org/)

Matches common linting rules and CI expectations
Popular Python linters and style tools such as pycodestyle/Flake8 (W291) and Ruff flag trailing whitespace as a violation, and many projects treat these warnings as errors in CI. Removing trailing whitespace from Python.gitignore aligns the template with those widely adopted rules.

Reduces noisy diffs caused by modern editors
Editors like Visual Studio Code support files.trimTrailingWhitespace, which trims whitespace on save. When users enable this (often the default recommendation), the current Python.gitignore template results in unintended changes and noisy diffs as soon as the file is saved. Removing trailing whitespace avoids these spurious diffs and makes using the official template smoother.

### Links to documentation supporting these rule changes

Flake8 / pycodestyle rule W291: “There should be no whitespace after the final character in a line.” 
[flake8rules.com](https://www.flake8rules.com/rules/W291.html)

Ruff rule trailing-whitespace (W291), which directly cites PEP 8’s recommendation to avoid trailing whitespace. 
[Astral Docs](https://docs.astral.sh/ruff/rules/trailing-whitespace/)

These references together justify removing trailing whitespace as consistent with Python style, tooling, and typical editor behaviour.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
