### PR TITLE
Add .gitignore for TouchDesigner project

### DIFF
--- a/TouchDesigner.gitignore
+++ b/TouchDesigner.gitignore
@@ -1,0 +1,68 @@
+# Backups
+Backup/
+*/Backup/
+
+
+# Autosaves
+CrashAutoSave.*
+*/CrashAutoSave.*
+*.dmp
+
+
+# TouchDesigner import cache
+TDImportCache/
+*/TDImportCache/
+
+
+# Logs
+*.log
+logs/
+*/logs/
+
+
+# Increment files on save
+*.*.toe
+*/*.*.toe
+*Autosave*.toe
+
+
+# Python / build artifacts
+__pycache__/
+*.pyc
+*.pyo
+
+
+# Visual Studio cache directory
+.vs/
+
+
+# IDE / editor settings
+.vscode/*
+!.vscode/extensions.json
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+*.code-workspace
+
+
+# Executables
+*.exe
+*.out
+*.app
+*.ipa
+
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/

--- a/TouchDesigner.gitignore
+++ b/TouchDesigner.gitignore
@@ -2,39 +2,32 @@
 Backup/
 */Backup/
 
-
 # Autosaves
 CrashAutoSave.*
 */CrashAutoSave.*
 *.dmp
 
-
 # TouchDesigner import cache
 TDImportCache/
 */TDImportCache/
-
 
 # Logs
 *.log
 logs/
 */logs/
 
-
 # Increment files on save
 *.*.toe
 */*.*.toe
 *Autosave*.toe
-
 
 # Python / build artifacts
 __pycache__/
 *.pyc
 *.pyo
 
-
 # Visual Studio cache directory
 .vs/
-
 
 # IDE / editor settings
 .vscode/*
@@ -47,22 +40,8 @@ __pycache__/
 *.sw?
 *.code-workspace
 
-
 # Executables
 *.exe
 *.out
 *.app
 *.ipa
-
-
-# macOS
-.DS_Store
-.AppleDouble
-.LSOverride
-
-
-# Windows
-Thumbs.db
-ehthumbs.db
-Desktop.ini
-$RECYCLE.BIN/

--- a/TouchDesigner.gitignore
+++ b/TouchDesigner.gitignore
@@ -1,24 +1,19 @@
 # Backups
-Backup/
-*/Backup/
+**/Backup/
 
 # Autosaves
-CrashAutoSave.*
-*/CrashAutoSave.*
+**/CrashAutoSave.*
 *.dmp
 
 # TouchDesigner import cache
-TDImportCache/
-*/TDImportCache/
+**/TDImportCache/
 
 # Logs
 *.log
-logs/
-*/logs/
+**/logs/
 
 # Increment files on save
-*.*.toe
-*/*.*.toe
+**/*.*.toe
 *Autosave*.toe
 
 # Python / build artifacts
@@ -32,7 +27,7 @@ __pycache__/
 # IDE / editor settings
 .vscode/*
 !.vscode/extensions.json
-.idea
+.idea/
 *.suo
 *.ntvs*
 *.njsproj


### PR DESCRIPTION
### Reasons for making this change

TouchDesigner is a very popular tool in the world of interactive and immersive art. While some online resources describe how to use this software with Git, there is almost no documentation on the various files to ignore. This is unfortunate, given that TouchDesigner automatically generates several files and folders.

I believe it would be beneficial for the community to have access to a standardized "gitignore" file.

The provided gitignore file prevents the tracking of many files automatically created by TouchDesigner. Such as :

- Backup folder
- Increment files on save
- Crash autosave files
- The import cache

It will also take care of many generic files such as :

- Logs
- macOs and Windows related files
- Python cache
- IDE / code editor settings
- Executables


This file is also uploaded to my personnal account : 
https://github.com/samuelfavreaubdeb/TouchDesigner-gitignore

### Links to documentation supporting these rule changes

Official documentation : https://docs.derivative.ca/
How TouchDesigner works : https://docs.derivative.ca/First_Things_to_Know_about_TouchDesigner
Using TouchDesigner with Git : https://derivative.ca/community-post/tutorial/github-external-toxes/61020

### If this is a new template

Link to application or project’s homepage: https://derivative.ca/

### Merge and Approval Steps
- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
