### PR TITLE
Add AI agent session/state files to Agents.gitignore

### DIFF
--- a/Global/Agents.gitignore
+++ b/Global/Agents.gitignore
@@ -13,6 +13,10 @@
 # OpenAI Codex
 # AGENTS.md
 # .codex/
+.codex/sessions/
+.codex/history*
+.codex/log/
+.codex/logs/
 
 # Aider
 .aider.input.history
@@ -22,8 +26,15 @@
 # .aiderignore
 
 # Claude Code
+.claude.json
 .claude/*.local.json
 .claude/**/*.log
+.claude/history*
+.claude/session*.json
+.claude/todos/
+.claude/projects/
+.claude/statsig/
+.claude/shell-snapshots/
 CLAUDE.local.md
 # .claude/
 
@@ -33,12 +44,16 @@ gemini-debug.log
 # .gemini/
 
 # Cursor AI
+.cursor/chats/
+.cursor/logs/
+.cursor/session*
 # .cursorrules
 # .cursor/
 # .cursor.json
 # .cursor-settings.yaml
 
 # Continue
+.continue/sessions/
 # .continue/
 # .continuerc.json
 
@@ -55,6 +70,14 @@ gemini-debug.log
 # .amazon-codewhisperer/
 # .tabnineignore
 # .tabnine/
+
+# Other agent session and state directories
+.agent/
+.copilot/
+.playwright-mcp/
+.remember/
+.specstory/
+.superpowers/
 
 # GitHub Copilot
 # .github/copilot-instructions.md


### PR DESCRIPTION
**Reason for the change**

The existing `Global/Agents.gitignore` comments out most agent paths on the grounds that they may be intentional team config. The paths added in this PR are never team config: they are session transcripts, chat history, caches, and local settings that AI coding tools write into the working tree. They follow the same logic as the aider history files the template already ignores unconditionally.

**What is added**

- Claude Code: `.claude.json`, `.claude/history*`, `.claude/session*.json`, `.claude/todos/`, `.claude/projects/`, `.claude/statsig/`, `.claude/shell-snapshots/`
- OpenAI Codex: `.codex/sessions/`, `.codex/history*`, `.codex/log/`, `.codex/logs/`
- Cursor: `.cursor/chats/`, `.cursor/logs/`, `.cursor/session*`
- Continue: `.continue/sessions/`
- Other state directories: `.agent/`, `.copilot/`, `.playwright-mcp/`, `.remember/`, `.specstory/`, `.superpowers/`

Tool directories that may hold shareable configuration (e.g. `.claude/`, `.codex/`, `.cursor/` themselves) stay commented out, as before.

**Source of the list**

The entries are cross-checked against the curated catalog in [aimhooman](https://github.com/rmyndharis/aimhooman) (`rules/paths.json`, rendered in `docs/ai-artifacts.gitignore`), which enforces these patterns in CI against real repositories.