### PR TITLE
fix(go-gitignore): prevent coverage.go files from being excluded

### DIFF
--- a/Go.gitignore
+++ b/Go.gitignore
@@ -14,6 +14,7 @@
 # Code coverage profiles and other test artifacts
 *.out
 coverage.*
+!coverage.go
 *.coverprofile
 profile.cov
 


### PR DESCRIPTION
### Reasons for making this change

The current `coverage.*` pattern unintentionally matches `*.go` files. When using Go vendoring, this causes legitimate source files to be excluded from version control:

- `vendor/golang.org/x/text/internal/language/coverage.go`
- `vendor/golang.org/x/text/language/coverage.go`

This leads to a particularly difficult-to-debug scenario where local builds succeed but CI pipelines fail due to missing vendored files that were never committed.

Adding `!coverage.go` ensures that Go source files are not accidentally excluded by the `coverage.*` pattern.

### Links to documentation supporting these rule changes

- [Go Modules: Vendoring](https://go.dev/ref/mod#vendoring) — Official documentation on `go mod vendor`
- [golang.org/x/text](https://pkg.go.dev/golang.org/x/text) — Standard extended text processing package containing the affected files

### If this is a new template

N/A — This is a modification to an existing template.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers