### PR TITLE
Update Godot.gitignore

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -1,3 +1,6 @@
+# Godot 4.2+ specific ignores
+~*.dll
+
 # Godot 4+ specific ignores
 .godot/
 .nomedia


### PR DESCRIPTION
### Link to the application or project's homepage

https://godotengine.org/

### Reasons for making this change

As of [Godot](https://godotengine.org/) 4.2 the editor has a Windows-specific workaround for loading extension libraries. Before the extension library is loaded the Godot editor creates a temp copy of the extension library `.dll` file with a `~` prefix (e.g. `example.dll` => `~example.dll`). When the extension library is unloaded the Godot editor deletes the temp copy. These copied `~*.dll` files are temporary and should be ignored.

### Links to documentation supporting these rule changes

Godot 4.2 changelog
https://godotengine.org/article/godot-4-2-arrives-in-style/#gdextension

Godot PR #80188 GDExtension: Copy DLL to a temp file before opening
https://github.com/godotengine/godot/pull/80188

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
