### PR TITLE
Update Agda.gitignore to exclude MAlonzo directories in any location

### DIFF
--- a/Agda.gitignore
+++ b/Agda.gitignore
@@ -1,2 +1,2 @@
 *.agdai
-MAlonzo/**
+**/MAlonzo/**


### PR DESCRIPTION
### Reasons for making this change

When having multiple Agda projects in one repo, this will make sure that any MAlonzo directory will be ignored by git.

### Links to documentation supporting these rule changes

https://wiki.portal.chalmers.se/agda/Docs/MAlonzo

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
