### PR TITLE
Update InforCRM.gitignore website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For example, this template might live at `community/DotNet/InforCRM.gitignore`:
 
 ```gitignore
 # gitignore template for InforCRM (formerly SalesLogix)
-# website: https://www.infor.com/product-summary/cx/infor-crm/
+# website: https://www.infor.com/products/customer-experience-suite/crm
 #
 # Recommended: VisualStudio.gitignore
 


### PR DESCRIPTION
## What
The InforCRM.gitignore template header links to a retired product page. Updated it to the current Infor CRM page.

## Why
infor.com/product-summary/cx/infor-crm/ returns 404. The live page is infor.com/products/customer-experience-suite/crm.

## Verification
Old URL 404, new URL 200 (checked today).