### PR TITLE
Correct styling in Python.gitignore for 'uv'

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -95,7 +95,7 @@ ipython_config.py
 #   install all needed dependencies.
 # Pipfile.lock
 
-# UV
+# uv
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.


### PR DESCRIPTION
### Link to the application or project's homepage

[Python](https://www.python.org/) and [uv](https://docs.astral.sh/uv/)

### Reasons for making this change

Their Style guide asks to refer to 'uv' without any capitalization - I just noticed and think we should honor that (even though it's mostly for their side of things). 

### Links to documentation supporting these rule changes

As per their current [Style guide](https://github.com/astral-sh/uv/blob/main/STYLE.md#styling-uv).

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
