### PR TITLE
Updates missing .phpunit.cache dir for newer laravel

### DIFF
--- a/Laravel.gitignore
+++ b/Laravel.gitignore
@@ -21,6 +21,7 @@ Homestead.yaml
 Homestead.json
 /.vagrant
 .phpunit.result.cache
+/.phpunit.cache
 
 /public/build
 /storage/pail


### PR DESCRIPTION
### Link to the application or project's homepage

https://laravel.com/

### Reasons for making this change

laravel moved the default location for test results and coverage cache back in 2023, to just  `.phpunit.cache`.
The old `.phpunit.result.cache` is still useful for projects using PHPUnit 9 or below, so I didn't touch that.

### Links to documentation supporting these rule changes
Official Laravel `.gitignore`: https://github.com/laravel/laravel/blob/master/.gitignore#L11
(added in https://github.com/laravel/laravel/pull/6052, during the PHPUnit 10 upgrade)


### Merge and Approval Steps

- [X] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
