### PR TITLE
Ignore Windows export files in Godot.ignore

### DIFF
--- a/Godot.gitignore
+++ b/Godot.gitignore
@@ -18,3 +18,7 @@ export_credentials.cfg
 .mono/
 data_*/
 mono_crash.*.json
+
+# Export outputs
+*.exe
+*.pck


### PR DESCRIPTION
### Link to the application or project's homepage

<!---
Link to the project or application's homepage.
--->
https://godotengine.org/

### Reasons for making this change

<!---
Please provide some background for this change.
--->
In Godot, you can export your project into binary executables. On Windows, you can export your project as an `.exe` file alongside a `.pck` file. These are compiled binary outputs that can be recreated from the project source files, so they do not belong in version control.

### Links to documentation supporting these rule changes

<!---
Link to the project docs, any existing .gitignore files that project may have in its own repo, etc
--->

https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_windows.html


### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
