### PR TITLE
Add Hardhat.gitignore

### DIFF
--- a/community/Hardhat.gitignore
+++ b/community/Hardhat.gitignore
@@ -1,0 +1,19 @@
+# Hardhat
+# https://hardhat.org/
+#
+# Recommended: Node.gitignore
+
+# Compilation artifacts
+/artifacts
+
+# Compilation cache
+/cache
+
+# TypeChain-generated types
+# Default for @nomicfoundation/hardhat-typechain (Hardhat 3)
+/types
+# Default for @typechain/hardhat (Hardhat 2)
+/typechain-types
+
+# Hardhat Ignition deployment output
+/ignition/deployments


### PR DESCRIPTION
### What

Adds `community/Hardhat.gitignore` — a template for projects using [Hardhat](https://hardhat.org/), the Ethereum smart-contract development environment maintained by Nomic Foundation.

### Why

Hardhat is one of the two most widely-used Ethereum development environments (alongside Foundry). Every Hardhat project generates the same set of build artifacts, cache files, generated TypeScript types, and deployment records that should not be committed. There is currently no template in this repo covering these paths — `Solidity-Remix.gitignore` is scoped specifically to the Remix IDE plugin's `artifacts/`, `deps/`, and `states/` folders and does not cover Hardhat's layout (`cache/`, `types/`, `ignition/deployments/`, etc.).

### Scope

Per the contributing guidelines, the template is limited to **Hardhat-specific paths only**. Generic Node.js paths (`node_modules`, `dist`) and coverage output are intentionally excluded — they are already covered by `Node.gitignore`, which the template file itself recommends as the base:

```
# Recommended: Node.gitignore
```

### Provenance for each rule

Every rule mirrors the `.gitignore` that ships in Hardhat's own [`packages/example-project/.gitignore`](https://github.com/NomicFoundation/hardhat/blob/main/packages/example-project/.gitignore):

| Rule | Purpose | Source |
|---|---|---|
| `/artifacts` | Compiled contract output | Hardhat example-project `.gitignore` (labelled "Hardhat Build Artifacts") |
| `/cache` | Compilation support cache | Hardhat example-project `.gitignore` (labelled "Hardhat compilation (v2) support directory") |
| `/types` | TypeChain output — default `outDir` for [`@nomicfoundation/hardhat-typechain`](https://github.com/NomicFoundation/hardhat/blob/main/packages/hardhat-typechain/src/internal/config/default.ts) (Hardhat 3) | Hardhat example-project `.gitignore` (labelled "Types generated by typechain") |
| `/typechain-types` | TypeChain output — default `outDir` for [`@typechain/hardhat`](https://github.com/dethcrypto/TypeChain) (Hardhat 2). Included for backward compatibility during the v2 → v3 transition | @typechain/hardhat plugin default |
| `/ignition/deployments` | [Hardhat Ignition](https://hardhat.org/ignition) deployment output | Hardhat example-project `.gitignore` (labelled "Ignition deployment output") |

All paths are anchored with a leading `/` to prevent accidentally matching similarly-named nested directories (e.g. hand-written `src/types/`).

### Compliance with CONTRIBUTING.md

- **Homepage link:** ✅ https://hardhat.org/
- **Reason for change:** ✅ (above)
- **Documentation links:** ✅ (upstream `.gitignore` cited per rule)
- **Scope limited:** ✅ only Hardhat-specific paths; generic Node.js rules are deferred to `Node.gitignore`
- **One template per PR:** ✅
- **No duplicate rules:** ✅
- **Placement:** `community/` per the README guidance that specialized ecosystem-specific templates start there and may be promoted later.