### PR TITLE
TeX: add ConTeXt utility cache file (.tuc, .tui & tuo)

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -75,6 +75,10 @@ acs-*.bib
 # comment
 *.cut
 
+# context
+*.tua
+*.tuc
+
 # cprotect
 *.cpt
 

--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -76,8 +76,9 @@ acs-*.bib
 *.cut
 
 # context
-*.tua
 *.tuc
+*.tui
+*.tuo
 
 # cprotect
 *.cpt


### PR DESCRIPTION
ConTeXt generates .tuc files (utility cache) during each run. 

These can be removed using the command line [--purgeall](https://wiki.contextgarden.net/Input_and_compilation/Executable_scripts_and_auxiliary_files/context_script#--purgeall).

ConTeXt MKII generates .tui and .tuo with the generation of [ToC](https://wiki.contextgarden.net/Document_structure_and_headlines/Table_of_contents).

These files store document metadata between compilations and are not part of the source, so they should be ignored.