### PR TITLE
Add Mistral Vibe to Agents.gitignore

### DIFF
--- a/Global/Agents.gitignore
+++ b/Global/Agents.gitignore
@@ -5,7 +5,7 @@
 # shared with a team, so only uncomment them if they are local-only in your
 # project.
 
-# GEMINI.md
+# PLAN.md
 # WARP.md
 # CRUSH.md
 # QWEN.md
@@ -28,9 +28,15 @@ CLAUDE.local.md
 # .claude/
 
 # Gemini CLI
+# GEMINI.md
 gemini-debug.log
 .gemini-clipboard/
 # .gemini/
+
+# Mistral Vibe
+# .vibe/
+# .vibe/config.toml
+# .vibe/hooks.toml
 
 # Cursor AI
 # .cursorrules


### PR DESCRIPTION
## Summary

Updates `Global/Agents.gitignore` with three changes:

1. **Add Mistral Vibe entries** (`.vibe/`, `.vibe/config.toml`, `.vibe/hooks.toml`) as a new commented-out section, consistent with how other CLI agents (Claude Code, Gemini CLI, Cursor) are handled.

2. **Move `GEMINI.md`** from the top examples block into the Gemini CLI section where it belongs.

3. **Add `PLAN.md`** to the top examples block, alongside the other commented-out instruction-file examples (`WARP.md`, `CRUSH.md`, `QWEN.md`).

All new entries are commented out by default, following the file's convention that agent config files are often intentionally committed and shared with a team.
