### PR TITLE
Add Astro generated types folder to Node.gitignore

### DIFF
--- a/Node.gitignore
+++ b/Node.gitignore
@@ -141,3 +141,7 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Astro generated types
+.astro/
+


### PR DESCRIPTION
### Link to the application or project's homepage

https://astro.build/
<!---
Link to the project or application's homepage.
--->

### Reasons for making this change

Minor annoyance with adding ".astro/" manually to .gitignore after copying Node.gitignore to my own projects and also based on feedback I saw from someone else's pull request https://github.com/github/gitignore/pull/4829
<!---
Please provide some background for this change.
--->

### Links to documentation supporting these rule changes

I couldn't find any official documentation on this auto-generated folder, but I did find this tutorial post https://cloudcannon.com/tutorials/astro-beginners-tutorial-series/astro-content-collections-typed-markdown/
It seems like this .astro/ folder gets auto-generated every time you run an Astro build
<!---
Link to the project docs, any existing .gitignore files that project may have in its own repo, etc
--->

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [X] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
