### PR TITLE
Add Deno.gitignore

### DIFF
--- a/Deno.gitignore
+++ b/Deno.gitignore
@@ -1,0 +1,11 @@
+# Deno
+# https://deno.com/
+
+# Cache directory (when using project-local DENO_DIR)
+# https://docs.deno.com/runtime/fundamentals/setup/#deno_dir
+.deno/
+
+# Coverage reports
+# https://docs.deno.com/runtime/reference/cli/coverage/
+coverage/
+*.lcov


### PR DESCRIPTION
### Reasons for making this change

[Deno](https://deno.com/) is a JavaScript/TypeScript runtime with 100k+ GitHub stars. The existing Node.gitignore covers Node.js artifacts but none of Deno's unique patterns.

This addresses @wirecat's [feedback on #4101](https://github.com/github/gitignore/pull/4101#issuecomment-2905881380), which asked for a version trimmed to Deno-specific rules only. The original PR (#4101, open since 2022) included IDE and OS rules that don't belong. The author hasn't responded since 2023. This is a fresh, focused replacement.

**Included patterns:**
- `.deno/` - local cache directory when using project-local [DENO_DIR](https://docs.deno.com/runtime/fundamentals/setup/#deno_dir)
- `coverage/` and `*.lcov` - output from [`deno coverage`](https://docs.deno.com/runtime/reference/cli/coverage/)

**Intentionally NOT ignored:**
- `deno.lock` - Deno [documentation](https://docs.deno.com/runtime/fundamentals/configuration/) says to commit the lockfile for reproducible builds
- `vendor/` - Deno [documentation](https://docs.deno.com/runtime/fundamentals/modules/) says to commit vendored dependencies for hermetic builds

The `coverage/` pattern matches what Deno's own [standard library uses](https://github.com/denoland/std/blob/main/.gitignore).

### Links to documentation supporting these rule changes

- [Deno docs - DENO_DIR setup](https://docs.deno.com/runtime/fundamentals/setup/#deno_dir) documents the `.deno/` cache directory
- [Deno docs - Coverage CLI](https://docs.deno.com/runtime/reference/cli/coverage/) documents `coverage/` output
- [Deno docs - Configuration](https://docs.deno.com/runtime/fundamentals/configuration/) documents that `deno.lock` should be committed
- [Deno standard library .gitignore](https://github.com/denoland/std/blob/main/.gitignore) uses `/coverage` pattern

### If this is a new template

Link to application or project's homepage: https://deno.com/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers

This contribution was developed with AI assistance (Claude Code).