### PR TITLE
Created macOS gitignore template.

### DIFF
--- a/macOS.gitignore
+++ b/macOS.gitignore
@@ -1,0 +1,5 @@
+*.DS_Store
+.DS_Store
+.DS_Store?
+.localized
+.AppleDouble


### PR DESCRIPTION
Added a .gitignore template for unwanted macOS filesystem files.

### Reasons for making this change

There are certain files used by the macOS filesystem to define localized folder data that tend to clutter macOS users' repositories.

### Links to documentation supporting these rule changes

The following repositories have manually added these files to their gitignore:
- https://github.com/wispnet-org/eitkek/blob/main/.gitignore
- https://github.com/wispnet-org/wispnet/blob/main/.gitignore
- https://github.com/Maxelweb/ds-store-patrol
- https://github.com/tjharrop/test-DS_store-remover
- https://github.com/StefanoDeVuono/sturdy-potato

### If this is a new template

macOS is the widely used Apple desktop operating system.
https://apple.com/macos/