### PR TITLE
docs: add Table of Contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ the following resources are a great place to start:
 [chapter]: https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring
 [progit]: https://git-scm.com/book
 
+
+## Table of Contents
+
+- [Folder structure](#folder-structure)
+- [What makes a good template?](#what-makes-a-good-template)
+- [Contributing guidelines](#contributing-guidelines)
+- [Versioned templates](#versioned-templates)
+- [Specialized templates](#specialized-templates)
+- [Contributing workflow](#contributing-workflow)
+- [License](#license)
+
 ## Folder structure
 
 We support a collection of templates, organized in this way:


### PR DESCRIPTION
## Description
added Table of Contents with 7 entries for easier navigation of the 14-section document

This change improves the README's navigability by adding a structured Table of Contents, making it easier for readers to find relevant sections quickly.

## Type of change
- [x] Documentation improvement

## Checklist
- [x] I have read the CONTRIBUTING guide
- [x] My changes follow the existing style and formatting
- [x] I have verified the Table of Contents links work correctly
- [x] This change does not alter any existing content, only adds navigation