### PR TITLE
Create PHP.gitignore for vanilla/general PHP projects.

### DIFF
--- a/PHP.gitignore
+++ b/PHP.gitignore
@@ -1,0 +1,26 @@
+# PHP .gitignore by penne-not-pasta (github)
+
+# FOLDERS/DIRECTORIES
+
+/vendor
+# /node_modules (if also using node.JS)
+/.vscode
+/.zed
+/.idea
+/dist
+/env
+
+# FILES
+
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+*.pfx
+*.p12
+*.log
+# package-lock.json (if also using node.JS)
+composer.phar
+composer.lock
+*.sql


### PR DESCRIPTION
### Reasons for making this change

This change was made because there was no `.gitignore` for general and/or vanilla PHP projects. Added a .gitignore file for PHP projects to exclude common files and directories.

<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

- [PHP ENGLISH DOCS](https://www.php.net/manual/en/)

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: https://www.php.net/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
