### PR TITLE
Update Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -37,6 +37,9 @@
 # Visual Studio cache directory
 .vs/
 
+# Jetbrains Rider cache directory
+.idea/
+
 # Gradle cache directory
 .gradle/
 


### PR DESCRIPTION
Add .idea/ to .gitignore

Rider generates project-specific configuration in .idea/ which is machine-specific and not required for Unity builds.

### Link to the application or project's homepage

https://unity.com/
https://www.jetbrains.com/rider/

### Reasons for making this change

JetBrains Rider stores IDE-specific project configuration inside the `.idea/` directory.  
These files are user- and machine-specific and can introduce unnecessary noise and merge conflicts in version control.

In Unity projects, these files are not required for building or running the project, as Unity relies only on `Assets/`, `ProjectSettings/`, and `Packages/`.

Ignoring `.idea/` aligns with common practices for Unity projects using Rider.

### Links to documentation supporting these rule changes

- https://rider-support.jetbrains.com/hc/en-us/articles/207097529-What-is-the-idea-folder
- https://www.jetbrains.com/help/rider/Adding_Files_to_Version_Control.html

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

