### PR TITLE
Add *.slnx to UnrealEngine.gitignore

### DIFF
--- a/UnrealEngine.gitignore
+++ b/UnrealEngine.gitignore
@@ -35,6 +35,7 @@
 *.xcodeproj
 *.xcworkspace
 *.sln
+*.slnx
 *.suo
 *.opensdf
 *.sdf


### PR DESCRIPTION
### Link to the application or project's homepage

[Unreal Engine](https://www.unrealengine.com/)

### Reasons for making this change

Visual Studio 2022 (v17.10+) introduced a new solution file format, `.slnx`, which serves the exact same role as the `.sln` file this template already ignores. Unreal Engine's `UnrealBuildTool` (UBT) generates IDE project files (`.sln`/`.slnx`, `.vcxproj`, etc.) from the project's `.uproject` and `*.Build.cs` files, and they can be regenerated at any time via "Generate Visual Studio project files" as long as the `Source` folder, `Content` folder, and `.uproject` file are present. These generated files are treated as intermediate build artifacts and may embed locally-mounted paths or personal environment settings, so — like `.sln` — they should not be shared between team members. This applies to every Unreal Engine developer using Visual Studio 2022 or later, not just a specific setup.

### Links to documentation supporting these rule changes

- [Project Files for IDEs in Unreal Engine](https://dev.epicgames.com/documentation/en-us/unreal-engine/project-files-for-ides-in-unreal-engine) — states that IDE project files are treated as intermediate files under `PROJECT_DIRECTORY\Intermediate\ProjectFiles`, and must be regenerated if the `Intermediate` folder is deleted.
- [Unreal Build Tool in Unreal Engine](https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-build-tool-in-unreal-engine) — notes that the build process runs independently of IDE project files (`.sln`/`.vcproj`, etc.), so project files don't need to be synced between team members — only source files need to be synced, and project files can be rebuilt locally.

### Merge and Approval Steps

- [x] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines