### PR TITLE
Add .slnx to Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -43,6 +43,7 @@ ExportedObj/
 *.csproj
 *.unityproj
 *.sln
+*.slnx
 *.suo
 *.tmp
 *.user


### PR DESCRIPTION
### Reasons for making this change

Microsoft released the new SLNX solution format which is now being automatically generated instead of the older SLN solutions by Visual Studio. Like with the older SLN file, there is no reason to keep the automatically generated SLNX file in a Unity project's version control.
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

[SLNX announcement](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/)

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
