### PR TITLE
Cleans up and clarifies gitignore contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,10 @@
+### Link to the application or project's homepage
+
+_TODO_
+<!---
+Link to the project or application's homepage.
+--->
+
 ### Reasons for making this change
 
 _TODO_
@@ -8,9 +15,8 @@ Please provide some background for this change.
 ### Links to documentation supporting these rule changes
 
 _TODO_
-
 <!---
-Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
+Link to the project docs, any existing .gitignore files that project may have in its own repo, etc
 --->
 
 ### If this is a new template
@@ -18,6 +24,14 @@ Link to the project docs, any existing .gitignore files that project may have in
 Link to application or project’s homepage: TODO
 
 ### Merge and Approval Steps
-- [ ] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
-- [ ] Ensure CI is passing
-- [ ] Get a review and Approval from one of the maintainers
+
+<!---
+Please ensure you accomplish these tasks in order to get your contribution accepted
+--->
+- [ ] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
+- [ ] I have ensured CI is passing
+
+<!---
+Once done, please wait for a GitHub maintainer to review your PR and if necessary,
+work with them to address any findings.
+--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,6 @@ Link to application or project’s homepage: TODO
 Please ensure you accomplish these tasks in order to get your contribution accepted
 --->
 - [ ] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
-- [ ] I have ensured CI is passing
 
 <!---
 Once done, please wait for a GitHub maintainer to review your PR and if necessary,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We’d love you to help us improve this project. To help us keep this collection
 high quality, we request that contributions adhere to the following guidelines.
-Any contributions that don't meet any of these guidelines will be closed.
+Any contributions that don't meet these guidelines will be closed.
 
 - **Provide a link to the application or project’s homepage**. Unless it’s
   extremely popular, there’s a chance the maintainers don’t know about or use
@@ -28,8 +28,9 @@ Any contributions that don't meet any of these guidelines will be closed.
 - **Only modify *one template* per pull request**. This helps keep pull
   requests and feedback focused on a specific project or technology.
 
-- **Add new rules to the best section**. Please ensure your contribution does
-  not create duplicate sections or add rules in places unrelated.
+- **Add new rules to the most appropriate existing section**. Please ensure
+  your contribution does not create duplicate sections or add rules in
+  unrelated sections.
 
 - **No duplicate rules**. It's easy to do, but it creates confusion and
   introduces the risk of one or the other being missed in an update.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,28 +2,37 @@
 
 We’d love you to help us improve this project. To help us keep this collection
 high quality, we request that contributions adhere to the following guidelines.
+Any contributions that don't meet any of these guidelines will be closed.
 
 - **Provide a link to the application or project’s homepage**. Unless it’s
   extremely popular, there’s a chance the maintainers don’t know about or use
   the language, framework, editor, app, or project your change applies to.
+
+- **Provide a reason for making this change**. Even if it seems self-evident,
+  please take a sentence or two to tell us why your change or addition should
+  happen. It’s especially helpful to articulate why this change applies to
+  *everyone* who works with the applicable technology, rather than just you or
+  your team.
 
 - **Provide links to documentation** supporting the change you’re making.
   Current, canonical documentation mentioning the files being ignored is best.
   If documentation isn’t available to support your change, do the best you can
   to explain what the files being ignored are for.
 
-- **Explain why you’re making a change**. Even if it seems self-evident, please
-  take a sentence or two to tell us why your change or addition should happen.
-  It’s especially helpful to articulate why this change applies to *everyone*
-  who works with the applicable technology, rather than just you or your team.
+- **Keep scope as limited as possible**. Changes should be as small as possible
+  and apply to the most specific gitignore template available for the target
+  application. For example: OS-specific ignore rules like `.DS_Store` are not
+  accepted anywhere but their specific gitignore, `Global/macOS.gitignore` in
+  this case.
 
