### PR TITLE
feat(nix): ignore nixos test history

### DIFF
--- a/Nix.gitignore
+++ b/Nix.gitignore
@@ -4,3 +4,6 @@ result-*
 
 # Ignore automatically generated direnv output
 .direnv
+
+# Ignore NixOS interactive test driver history
+**/.nixos-test-history


### PR DESCRIPTION
### Reasons for making this change

When testing NixOS modules, the interactive test driver leaves us with the `.nixos-test-history` file. This is common for anyone making NixOS module tests.

### Links to documentation supporting these rule changes

This file doesn't seem to be official but here is the line of code which creates it:

- https://github.com/NixOS/nixpkgs/blob/e347ac28905f77edcd1e9855dedcfb61e517f265/nixos/lib/test-driver/src/test_driver/__init__.py#L205

### If this is a new template

This is not a new template.

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
