### PR TITLE
docs: fix SCons homepage URL

### DIFF
--- a/SCons.gitignore
+++ b/SCons.gitignore
@@ -1,4 +1,4 @@
-# for projects that use SCons for building: http://http://www.scons.org/
+# for projects that use SCons for building: https://www.scons.org/
 .sconsign.dblite
 
 # When configure fails, SCons outputs these


### PR DESCRIPTION
### Link to the application or project's homepage

https://www.scons.org/

### Reasons for making this change

The SCons template currently includes a malformed homepage URL with a duplicated `http://` prefix. This updates the comment to the working HTTPS homepage.

### Links to documentation supporting these rule changes

https://www.scons.org/

### Merge and Approval Steps

- [x] I have read the contribution guidelines and understand my PR will be closed if it doesn't meet these guidelines