### PR TITLE
Add .expert to Elixir.gitignore

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -8,3 +8,4 @@ erl_crash.dump
 *.beam
 /config/*.secret.exs
 .elixir_ls/
+.expert/


### PR DESCRIPTION
### Reasons for making this change

Expert is the official language server implementation for the Elixir programming language. It's eventually meant to become the de facto LS (replacing Elixir LS that is already gitignored here).

Link: https://expert-lsp.org/

It stores its data in an `.expert` directory (similarly to Elixir LS). It is not meant to be tracked in the repository.

### Links to documentation supporting these rule changes

Expert doesn't have any proper documentation of this directory, but it's mentioned in FAQ: https://expert-lsp.org/docs/troubleshooting/

Lots of projects gitignore this file: https://grep.app/search?f.path.pattern=.gitignore&q=.expert

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
