### PR TITLE
Add UserState folder to LabVIEW.gitignore

### DIFF
--- a/LabVIEW.gitignore
+++ b/LabVIEW.gitignore
@@ -15,3 +15,4 @@
 *.aliases
 *.lvlps
 .cache/
+*.UserState


### PR DESCRIPTION
### Reasons for making this change
With the release of LabVIEW 2026Q1, NI created a *.lvprojstate file to handle debugging artifacts, such as breakpoints, instead of storing them in the VI file. These project state files are saved inside of a *.UserState folder. It would be best to just ignore the entire folder instead of targeting a specific file.

### Links to documentation supporting these rule changes
[LabVIEW New Features and Changes](https://www.ni.com/docs/en-US/bundle/labview/page/labview-changes.html#d70042e117)

### Merge and Approval Steps
- [X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
