### PR TITLE
Anchor MANIFEST to repo root to avoid matching subdirectories

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -24,7 +24,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-MANIFEST
+/MANIFEST
 
 # PyInstaller
 #   Usually these files are written by a python script from a template


### PR DESCRIPTION
### Link to the application or project's homepage

N/A

### Reasons for making this change

`MANIFEST` on it's own matches files and directories named "manifest" (case-insensitive) in the entire project. However, `/MANIFEST` matches for only the root, which is where 99% of all `MANIFEST` files that are being targeted by this rule are living. Therefore, I see this as an improvement.

### Links to documentation supporting these rule changes

N/A

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
