### PR TITLE
Add .gitignore for SvelteKit project

### DIFF
--- a/SvelteKit.gitignore
+++ b/SvelteKit.gitignore
@@ -1,0 +1,29 @@
+# SvelteKit
+# https://svelte.dev/docs/kit
+
+# SvelteKit
+/.svelte-kit/
+/build/
+/.output/
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+
+# Deployment
+.vercel/
+.netlify/
+.wrangler/
+
+# Dependencies
+node_modules/
+
+# Environment variables
+.env
+.env.*
+!.env.example
+!.env.test
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Link to the application or project's homepage

https://svelte.dev/docs/kit

Reasons for making this change

SvelteKit is a widely used web application framework, but there is currently no dedicated SvelteKit template in this repository.

This adds a SvelteKit.gitignore template based on the .gitignore used by the official SvelteKit starter template.

The template includes SvelteKit-specific generated directories such as /.svelte-kit/ and /build/, as well as the framework's supported deployment output directories and Vite-generated timestamp files.

A dedicated template makes it easier for SvelteKit users to create an appropriate .gitignore without having to combine generic JavaScript/Node.js templates with framework-specific rules.

Links to documentation supporting these rule changes
Official SvelteKit repository: https://github.com/sveltejs/kit
Official SvelteKit starter template: https://github.com/sveltejs/kit-template-default
Official SvelteKit starter .gitignore: https://github.com/sveltejs/kit-template-default/blob/main/.gitignore
SvelteKit documentation: https://svelte.dev/docs/kit

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->