### PR TITLE
Add Flatpak.gitignore

### DIFF
--- a/community/Linux/Flatpak.gitignore
+++ b/community/Linux/Flatpak.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+builddir
+repo


### PR DESCRIPTION
### Reasons for making this change

Flatpak is a widely-used Linux application packaging format that's available for install on basically every Linux distribution, and is installed out-of-the-box on many, including all Linux distributions in the Red Hat family and many distributions downstream of Ubuntu.

### Links to documentation supporting these rule changes

Cribbed directly from the Element Flatpak's .gitignore file at https://github.com/flathub/im.riot.Riot/blob/master/.gitignore, simply because Element is a pretty popular application. (Important bit of context for those not familiar with Flatpak/Flathub packaging: the workflow for getting an app into Flathub, the de-facto public Flatpak repository, puts packaging files in a separate repository from the actual app.)

Note in particular that this covers all directories that will be created by the Flatpak tutorial's suggested `flatpak-builder` command: https://docs.flatpak.org/en/latest/first-build.html#build-and-install

`repo` is the OSTree repository that the built Flatpak will be "published" to for testing, `.flatpak-builder` is an internal build directory, and `builddir` is another, user-specified build directory.

### If this is a new template

Link to application or project’s homepage: https://flatpak.org/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
