### PR TITLE
Ignore conda environment metadata directory

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -157,6 +157,10 @@ ENV/
 env.bak/
 venv.bak/
 
+# Conda environments
+conda-meta/
+
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
### Reasons for making this change

_TODO_
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

_TODO_

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->
Adds conda-meta/ to Python.gitignore to prevent committing Conda environment metadata.

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
