### PR TITLE
Add Zed editor to Global gitignore templates

### DIFF
--- a/Global/Zed.gitignore
+++ b/Global/Zed.gitignore
@@ -1,0 +1,10 @@
+# Zed
+# https://zed.dev/docs/configuring-zed#settings-files
+#
+# Zed stores project settings in a .zed/ directory, similar to .vscode/.
+# By default, ignore the directory but allow commonly shared config files.
+
+.zed/*
+!.zed/settings.json
+!.zed/tasks.json
+!.zed/debug.json


### PR DESCRIPTION
### Reasons for making this change

The [Zed editor](https://zed.dev/) (56k+ GitHub stars) creates a `.zed/` directory in project roots for project-specific settings. This mirrors VS Code's `.vscode/` directory - some files are shared team config, others are user-specific.

The Global/ directory has templates for 20+ editors (VS Code, Cursor, JetBrains, Vim, Emacs, Sublime Text, etc.) but is missing Zed. This template follows the same [ignore-all, whitelist-shared pattern](https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore) used by the existing VS Code template.

**Whitelisted files:**
- `.zed/settings.json` - project settings (formatter, language server config, tab size)
- `.zed/tasks.json` - project task definitions
- `.zed/debug.json` - project debug configurations

These are team-shareable project config. Everything else in `.zed/` is ignored by default to catch any future user-specific state files.

### Links to documentation supporting these rule changes

- [Zed docs - Settings Files](https://zed.dev/docs/configuring-zed#settings-files) documents the `.zed/` project settings directory and the three config files
- [Zed docs - Tasks](https://zed.dev/docs/tasks) documents `.zed/tasks.json`
- [Zed docs - Debugger](https://zed.dev/docs/debugger) documents `.zed/debug.json`

### If this is a new template

Link to application or project's homepage: https://zed.dev/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers

This contribution was developed with AI assistance (Claude Code).