### PR TITLE
[R] Add compiled code files to .gitignore

### DIFF
--- a/R.gitignore
+++ b/R.gitignore
@@ -47,3 +47,8 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
+
+# compiled code 
+src/*.o
+src/*.so
+src/*.dll


### PR DESCRIPTION
Adding a default `.gitignore` for new R projects is a nice features.  Around 20% of CRAN packages contained compiled code, often C/C++ (and increasingly Rust etc).  Those packages will when `git add everything` is used also commit their object code and shared libraries. With this PR they will no longer so it should offer a small quality-of-life improvement to these repositories.

### Link to the application or project's homepage

https://www.r-project.org/

### Reasons for making this change

Compilation results such as object files and shared libraries are build-specific temporaries that should not be committed.

### Links to documentation supporting these rule changes

N/A

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

