### PR TITLE
Revert "Add *.snk strong name key files"

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -269,10 +269,6 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk
-# (https://github.com/github/gitignore/pull/2483#issue-259490424)
-#*.snk
-
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
 #bower_components/


### PR DESCRIPTION
### Reasons for making this change

This reverts #2483 per discussion in there.

### Links to documentation supporting these rule changes

https://learn.microsoft.com/dotnet/standard/library-guidance/strong-naming

> ✔️ CONSIDER adding the strong naming key pair (public + private) to your source control system.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
