### PR TITLE
Add macOS specific ignore for .DS_Store files

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -218,3 +218,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# macOS
+*.DS_Store*


### PR DESCRIPTION
### Link to the application or project's homepage

https://github.com/github/gitignore

### Reasons for making this change

Add `*.DS_Store*` to `Python.gitignore` to prevent macOS Finder metadata files from being accidentally committed to Python projects.

`.DS_Store` files are automatically generated by macOS and do not contain project source code or Python-specific project data. Ignoring them helps keep repositories free of operating-system-specific metadata and avoids unnecessary changes appearing in version control.

### Links to documentation supporting these rule changes

* GitHub Gitignore repository: https://github.com/github/gitignore
* GitHub documentation on ignoring files: https://docs.github.com/en/get-started/git-basics/ignoring-files

### Merge and Approval Steps

* [x] I have read the contribution guidelines and understand my PR will be closed if it doesn't meet these guidelines.

Once submitted, I will wait for a GitHub maintainer to review the change and address any requested feedback.