### PR TITLE
Add lvprojstate to .gitignore

### DIFF
--- a/LabVIEW.gitignore
+++ b/LabVIEW.gitignore
@@ -14,4 +14,5 @@
 # Metadata
 *.aliases
 *.lvlps
+*.lvprojstate
 .cache/


### PR DESCRIPTION
In LabVIEW 2026 local project state has been added to retain local session settings, like debug information (probes, breakpoints).

### Reasons for making this change

This is a new feature in LabVIEW that should be ignored by source code control providers

### Links to documentation supporting these rule changes

https://www.ni.com/docs/en-US/bundle/labview/page/labview-changes.html?srsltid=AfmBOoos6MOVeDDmnJZzNVa-ooN63xazEq6rMTMv1sy8X_ovqd7ihtkJ#:~:text=Enable%20or%20Disable,member%20Darin.K%5D



### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
