### PR TITLE
fix: incorrect stylization of VS Code

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -123,7 +123,7 @@ dist
 # TernJS port file
 .tern-port
 
-# Stores VSCode versions used for testing VSCode extensions
+# Stores Visual Studio Code versions used for testing Visual Studio Code extensions
 .vscode-test
 
 # yarn v3


### PR DESCRIPTION
### Reasons for making this change

The comment for ".vscode-test" is incorrectly styled.

### Links to documentation supporting these rule changes

https://en.wikipedia.org/wiki/Visual_Studio_Code

From this page, we can see that the correctly stylization is either "Visual Studio Code" or "VS Code", NOT "VSCode". When fixing this, I opted for "Visual Studio Code" instead of "VS Code", because it is more explicit and better documentation to use the full name.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
