### PR TITLE
Update Rust.gitignore to include rustc-ice files

### DIFF
--- a/Rust.gitignore
+++ b/Rust.gitignore
@@ -13,6 +13,9 @@ target
 # Contains mutation testing data
 **/mutants.out*/
 
+# rustc will dump stack traces when hitting an internal compiler error to PWD
+rustc-ice-*.txt
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore


### PR DESCRIPTION
Add rustc internal compiler error stack trace files to ignore

### Link to the application or project's homepage

<https://rustc-dev-guide.rust-lang.org/compiler-debugging.html>

### Reasons for making this change

From below documentation:

> By default, if rustc encounters an Internal Compiler Error (ICE) it will dump the ICE contents to an ICE file within the current working directory named `rustc-ice-<timestamp>-<pid>.txt`.

These contents do not need to be committed and should be ignored.

### Links to documentation supporting these rule changes

<https://rustc-dev-guide.rust-lang.org/compiler-debugging.html#suppressing-the-ice-file>

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
