### PR TITLE
Add .pyright/ to Python.gitignore

### DIFF
--- a/Python.gitignore
+++ b/Python.gitignore
@@ -180,6 +180,9 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
+# Pyright type checker
+.pyright/
+
 # Cython debug symbols
 cython_debug/
 


### PR DESCRIPTION
### Summary

Adds `.pyright/` to `Python.gitignore` alongside existing static type checkers (`.mypy_cache/`, `.pyre/`, `.pytype/`).
