### PR TITLE
Update Python.gitignore to include .env.example

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -151,6 +151,7 @@ activemq-data/
 
 # Environments
 .env
+!.env.example
 .envrc
 .venv
 env/


### PR DESCRIPTION
Add exception for .env.example in gitignore

### Link to the application or project's homepage

https://github.com/github/gitignore

### Reasons for making this change

The Python.gitignore template ignores `.env` files (since they typically hold secrets like API keys and database credentials). However, this same rule also matches `.env.example`, a template file that intentionally contains no secrets and is meant to be committed to the repo so other contributors know which environment variables to set up. Right now, anyone who creates a `.env.example` file has it silently ignored and has to manually force-add it or edit their .gitignore. Adding a negation rule (`!.env.example`) keeps `.env` ignored while explicitly un-ignoring the safe example file, matching common convention (e.g. `.env.example`, `.env.sample`) used across many Python projects.

### Links to documentation supporting these rule changes

- https://github.com/github/gitignore/blob/main/Python.gitignore (current .env rule)
- General convention discussed here: https://salferrarello.com/add-env-to-gitignore/
- Related community request for broader `.env*` handling: https://github.com/github/gitignore/pull/4393


### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines