### PR TITLE
feat: create Lean.gitignore

### DIFF
--- a/Lean.gitignore
+++ b/Lean.gitignore
@@ -1,2 +1,2 @@
 # cache and other artifacts produced by Lean's Lake build tool
-.lake
+.lake/

--- a/Lean.gitignore
+++ b/Lean.gitignore
@@ -1,0 +1,2 @@
+# cache and other artifacts produced by Lean's Lake build tool
+.lake


### PR DESCRIPTION
### Reasons for making this change

This adds a standard gitignore template for the [Lean programming language](https://lean-lang.org/).

### Links to documentation supporting these rule changes

[This page](https://lean-lang.org/doc/reference/latest/Build-Tools-and-Distribution/Lake/) describes how Lake, Lean's package manager, works. Currently the template only ignores `.lake` which is where cache and other data is stored. Others are welcome to add/suggest other useful things to add to the gitignore template, though most Lean projects typically only have this in their gitignore.

### If this is a new template

Lean project homepage: <https://lean-lang.org/>

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers