### PR TITLE
Remove trailing whitespace in C++.gitignore

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -49,7 +49,7 @@ CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
 Makefile
-install_manifest.txt 
+install_manifest.txt
 compile_commands.json
 
 # Temporary files

--- a/C++.gitignore
+++ b/C++.gitignore
@@ -53,10 +53,10 @@ install_manifest.txt
 compile_commands.json
 
 # Temporary files
-*.tmp 
-*.log 
-*.bak 
-*.swp 
+*.tmp
+*.log
+*.bak
+*.swp
 
 # vcpkg
 vcpkg_installed/


### PR DESCRIPTION
### Reasons for making this change

Remove trailing whitespace from `C++.gitignore`.

### Links to documentation supporting these rule changes

N/A

### If this is a new template

N/A

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers