### PR TITLE
TeX: add thumbs' .tmb

### DIFF
--- a/TeX.gitignore
+++ b/TeX.gitignore
@@ -245,6 +245,9 @@ pythontex-files-*/
 # thmtools
 *.loe
 
+# thumbs
+*.tmb
+
 # TikZ & PGF
 *.dpth
 *.md5


### PR DESCRIPTION
### Link to the application or project's homepage

When using the `thumbs` package in LaTeX, a `.tmb` file gets created. This file is mentioned in the package's documentation that can be found here: https://ctan.org/pkg/thumbs

### Reasons for making this change

This `.tmb` file is not intended for being modified by the user, so it is not useful to track. It contains the commands relative to the thumbs package, which executes them from that file, from what I understood.

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
