### PR TITLE
Add Zensical comment to Python

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -164,7 +164,7 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
+# mkdocs/Zensical documentation
 /site
 
 # mypy


### PR DESCRIPTION
### Reasons for making this change

Zensical (https://zensical.org/) uses the same output directory as mkdocs. Worth mentioning for clarity.

### Links to documentation supporting these rule changes

https://zensical.org/docs/usage/build/#usage

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
