### PR TITLE
add eslint, swc and turborepo cache ignores

### DIFF
--- a/Nextjs.gitignore
+++ b/Nextjs.gitignore
@@ -34,3 +34,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# cache
+.cache
+.eslintcache
+.turbo
+.swc


### PR DESCRIPTION
### Reasons for making this change

_TODO_
This change improves the Next.js `.gitignore` template by including commonly generated cache and tooling artifacts used in modern Next.js development workflows (e.g. ESLint, SWC, Turborepo, Playwright).

These files are not intended to be committed and frequently cause unnecessary repository noise when omitted from `.gitignore`. Adding them helps keep repositories clean and aligns the template with current ecosystem practices.

### Links to documentation supporting these rule changes

_TODO_

Next.js build and cache outputs
https://nextjs.org/docs/app/building-your-application/deploying

ESLint cache file
https://eslint.org/docs/latest/use/command-line-interface#--cache

Turborepo cache directory
https://turbo.build/repo/docs/core-concepts/caching

Playwright test artifacts
https://playwright.dev/docs/test-reporters

Existing .gitignore references in popular Next.js projects
https://github.com/vercel/next.js/blob/canary/.gitignore


### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers