### PR TITLE
Fix lowercase letter in WordPress.gitignore comment

### DIFF
--- a/WordPress.gitignore
+++ b/WordPress.gitignore
@@ -1,4 +1,4 @@
-# Wordpress - ignore core, configuration, examples, uploads and logs.
+# WordPress - ignore core, configuration, examples, uploads and logs.
 # https://github.com/github/gitignore/blob/main/WordPress.gitignore
 
 # Core


### PR DESCRIPTION
corrected the lowercase letters that should have been uppercase.

### Link to the application or project's homepage

- https://github.com/WordPress/wordpress-develop

### Reasons for making this change

Word**P**ress is the correct spell. Word**p**ress is wrong.

### Links to documentation supporting these rule changes

- cf. https://wordpress.com/ja/

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
