### PR TITLE
Add .gitignore for Astro

### DIFF
--- a/Astro
+++ b/Astro
@@ -1,0 +1,49 @@
+node_modules/
+/triage/
+/.compiler/
+dist/
+temp/
+*.tsbuildinfo
+.DS_Store
+.vercel
+.netlify
+_site/
+.astro/
+scripts/smoke/*-main/
+scripts/memory/project/src/pages/
+benchmark/projects/
+benchmark/results/
+test-results/
+*.log
+package-lock.json
+.turbo/
+.eslintcache
+.pnpm-store
+.vscode-test/
+.claude
+
+# do not commit .env files or any files that end with `.env`
+*.env
+
+packages/astro/src/**/*.prebuilt.ts
+packages/astro/src/**/*.prebuilt-dev.ts
+packages/astro/test/units/_temp-fixtures/*
+!packages/astro/test/units/_temp-fixtures/package.json
+packages/integrations/**/.netlify/
+
+# exclude IntelliJ/WebStorm stuff
+.idea
+
+# ignore content collection generated files
+packages/**/test/**/fixtures/**/.astro/
+packages/**/test/**/fixtures/**/env.d.ts
+packages/**/e2e/**/fixtures/**/.astro/
+packages/**/e2e/**/fixtures/**/env.d.ts
+examples/**/.astro/
+examples/**/env.d.ts
+
+# make it easy for people to add project-specific Astro settings that they don't
+# want to share with others (see
+# https://github.com/withastro/astro/pull/11759#discussion_r1721444711)
+*.code-workspace
+packages/astro/e2e/fixtures/cloudflare/.wrangler/deploy/config.json


### PR DESCRIPTION
### Reasons for making this change

I wanted to use "npx gitignore" with my new Astro project. I then found out that there is no gitignore for Astro in this repo.

### Links to documentation supporting these rule changes
I couldn't find any documentation showing the gitignore file. I used the gitignore file from the astro repo from withastro. 

https://github.com/withastro/astro/blob/main/.gitignore
https://github.com/withastro/astro/

### If this is a new template

Link to application or project’s homepage: https://astro.build/

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
