### PR TITLE
Add UserState to LabVIEW gitignore

### DIFF
--- a/LabVIEW.gitignore
+++ b/LabVIEW.gitignore
@@ -15,3 +15,4 @@
 *.aliases
 *.lvlps
 .cache/
+*.UserState


### PR DESCRIPTION
### Reasons for making this change
With the release of LabVIEW 2026 Q1, we have released **Project Level Debugging** feature. This feature stores debugging specific information like debug state of the VIs, probe related information into a project specific `.lvprojstate` file. These files are stored under the project specific folder ending with `.UserState`.

However, these files are user and state dependent and should be ignored by source control. Adding `*.UserState` to gitignore

### Links to documentation supporting these rule changes
[LabVIEW 2026 Q1 New Features and Changes](https://www.ni.com/docs/en-US/bundle/labview/page/labview-changes.html#d72575e114)

### Merge and Approval Steps
- [X] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines