### PR TITLE
Add .lscache from c# dev kit got VisualStudio.gitignore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -259,6 +259,9 @@ _pkginfo.txt
 # but keep track of directories ending in .cache
 !?*.[Cc]ache/
 
+# Visual Studio Code C# Dev Kit cache files
+*.lscache
+
 # Others
 ClientBin/
 ~$*


### PR DESCRIPTION
### Link to the application or project's homepage

[C# Dev Kit VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)

### Reasons for making this change

Those cache files are not valid for cross-platform build, especially on NixOS systems

### Links to documentation supporting these rule changes

[vscode-dotnettools repo discussion](https://github.com/microsoft/vscode-dotnettools/issues/2961)
It's the same place https://aka.ms/lscache redirects

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
