### PR TITLE
TwinCAT3: remove *.xtv (project-specific mappings since 4026.xx)

### DIFF
--- a/TwinCAT3.gitignore
+++ b/TwinCAT3.gitignore
@@ -28,7 +28,6 @@ LineIDs.dbg.bak
 *.xti.bak
 *.xti.bk?
 *.xti.orig
-*.xtv
 *.xtv.bak
 *.xtv.bk?
 *.xt?.bk?


### PR DESCRIPTION
**Reasons for making this change:**

Since TwinCAT 3.1 build 4026.xx, the `*.xtv` file stores project-specific
mappings and is therefore a regular project file that must be tracked in
version control. Ignoring it causes the mapping information to be lost when
a solution is cloned or checked out on another machine.

Only the backup/temporary variants should stay ignored, and they still are:
`*.xtv.bak`, `*.xtv.bk?`, `*.xt?.bk?` and `*.xt?.orig`.

**Links to documentation supporting these rule changes:**

Beckhoff's officially recommended .gitignore for TwinCAT 3 source control:
https://infosys.beckhoff.com/content/1033/tc3_sourcecontrol/14604066827.html

It lists `*.xtv.bak` and `*.xtv.bk?`, but deliberately **not** `*.xtv`.
