### PR TITLE
Add .gitignore for Supabase

### DIFF
--- a/Supabase.gitignore
+++ b/Supabase.gitignore
@@ -1,0 +1,12 @@
+# Referred to https://github.com/supabase/supabase/blob/8547b6f2335c5b8d534eaa223fdffdd7cd041714/.gitignore
+
+# Ignore config directories for local 
+**/supabase/.branches
+**/supabase/.temp
+
+# Ignore signing key file for JWT
+**/signing_key.json
+
+# Include template .env file for docker-compose
+!docker/supabase/.env
+!docker/supabase-traefik/.env


### PR DESCRIPTION
### Reasons for making this change

I think Supabase is a popular service.
But there was no `.gitignore` for Supabase, so I added it.

<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

https://github.com/supabase/supabase/blob/master/.gitignore

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: https://supabase.com/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
