### PR TITLE
Improve TeX.gitignore to ignore Overleaf temporary files

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -44,6 +44,13 @@
 *.rubbercache
 rubber.cache
 
+## Overleaf (online LaTeX editor)
+.overleaf/
+*.synctex.gz.tmp
+*.lock
+*.partial
+*.upload
+
 ## Build tool directories for auxiliary files
 # latexrun
 latex.out/


### PR DESCRIPTION
### Reasons for making this change

Overleaf is a widely used online LaTeX editor.
When compiling or synchronizing projects, it generates internal metadata and temporary files that are not intended to be committed to version control, including files stored in the .overleaf/ directory.

In addition, Overleaf may generate several temporary artifacts during compilation and synchronization workflows, such as compilation-related temporary files, lock files, partially generated outputs, and upload-related auxiliary files.

These files commonly appear when downloading projects from Overleaf or when synchronizing a project between Overleaf and a local repository. Ignoring them helps keep LaTeX repositories clean, portable, and free from editor-specific or transient artifacts.

### Links to documentation supporting these rule changes

- [Overleaf home page](https://www.overleaf.com/)
- [Overleaf documentation](https://www.overleaf.com/learn)
- [Overleaf downloading a project](https://docs.overleaf.com/managing-projects-and-files/downloading-a-project)
- [Overleaf additional guides](https://docs.overleaf.com/)

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Not applicable this change updates the existing TeX.gitignore template.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
