### PR TITLE
KiCad: add exclusion for V10's .history folder

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -36,5 +36,9 @@ fp-info-cache
 # Archived Backups (KiCad 6.0)
 **/*-backups/*.zip
 
+# Archived Backups (KiCad 10.0)
+.history/
+
 # Local project settings
 *.kicad_prl
+


### PR DESCRIPTION
Signed-off-by: Helmut Lord <kellyhlord@gmail.com>

### Reasons for making this change

KiCad V10 adds a ".history" folder for internal use.

### Links to documentation supporting these rule changes

_TODO_

https://forum.kicad.info/t/history-folder/65861/4

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
