### PR TITLE
Added Microchip MPLAB X IDE

### DIFF
--- a/community/embedded/MPLAB-X.gitignore
+++ b/community/embedded/MPLAB-X.gitignore
@@ -1,0 +1,48 @@
+# gitignore for Microchip MPLAB X projects
+# to be placed in the root directory (*.X) of the project
+#
+# based on https://microchipdeveloper.com/faq:72
+# and https://developerhelp.microchip.com/xwiki/bin/view/software-tools/ides/x/version-control/working-with-version-control
+
+# binary output directories
+/build/
+/debug/
+/dist/
+
+# project cache
+/.generated_files/
+/nbproject/private/
+/nbproject/Makefile-*
+/nbproject/Package-*
+
+# keep project settings and configuration
+!/nbproject/*.xml
+
+# if older versions of MPLAB X are used (including this file does not interfere
+# with recent versions)
+!/nbproject/project.properties
+
+# code configurator
+/mcc_generated_files/
+mcc-manifest-*.yml
+
+# log files
+/defmplabxtrace.log*
+/queuelogs/
+
+# intermediate and output file types (as a fallback)
+*.a
+*.bin
+*.d
+*.elf
+*.hex
+*.lst
+*.map
+*.o
+*.obj
+*.obj.dmp
+*.p1
+*.pre
+*.sdb
+*.so
+*.sym


### PR DESCRIPTION
### Reasons for making this change

The community seem to lack a template for Microchips MPLAB X IDE. Over the years I've worked with several versions. This helped me to add some additional lines for files/directories which are not documented by the link below.

### Links to documentation supporting these rule changes

- [Working with Version Control Systems in the MPLAB X IDE](https://developerhelp.microchip.com/xwiki/bin/view/software-tools/ides/x/version-control/working-with-version-control)
- old [faq:72](https://microchipdeveloper.com/faq:72) (dead link)

An older version of this ignore file can be found in one of my public projects: [HDSP-21xx-driver.X/.gitignore](https://github.com/oblaser/HDSP-21xx-driver/blob/master/sw/HDSP-21xx-driver.X/.gitignore).

### If this is a new template

Link to application or project’s homepage: https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide

### Merge and Approval Steps
- [X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [X] Ensure CI is passing
  - there's none, right?
  - tested with various repos (for PIC, AVR and SAM)
- [ ] Get a review and Approval from one of the maintainers
