### PR TITLE
Add db-forest-config.xml to JetBrains gitignore

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -3,6 +3,7 @@
 
 # User-specific stuff
 .idea/**/workspace.xml
+.idea/**/db-forest-config.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries


### PR DESCRIPTION
### Link to the application or project's homepage

https://www.jetbrains.com/idea/

### Reasons for making this change

- db-forest-config.xml stores the IntelliJ Database tool window tree state (which data source  nodes are expanded, and in what order) — per-developer UI state that churns on  every expand/collapse, exactly like the already-ignored workspace.xml.
- Its payload tracks developer's local-only  connections, so committing the file might push dangling references into every teammate's IDE.

### Links to documentation supporting these rule changes

https://www.jetbrains.com/help/clion/database-tool-window.html#use_folders_in_the_tree

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines