### PR TITLE
Update Elixir.gitignore to match modern standards

### DIFF
--- a/Elixir.gitignore
+++ b/Elixir.gitignore
@@ -1,10 +1,32 @@
-/_build
-/cover
-/deps
-/doc
-/.fetch
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+*.tar
+
+# Compiled files (usually in /_build/).
 *.beam
+
+# Sensitive configuration, common convention in older Phoenix applications.
 /config/*.secret.exs
+
+# Language Server temporary files.
 .elixir_ls/


### PR DESCRIPTION
Update Elixir.gitignore to match the upstream template for new Elixir projects.

https://github.com/elixir-lang/elixir/blob/a9021b1c8d932fd5cf2339e4536c5c9ef024003f/lib/mix/lib/mix/tasks/new.ex#L307-L331

Remove `.fetch` which was also removed upstream (https://github.com/elixir-lang/elixir/pull/13871).

Preserve additional patterns added in https://github.com/github/gitignore/pull/2132, https://github.com/github/gitignore/pull/2611, and https://github.com/github/gitignore/pull/2872, adding comments to match the style of the rest of the file.

### Link to the application or project's homepage

https://elixir-lang.org/

### Reasons for making this change

The template hasn't been updated in 8 years, and has drifted from upstream.
This addresses the small differences, while preserving additional entries contributed by the community over the years.

### Links to documentation supporting these rule changes

- Current `.gitignore` produced by `mix new` (the default tool for creating new projects in the Elixir ecosystem): https://github.com/elixir-lang/elixir/blob/a9021b1c8d932fd5cf2339e4536c5c9ef024003f/lib/mix/lib/mix/tasks/new.ex#L307-L331
- Removal of `.fetch` from `.gitignore` upstream: https://github.com/elixir-lang/elixir/pull/13871 (it was originally added in https://github.com/github/gitignore/pull/2425 with the intention to match upstream)
- Phoenix documentation referring to the old configuration pattern (preserved): https://phoenix.hexdocs.pm/deployment.html#handling-of-your-application-secrets
- Phoenix's own `.gitignore` template generated for new apps with `mix phx.new` (matches Elixir, with a few additions): https://github.com/phoenixframework/phoenix/blob/1abb125bf22610a4c38b773b537186902bc5b576/installer/templates/phx_single/gitignore.eex

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
