### PR TITLE
Update Zig.gitignore by adding `zig-pgk/`

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
 zig-out/
+zig-pkg/
 *.o


### PR DESCRIPTION
### Reasons for making this change

As announced in the devlog all Zig dependencies will now be fetched in the `zig-pgk` directory. Unless the programmer have a specific reason to include them in your source code, they should be ignored.

### Links to documentation supporting these rule changes

https://ziglang.org/devlog/2026/#2026-02-06

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
