### PR TITLE
Add *.lscache to VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -426,3 +426,6 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# VS Code C# Dev Kit
+*.lscache

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -428,4 +428,4 @@ FodyWeavers.xsd
 *.msp
 
 # VS Code C# Dev Kit
-*.lscache
+#*.lscache

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -427,5 +427,5 @@ FodyWeavers.xsd
 *.msm
 *.msp
 
-# VS Code C# Dev Kit
+# Offical VS Code C# Dev Kit Extension exclusion
 #*.lscache

--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -427,5 +427,5 @@ FodyWeavers.xsd
 *.msm
 *.msp
 
-# Offical VS Code C# Dev Kit Extension exclusion
+# Official VS Code C# Dev Kit Extension exclusion
 #*.lscache


### PR DESCRIPTION
### Reasons for making this change

The C# Dev Kit create `*.csproj.lscache` in new version.

### Links to documentation supporting these rule changes

Said by `*.csproj.lscache`
```txt
# This file caches language service data to improve the performance of C# Dev Kit.
# It is not intended for manual editing. It can safely be deleted and will be
# regenerated automatically.
#
# To exclude from version control, add *.lscache to your .gitignore file.
```

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [ ] Ensure CI is passing
- [ ] Get a review and Approval from one of the maintainers
