### PR TITLE
Add .claude/worktrees/ to Agents.gitignore

### DIFF
--- a/Global/Agents.gitignore
+++ b/Global/Agents.gitignore
@@ -24,6 +24,7 @@
 # Claude Code
 .claude/*.local.json
 .claude/**/*.log
+.claude/worktrees/
 CLAUDE.local.md
 # .claude/
 


### PR DESCRIPTION
### Link to the application or project's homepage

https://claude.com/claude-code

### Reasons for making this change

Claude Code (Anthropic's CLI coding agent) creates git worktrees under `.claude/worktrees/<name>/` at the repository root. This isn't an opt-in corner of the tool: worktrees are created by the `--worktree`/`-w` flag, by subagents declaring `isolation: worktree`, and automatically for every new session in the Claude desktop app.

Because a worktree is a full second checkout of the repository, leaving the path untracked is the noisiest possible case — `git status` in the main checkout reports the entire worktree tree as untracked files. The directory is generated, machine-local, and never meant to be committed, so the rule applies to everyone using Claude Code rather than to any particular team or workflow. Anthropic's documentation says so directly (quoted below).

The existing `# Claude Code` section in `Global/Agents.gitignore` doesn't already cover this: `.claude/*.local.json` matches only top-level `.local.json` files, and `.claude/**/*.log` matches only log files. The commented-out `# .claude/` is not a substitute either — it's commented precisely because `.claude/settings.json`, `.claude/commands/`, `.claude/agents/`, and `.claude/skills/` are commonly committed and shared with a team, which is the distinction this template already draws.

Scope is one line, in the existing `# Claude Code` section, with no duplicate rule.

### Links to documentation supporting these rule changes

- [Run parallel sessions with worktrees — Start Claude in a worktree](https://code.claude.com/docs/en/worktrees#start-claude-in-a-worktree): "By default, the worktree is created under `.claude/worktrees/<name>/` at your repository root", followed by the explicit tip: "Add `.claude/worktrees/` to your `.gitignore` so worktree contents don't appear as untracked files in your main checkout."
- [Isolate subagents with worktrees](https://code.claude.com/docs/en/worktrees#isolate-subagents-with-worktrees): subagents with `isolation: worktree` get their own worktree in the same location.
- [Desktop parallel sessions](https://code.claude.com/docs/en/desktop#work-in-parallel-with-sessions): every new desktop session gets its own worktree automatically.

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines
