### PR TITLE
Add Lateralus.gitignore

### DIFF
--- a/Lateralus.gitignore
+++ b/Lateralus.gitignore
@@ -1,0 +1,25 @@
+# Lateralus — https://github.com/bad-antics/lateralus-lang
+
+# Compiled source / bytecode
+*.ltlc
+*.ltbc
+
+# Compiler and LSP caches
+.ltl-cache/
+.lateralus-cache/
+
+# Default build and distribution directories used by the Lateralus
+# toolchain (`ltl build` / `ltl publish`).
+build/
+dist/
+
+# Package manager dependency tree (`ltl add <pkg>`)
+.ltl-deps/
+
+# Benchmark output produced by `ltl bench`
+benchmark_results.json
+*.prof
+
+# Editor scratch files produced by the Lateralus LSP
+*.ltl.swp
+*.ltl.bak


### PR DESCRIPTION
## What does this PR do?

Adds a `Lateralus.gitignore` template covering the artefacts produced by the **Lateralus** toolchain.

## Why this change applies to everyone working with the technology

Lateralus is a statically typed, pipeline-oriented programming language. It has:

- A public, open-source reference compiler at https://github.com/bad-antics/lateralus-lang (MIT) with Python, C, JS, LLVM, WASM and x86 backends
- An official LSP, formatter and linter
- A VS Code extension (`lateralus.lateralus-lang`)
- A standard library and package manager (`ltl add`, `ltl build`, `ltl bench`)

Any developer creating a new Lateralus project today needs to ignore the same set of files — compiled output, caches, build/dist directories, benchmark JSON, LSP scratch files — and they all come from the canonical toolchain, not anything project-specific.

## What's in the template

```
*.ltlc, *.ltbc          compiled source / bytecode  (emitted by `ltl build`)
.ltl-cache/             incremental compile cache  (used by the reference compiler)
.lateralus-cache/       LSP & formatter cache
build/, dist/           default build and publish directories
.ltl-deps/              package manager dependency tree
benchmark_results.json  output of `ltl bench`
*.prof                  profiler output
*.ltl.swp, *.ltl.bak    editor scratch files produced by the LSP
```

## Scope

Per CONTRIBUTING.md, I've kept it tight:

- ✅ Only Lateralus-specific rules — no Python, OS, or editor rules (those belong in their own templates)
- ✅ No duplicates
- ✅ Single new file, no edits to other templates
- ✅ Each section has a one-line comment explaining *why* the pattern is ignored

## References

- Reference implementation & docs: https://github.com/bad-antics/lateralus-lang
- `ltl build` / `ltl bench` toolchain reference: https://github.com/bad-antics/lateralus-lang/tree/main/docs
- File extension registry: `.ltl` source, `.ltlc` compiled, `.ltbc` bytecode (see the [language's .gitattributes template](https://github.com/bad-antics/lateralus-lang/blob/main/scripts/seed_repo_template/.gitattributes))

Happy to iterate on any of the entries if you'd prefer a shorter list or different formatting.
