### PR TITLE
Improve andoid gitignore template

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,34 +1,45 @@
-# Gradle files
+# Gradle
 .gradle/
 build/
+!gradle-wrapper.jar
 
-# Local configuration file (sdk path, etc)
+# Local configuration
 local.properties
 
-# Log/OS Files
+# Log files
 *.log
 
-# Android Studio generated files and folders
+# Android Studio / IntelliJ
+*.iml
+.idea/
+
+# Android generated files
 captures/
 .externalNativeBuild/
 .cxx/
-*.aab
 *.apk
+*.ap_
+*.aab
 output-metadata.json
 
-# IntelliJ
-*.iml
-.idea/
-misc.xml
-deploymentTargetDropDown.xml
-render.experimental.xml
-
-# Keystore files
+# Keystore files (never commit these)
 *.jks
 *.keystore
 
-# Google Services (e.g. APIs or Firebase)
+# Google Services
 google-services.json
+google-services.plist
 
-# Android Profiling
+# Firebase Crashlytics / Performance
+crashlytics-build.properties
+fabric.properties
+
+# NDK / CMake
+obj/
+
+# Profiling
 *.hprof
+
+# OS-specific
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
**This PR updates the Android.gitignore template to make it more consistent, minimal, and aligned with common Android development practices. The goal is to ignore only universally generated or sensitive files while removing project‑specific or redundant entries.**

## Key Improvements

1. Simplifies IntelliJ/Android Studio section by keeping only *.iml and .idea/, removing overly specific IDE files

2. Adds common Android build artifacts (*.apk, *.ap_, *.aab) and output-metadata.json

3. Adds Google Services and Firebase Crashlytics files that should never be committed

4. Adds NDK/CMake obj/ directory

5. Adds OS‑specific junk files (.DS_Store, Thumbs.db)

6. Removes redundant or overly specific patterns that are already covered by existing ignores

7. Keeps the template focused on broadly applicable Android/Gradle behavior