### PR TITLE
feat(qt): add build directory to gitignore

### DIFF
--- a/Qt.gitignore
+++ b/Qt.gitignore
@@ -29,6 +29,7 @@ ui_*.h
 *.jsc
 Makefile*
 *build-*
+build/
 *.qm
 *.prl
 


### PR DESCRIPTION
### Reasons for making this change

Qt projects commonly use a `build/` directory for out-of-source builds, especially when using CMake (the default build system for Qt 6). While Qt.gitignore already includes `*build-*` to handle Qt Creator's build directories (e.g., `build-MyProject-Debug`), it doesn't cover the standard `build/` directory that many Qt projects use.

This change applies to all Qt developers because:
1. Qt 6 uses CMake by default, which commonly generates a `build/` directory
2. The official Qt documentation and examples often use `build/` as the build directory
3. Many Qt tutorials and best practices recommend using a `build/` directory for out-of-source builds
4. This aligns with C++.gitignore, which also includes `build/`

### Links to documentation supporting these rule changes

- **Qt 6 Documentation**: [CMake Manual](https://doc.qt.io/qt-6/cmake-manual.html) - Shows examples using `build/` directory
- **Qt Wiki**: [Building Qt 5 from Git](https://wiki.qt.io/Building_Qt_5_from_Git) - Recommends using a separate build directory
- **Qt Creator Manual**: [Build Settings](https://doc.qt.io/qtcreator/creator-build-settings.html) - Documents how Qt Creator creates build directories
- **CMake Documentation**: [CMake Tutorial](https://cmake.org/cmake/help/latest/guide/tutorial/index.html) - Standard practice is to use a `build/` directory

**Related .gitignore files**:
- C++.gitignore (already includes `build/`)
- Python.gitignore (already includes `build/`)
- Most other language templates include `build/` as it's a universal convention

### If this is a new template

N/A - This is an improvement to an existing template

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers