### PR TITLE
Ignore LangGraph runtime files in Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -196,6 +196,11 @@ cython_debug/
 #   Learn more at https://abstra.io/docs
 .abstra/
 
+# LangGraph
+#   LangGraph stores local API runtime files used during development.
+#   Learn more at https://docs.langchain.com/langgraph
+.langgraph_api/
+
 # Visual Studio Code
 #   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore


### PR DESCRIPTION
### Link to the application or project's homepage

https://docs.langchain.com/oss/python/langgraph/overview

### Reasons for making this change

LangGraph's `langgraph dev` command stores checkpointing and memory data in a `.langgraph_api` directory in the current working directory. These files are local runtime artifacts and should not be committed to source control.

This change is intentionally small and limited to the Python template.

### Links to documentation supporting these rule changes

https://docs.langchain.com/langsmith/data-storage-and-privacy

https://docs.langchain.com/oss/python/langgraph/local-server

### Merge and Approval Steps

- [x] I have read the contribution guidelines and understand my PR will be closed if it doesn't meet these guidelines.