### PR TITLE
docs: clarify VS Code ignore rules in `Python.gitignore`

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -197,9 +197,14 @@ cython_debug/
 # Visual Studio Code
 #   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
-#   you could uncomment the following to ignore the entire vscode folder
+#   and can be added to the global gitignore or merged into this file.
+#   1. If you prefer, you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+#
+#   2. If you prefer to track shared VS Code settings, you could uncomment the following lines to
+#   include settings.json while ignoring all other files in the .vscode directory.
+# .vscode/*
+# !.vscode/settings.json
 
 # Ruff stuff:
 .ruff_cache/


### PR DESCRIPTION
This change clarifies how Visual Studio Code workspace files can be optionally ignored in python.gitignore while allowing contributors to track shared settings.json if desired.

### Reasons for making this change

- Many contributors use VS Code and often want to:
- Avoid committing editor- and user-specific workspace files
- Still share common editor settings (formatting, linting, tooling) across the project

The current comments reference ignoring the entire .vscode directory but do not clearly document the common pattern of allowing settings.json while ignoring other files. This change improves clarity without altering default behavior.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
