### PR TITLE
Add CMake build directories commonly used by JetBrains CLion.

### DIFF
--- a/C++.gitignore
+++ b/C++.gitignore
@@ -39,9 +39,9 @@
 *.app
 
 # Build directories
-build/
-Build/
-build-*/
+[Bb]uild/
+[Bb]uild-*/
+cmake-build-*/
 
 # CMake generated files
 CMakeFiles/


### PR DESCRIPTION
### Link to the application or project's homepage

https://www.jetbrains.com/clion/

### Reasons for making this change

The default build directory for CMake based projects opened from CLion without CMakePresets.json or already configured CMake project build directory will default to:
- `cmake-build-debug`
- `cmake-build-release`
- `cmake-build-relwithdebinfo`
- `cmake-build-minsizerel`
- `cmake-build-default` (when adding more than 4 profiles of different build types already exists)

<img width="1572" height="997" alt="JetBrains Settings window showing Build, Execution, Deployment > CMake page with a profile selected and Build directory field is empty, showing the default build directory used by JetBrains CLion" src="https://github.com/user-attachments/assets/7b20c886-b272-4b21-b99d-b564244c43dd" />

This defers from the regular `build` directory that is conventionally used for CMake configuration output directory.

### Links to documentation supporting these rule changes

https://www.jetbrains.com/help/clion/quick-cmake-tutorial.html#cmake-buildtypes

> Notice the Build directory field that specifies the location of build results. The default folders are cmake-build-debug for Debug profiles and cmake-build-release for Release profiles. You can always set other locations of your choice.

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/blob/main/CONTRIBUTING.md) and understand my PR will be closed if it doesn't meet these guidelines