### PR TITLE
KiCad: Add `.history` folder to template

### DIFF
--- a/KiCad.gitignore
+++ b/KiCad.gitignore
@@ -36,5 +36,8 @@ fp-info-cache
 # Archived Backups (KiCad 6.0)
 **/*-backups/*.zip
 
+# Local git-based history (KiCad 9.0+)
+.history
+
 # Local project settings
 *.kicad_prl


### PR DESCRIPTION
### Reasons for making this change

As of KiCad v9, a new `.history/` folder is added in the KiCad project's project folder. It contains a local git repo that automatically gets committed to on every file save, storing a local history of file changes. It's a very neat feature, but it causes git to malfunction a bit (and mostly causes a lot of git warnings) until it's properly ignored (or setup as a submodule - though that's not the recommended approach).

### Links to documentation supporting these rule changes

* Feature is new in KiCad 9.0, though this gitignore part is not strictly documented: https://docs.kicad.org/9.0/en/kicad/kicad.html#git_integration


The following snippet is from `project_dir/.history/README.txt`, which explains the way this works.

```
KiCad Local History Directory
=============================

This directory contains automatic snapshots of your project files.
KiCad periodically saves copies of your work here, allowing you to
recover from accidental changes or data loss.

You can browse and restore previous versions through KiCad's
File > Local History menu.

To disable this feature:
  Preferences > Common > Project Backup > Enable automatic backups

This directory can be safely deleted if you no longer need the
history, but doing so will permanently remove all saved snapshots.
```

Here is an example of the folder structure that gets created with `.history`, as of KiCad v10.

```
tree -L 3 -a
.
├── fabrication-toolkit-options.json
├── fp-lib-table
├── .history
│   ├── .git
│   │   ├── config
│   │   ├── description
│   │   ├── HEAD
│   │   ├── hooks
│   │   ├── index
│   │   ├── info
│   │   ├── logs
│   │   ├── objects
│   │   └── refs
│   ├── .gitignore
│   ├── jtag_hs3_blaster_pcb.kicad_pcb
│   ├── jtag_hs3_blaster_pcb.kicad_sch
│   └── README.txt
├── jtag_hs3_blaster_pcb-backups
│   ├── jtag_hs3_blaster_pcb-2026-04-11_213603.zip
│   ├── jtag_hs3_blaster_pcb-2026-04-11_213625.zip
│   └── jtag_hs3_blaster_pcb-2026-04-11_213817.zip
│   └── ...
├── jtag_hs3_blaster_pcb.kicad_pcb
├── jtag_hs3_blaster_pcb.kicad_prl
├── jtag_hs3_blaster_pcb.kicad_pro
├── jtag_hs3_blaster_pcb.kicad_sch
```

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
