### PR TITLE
Add .vscode and .idea to Unity.gitignore

### DIFF
--- a/Unity.gitignore
+++ b/Unity.gitignore
@@ -33,9 +33,11 @@
 /[Aa]ssets/Plugins/Editor/JetBrains*
 # Jetbrains Rider personal-layer settings
 *.DotSettings.user
+.idea/
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 # Gradle cache directory
 .gradle/


### PR DESCRIPTION
### Link to the application or project's homepage
https://unity.com/

### Reasons for making this change
Unity developers commonly use Visual Studio Code and JetBrains Rider (which uses the .idea folder format) as external script editors alongside the Unity Editor. Currently, Unity.gitignore does not exclude the local settings folders these editors generate (.vscode/ and .idea/), which causes editor-specific configuration files to be accidentally committed to Unity project repositories.

### Links to documentation supporting these rule changes
- VS Code workspace settings folder: https://code.visualstudio.com/docs/getstarted/settings (stores per-project settings in .vscode/)
- JetBrains Rider project files: https://www.jetbrains.com/help/rider/Project_Files.html (stores per-project settings in .idea/)
- These same entries already exist in the global VisualStudioCode.gitignore and JetBrains.gitignore files in this repo. This PR adds them specifically to Unity.gitignore since Rider/VSCode + Unity is an extremely common combination, and many contributors don't chain the global gitignore templates together.

### Merge and Approval Steps
- [x] I have read the contribution guidelines and understand my PR will be closed if it doesn't meet these guidelines