### PR TITLE
Exclude output of Compiler Advisor for MPLAB X IDE gitignore

### DIFF
--- a/community/embedded/Microchip_MPLAB_X_IDE.gitignore
+++ b/community/embedded/Microchip_MPLAB_X_IDE.gitignore
@@ -18,6 +18,7 @@
 **/*.X/build/
 **/*.X/dist/
 **/*.X/debug/
+**/*.X/.ca/
 
 # MPLAB Code Configurator (MCC)
 **/*.X/mcc_generated_files/


### PR DESCRIPTION
### [Link to the application or project's homepage](https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide)

### Reasons for making this change

Exclude output of Compiler Advisor.

### Merge and Approval Steps

<!---
Please ensure you accomplish these tasks in order to get your contribution accepted
--->
- [x ] I have read the [contribution guidelines](https://github.com/github/gitignore/tree/main?tab=readme-ov-file#contributing-guidelines) and understand my PR will be closed if it doesn't meet these guidelines

<!---
Once done, please wait for a GitHub maintainer to review your PR and if necessary,
work with them to address any findings.
--->
