### PR TITLE
Fix Xojo.gitignore exclusion of Builds folder

### DIFF
--- a/Xojo.gitignore
+++ b/Xojo.gitignore
@@ -1,6 +1,5 @@
 # Xojo (formerly REALbasic and Real Studio)
-
-Builds*
+Builds - */
 *.debug
 *.debug.app
 Debug*.exe


### PR DESCRIPTION
### Link to the application or project's homepage

https://www.xojo.com

### Reasons for making this change

Xojo is only compiled through the Xojo IDE. The Xojo IDE writes compiled output to a directory of the form `Builds - [Project Name]`. The previous rule of `Builds*` can match source code files such as `BuildsManager.xojo_code`. It makes more sense to use a more specific pattern limited to directories.

I also removed the blank line between the comment header and the patterns.

### Links to documentation supporting these rule changes

A getting started tutorial...

https://documentation.xojo.com/getting_started/tutorials/desktop_tutorial.html#:~:text=In%20the%20folder,for%20each%20platform

...makes reference to the naming convention of the Builds folder for compiled output...

> a folder called *Builds - TutorialDesktop*

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [X] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
