### PR TITLE
Add Claude Code gitignore

### DIFF
--- a/Global/Claude.gitignore
+++ b/Global/Claude.gitignore
@@ -1,0 +1,40 @@
+# Claude Code (Anthropic's official CLI)
+# Reference: https://code.claude.com/docs/en/claude-directory
+#
+# Only the local, machine-specific files that Claude Code writes into a
+# project's .claude/ directory are ignored below. Everything else it creates
+# there (settings.json, rules/, skills/, commands/, agents/, workflows/,
+# output-styles/, agent-memory/, ...) is meant to be committed and shared
+# with the team.
+
+# Personal settings overrides. Take precedence over settings.json and are not
+# shared. Claude Code auto-adds this to ~/.config/git/ignore; listing it here
+# shares the ignore rule with your team.
+.claude/settings.local.json
+
+# Local project instructions. Personal per-project preferences (sandbox URLs,
+# test data, ...). Loaded alongside CLAUDE.md but meant to stay private.
+CLAUDE.local.md
+
+# Local subagent memory. Subagents with `memory: local` write their MEMORY.md
+# here to keep it out of version control. Project-shared subagent memory lives
+# in .claude/agent-memory/ instead, which is meant to be committed.
+.claude/agent-memory-local/
+
+# Git worktrees for parallel sessions. Claude Code checks out `--worktree` and
+# isolated-subagent worktrees here; ignoring the directory keeps their contents
+# from showing up as untracked files in your main checkout.
+.claude/worktrees/
+.worktrees/
+
+# The files below are committed on purpose. Uncomment a line only if you want
+# to keep it local to your machine instead of sharing it with the team.
+
+# Shared project settings
+# .claude/settings.json
+
+# Project instructions
+# CLAUDE.md
+
+# The entire Claude Code directory
+# .claude/


### PR DESCRIPTION
### Link to the application or project's homepage

https://claude.com/

### Reasons for making this change

Add a dedicated gitignore template for Claude Code, Anthropic's official CLI coding agent (claude). Claude Code stores project-level configuration and generated state in a .claude/ directory at the repository root, plus a couple of dot files. Some of these are meant to be committed and shared with the team (.claude/settings.json, .claude/rules/, .claude/skills/, .claude/commands/, .claude/agents/, .claude/agent-memory/, CLAUDE.md), while others are personal, machine-specific, or generated and should not be committed.

### Links to documentation supporting these rule changes

- [Explore the .claude directory](https://code.claude.com/docs/en/claude-directory) — settings.local.json is flagged as gitignored; .claude/agent-memory-local/ is where local subagent memory is written to keep it out of version control (project-shared memory lives in the committed .claude/agent-memory/).
- [Memory — Choose where to put CLAUDE.md files](https://code.claude.com/docs/en/memory#choose-where-to-put-claude-md-files) — “./CLAUDE.local.md … Personal project-specific preferences; add to .gitignore.”
- [Worktrees — Start Claude in a worktree](https://code.claude.com/docs/en/worktrees) — “Add .claude/worktrees/ to your .gitignore so worktree contents don't appear as untracked files in your main checkout.”

### Merge and Approval Steps

- [X] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