-- **Please consider the scope of your change**. If your change specific to a
-  certain language or framework, then make sure the change is made to the
-  template for that language or framework, rather than to the template for an
-  editor, tool, or operating system.
-
-- **Please only modify *one template* per pull request**. This helps keep pull
+- **Only modify *one template* per pull request**. This helps keep pull
   requests and feedback focused on a specific project or technology.
+
+- **Add new rules to the best section**. Please ensure your contribution does
+  not create duplicate sections or add rules in places unrelated.
+
+- **No duplicate rules**. It's easy to do, but it creates confusion and
+  introduces the risk of one or the other being missed in an update.
 
 In general, the more you can do to help us understand the change you’re making,
 the more likely we’ll be to accept your contribution quickly.
@@ -31,7 +40,7 @@ the more likely we’ll be to accept your contribution quickly.
 If a template is mostly a list of files installed by a particular version of
 some software (e.g. a PHP framework) then it's brittle and probably no more
 helpful than a simple `ls`. If it's not possible to curate a small set of
-useful rules, then the template might not be a good fit for this collection.
+useful rules, then the template is not a good fit for this collection.
 
 Please also understand that we can’t list every tool that ever existed.
 Our aim is to curate a collection of the *most common and helpful* templates,

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We support a collection of templates, organized in this way:
 ## What makes a good template?
 
 First and foremost, a template contribution must adhere to our
-[Contribution Guidelines](CONTRIBUTING.md).
+[Contributing Guidelines](CONTRIBUTING.md).
 
 A template should contain a set of rules to help Git repositories work with a
 specific programming language, framework, tool or environment.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ We support a collection of templates, organized in this way:
 
 ## What makes a good template?
 
+First and foremost, a template contribution must adhere to our
+[Contribution Guidelines](CONTRIBUTING.md).
+
 A template should contain a set of rules to help Git repositories work with a
 specific programming language, framework, tool or environment.
 
@@ -61,33 +64,7 @@ include your language, tool, or project, it’s not because it’s not awesome.
 
 ## Contributing guidelines
 
-We’d love for you to help us improve this project. To help us keep this collection
-high quality, we request that contributions adhere to the following guidelines.
-
-- **Provide a link to the application or project’s homepage**. Unless it’s
-  extremely popular, there’s a chance the maintainers don’t know about or use
-  the language, framework, editor, app, or project your change applies to.
-
-- **Provide links to documentation** supporting the change you’re making.
-  Current, canonical documentation mentioning the files being ignored is best.
-  If documentation isn’t available to support your change, do the best you can
-  to explain what the files being ignored are for.
-
-- **Explain why you’re making a change**. Even if it seems self-evident, please
-  take a sentence or two to tell us why your change or addition should happen.
-  It’s especially helpful to articulate why this change applies to _everyone_
-  who works with the applicable technology, rather than just you or your team.
-
-- **Please consider the scope of your change**. If your change is specific to a
-  certain language or framework, then make sure the change is made to the
-  template for that language or framework, rather than to the template for an
-  editor, tool, or operating system.
-
-- **Please only modify _one template_ per pull request**. This helps keep pull
-  requests and feedback focused on a specific project or technology.
-
-In general, the more you can do to help us understand the change you’re making,
-the more likely we’ll be to accept your contribution quickly.
+Please see our [Contributing Guidelines](CONTRIBUTING.md).
 
 ## Versioned templates
 
@@ -153,3 +130,4 @@ by automatically forking the project and prompting to send a pull request too.
 ## License
 
 [CC0-1.0](./LICENSE).
+


### PR DESCRIPTION


### Reasons for making this change
Adds clarification around our expectations for contributions and how contributions will be handled when they don't meet our requirements.

Updates template to lean into our contribution guidelines.

Cleans up duplicate wording around our contribution guidelines.
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes
NA

<!---
Link to the project docs, any existing .gitignore files that project may have in it's own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: github.com/github/gitignore 😄 

### Merge and Approval Steps
- [x] Confirm that you've read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and ensured your PR aligns
- [x] Ensure CI is passing
- [x] Get a review and Approval from one of the maintainers
