### PR TITLE
Fix comment URL for Maven wrapper usage

### DIFF
--- a/Maven.gitignore
+++ b/Maven.gitignore
@@ -7,7 +7,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://maven.apache.org/wrapper/#usage-without-binary-jar
+# https://maven.apache.org/tools/wrapper/#Usage_with_or_without_Binary_JAR
 .mvn/wrapper/maven-wrapper.jar
 
 # Eclipse m2e generated files


### PR DESCRIPTION
Updated the URL and fragment in the comment for Maven wrapper usage.

### Reasons for making this change

The .gitignore template for Maven contains a URL with the rationale and procedure to exclude Maven binary JAR. The link no longer points to the current Apache Maven documentation: while the original URL yields a redirect, the URI fragment does not exist in the current document version
.
### Links to documentation supporting these rule changes

https://maven.apache.org/tools/wrapper/#Usage_with_or_without_Binary_JAR

### If this is a new template

N/A

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
