### PR TITLE
Add zig-pkg to Zig.gitignore

### DIFF
--- a/Zig.gitignore
+++ b/Zig.gitignore
@@ -1,3 +1,4 @@
 .zig-cache/
+zig-pkg/
 zig-out/
 *.o


### PR DESCRIPTION
### Reasons for making this change

> # Zig 0.16.0 Release Notes
> ### Fetch Packages Into Project-Local Directory
> Instead of being fetched into `$GLOBAL_ZIG_CACHE/p/$HASH`, package dependencies are now fetched into a "zig-pkg" directory relative to the build root (next to `build.zig`). Users are generally encouraged to not commit these files to source control, however it is understood that some will choose to do so for convenience.

### Links to documentation supporting these rule changes

https://ziglang.org/download/0.16.0/release-notes.html#Fetch-Packages-Into-Project-Local-Directory

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
