### PR TITLE
Removes duplicate project homepage ask

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,10 +19,6 @@ _TODO_
 Link to the project docs, any existing .gitignore files that project may have in its own repo, etc
 --->
 
-### If this is a new template
-
-Link to application or project’s homepage: TODO
-
 ### Merge and Approval Steps
 
 <!---


### PR DESCRIPTION
### Link to the application or project's homepage
github.com/github/gitignore 😄 

<!---
Link to the project or application's homepage.
--->

### Reasons for making this change
We always want to know information about a project before we accept changes in a PR.

<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

NA
<!---
Link to the project docs, any existing .gitignore files that project may have in its own repo, etc
--->

### If this is a new template

Link to application or project’s homepage: TODO

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
