### PR TITLE
feat: update Python.gitignore to exclude PDF, CSV, and temporary files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -37,8 +37,12 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Generated documents / data exports
-*.pdf
-*.csv
+reports/*.pdf
+reports/*.csv
+output/*.pdf
+output/*.csv
+data/*.pdf
+data/*.csv
 
 # Microsoft Office temporary files
 ~$*

--- a/Python.gitignore
+++ b/Python.gitignore
@@ -36,6 +36,13 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Generated documents / data exports
+*.pdf
+*.csv
+
+# Microsoft Office temporary files
+~$*
+
 # Unit test / coverage reports
 htmlcov/
 .tox/


### PR DESCRIPTION
### Link to the application or project's homepage

https://www.python.org/

### Reasons for making this change

These changes add common generated files that should not be versioned, specifically PDF outputs and temporary Microsoft Office files. These files are usually build artifacts or temporary lock files, add noise to commits, and are not source files that should be tracked.

### Links to documentation supporting these rule changes

- [Python documentation - Interactive use](https://docs.python.org/3/using/cmdline.html#cmdoption-p)
- [pytest documentation - Caching](https://docs.pytest.org/en/stable/how-to/cache.html)

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
