### PR TITLE
Add pattern to ignore *_i.h files

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -97,6 +97,7 @@ StyleCopReport.xml
 *_i.c
 *_p.c
 *_h.h
+*_i.h
 *.ilk
 *.meta
 *.obj


### PR DESCRIPTION

### Reasons for making this change

The ATL project template of Visual Studio will generate the header file xxx_i.h.

<img width="1085" height="439" alt="ATL" src="https://github.com/user-attachments/assets/f675f5bf-431a-47a3-8eaf-ae72069a758b" />


### Links to documentation supporting these rule changes

_TODO_

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps
- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
