### PR TITLE
Adds .kotlin to Android.gitignore

### DIFF
--- a/Android.gitignore
+++ b/Android.gitignore
@@ -1,6 +1,7 @@
 # Gradle files
 .gradle/
 build/
+.kotlin/
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
### Link to the application or project's homepage

- https://developer.android.com/
- https://kotlinlang.org/ - (since kotlin is the default lang for android development now)
- https://gradle.org/- (already configured in this file, before my changes)


### Reasons for making this change

Some of the Android's `.gradle` directory contents has now moved over to the `.kotlin` directory (since v 2.0.0). And the [docs](https://kotlinlang.org/docs/gradle-configure-project.html#kotlin-gradle-plugin-data-in-a-project) mention it needs to be gitignore'd alongside the .gradle.
This is already ignored in the [Android's official `.gitignore`](https://github.com/android/nowinandroid/blob/main/.gitignore), but was missing here. 

<a href="https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects"><img width="400" alt="image" src="https://github.com/user-attachments/assets/c4b7dc94-786d-473c-aa7b-b280525ed41a" /></a>


### Links to documentation supporting these rule changes

- https://kotlinlang.org/docs/gradle-configure-project.html#kotlin-gradle-plugin-data-in-a-project
- https://github.com/android/nowinandroid/blob/main/.gitignore
- https://github.com/android/compose-samples/commit/b2158b8d256fb6205e3d4a9638d38fb023199697

### Merge and Approval Steps
- [X] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
