### PR TITLE
Extend stale PR closure period to 365 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
-          stale-pr-message: 'This PR is stale because there have been no updates in 90 days. It will close after 180 days of inactivity. Leave a comment if you want to keep it open :smile:'
-          close-pr-message: 'This PR has been closed because it was inactive for 180 days. If you want to continue working on it, please open a new PR.'
+          stale-pr-message: 'This PR is stale because there have been no updates in 90 days. It will close after 365 days of inactivity. Leave a comment if you want to keep it open.'
+          close-pr-message: 'This PR has been closed because it was inactive for 365 days. If you want to continue working on it, please open a new PR.'
           days-before-stale: 90
           days-before-close: 365
           stale-pr-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
           stale-pr-message: 'This PR is stale because there have been no updates in 90 days. It will close after 180 days of inactivity. Leave a comment if you want to keep it open :smile:'
           close-pr-message: 'This PR has been closed because it was inactive for 180 days. If you want to continue working on it, please open a new PR.'
           days-before-stale: 90
-          days-before-close: 180
+          days-before-close: 365
           stale-pr-label: 'stale'
           exempt-pr-labels: 'keep'
           close-issue-reason: not_planned


### PR DESCRIPTION
### Reasons for making this change
Updated the days before closing stale PRs from 180 to 365. Due to internal priorities we need to allow more time for PR reviews.

Based on my reading, we need to increase `days-before-close` to ensure that any PR marked with the `stale` label currently benefits from the extension.

Once we are caught up on the backlog, we can revisit this setting.
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes
https://github.com/actions/stale?tab=readme-ov-file#days-before-close

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: NA

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
