### PR TITLE
Add gitignore for SolidWorks projects

### DIFF
--- a/SolidWorks.gitignore
+++ b/SolidWorks.gitignore
@@ -1,0 +1,16 @@
+# gitignore file for a SolidWorks project
+
+# SolidWorks temporary files
+~$*
+
+# Redundant entries for SolidWorks temporary files
+~$*.sldprt
+~$*.sldasm
+~$*.slddrw
+
+# SolidWorks backups e auto-recovery
+*.bak
+*.swbak
+
+# Cache of simulation results
+/simulation_results/

--- a/SolidWorks.gitignore
+++ b/SolidWorks.gitignore
@@ -1,14 +1,18 @@
 # gitignore file for a SolidWorks project
 
 # SolidWorks temporary files
-~$*
-
-# Redundant entries for SolidWorks temporary files
 ~$*.sldprt
 ~$*.sldasm
 ~$*.slddrw
+~$*.sld
 
-# SolidWorks backups e auto-recovery
+# For systems with case-sensitive (SolidWorks uses both)
+~$*.SLDPRT
+~$*.SLDASM
+~$*.SLDDRW
+~$*.SLD
+
+# SolidWorks backups and auto-recovery
 *.bak
 *.swbak
 


### PR DESCRIPTION
SolidWorks is one of the most famous and widely used CAD tools in the world.
It generates many temporary files, and a .gitignore file is necessary to avoid unnecessary files in the repository.

Link to application or project’s homepage: https://www.solidworks.com/

### Merge and Approval Steps
- [X] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers