### PR TITLE
Add ignore rule for TwinCAT Measurement files

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -55,3 +55,6 @@ LineIDs.dbg.bak
 *.~u
 *.project.~u
 *.suo
+
+# TwinCAT Measurement
+*.vsm


### PR DESCRIPTION
### Reasons for making this change

TwinCAT Measurement also creates vs files, called vsm
